### PR TITLE
Fix reopen data loss, Dyna key loss, crash durability, and view write loss

### DIFF
--- a/database/bfile.go
+++ b/database/bfile.go
@@ -90,9 +90,15 @@ func (b *BFile) Flush() (err error) {
 }
 
 // Close
-// Close the underlying file
+// Close the underlying file.  The file is synced first so the data is
+// durable once Close returns.
 func (b *BFile) Close() (err error) {
 	if err = b.Flush(); err != nil {
+		return err
+	}
+	if err = b.File.Sync(); err != nil {
+		b.File.Close()
+		b.File = nil
 		return err
 	}
 	err = b.File.Close()

--- a/database/bloom.go
+++ b/database/bloom.go
@@ -6,7 +6,7 @@ type Bloom struct {
 	SizeOfMap float64
 	NumBytes  uint64
 	Map       []byte
-	K         int     // Number of hash functions
+	K         int // Number of hash functions
 }
 
 // NewBloom
@@ -37,20 +37,20 @@ func (b *Bloom) ByteMask(key [32]byte, hashNum int) (Index uint64, BitMask byte)
 	// Since the key is a SHA-256 hash, we can simply use different byte ranges
 	// Each 8-byte segment provides enough entropy for a good hash function
 	offset := (hashNum * 8) % 24 // Use different 8-byte chunks, wrapping if needed
-	
+
 	// Extract an 8-byte value from the key
 	v := binary.BigEndian.Uint64(key[offset:])
-	
+
 	// Modulo to fit in our bitmap
 	v = v % (b.NumBytes << 8)
-	
+
 	// Split into byte index and bit index
 	Index = v >> 8
 	BitIndex := v & 0xFF
-	
+
 	// Convert bit index to a bitmask
 	BitMask = 1 << (BitIndex % 8)
-	
+
 	return Index, BitMask
 }
 

--- a/database/bloom_test.go
+++ b/database/bloom_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestBloom(t *testing.T) {
 	const NumTests = 1_000_000
-	
+
 	// Increased size from 4.5MB to 6MB
 	// Using 3 hash functions (default in NewBloom)
 	bloom := NewBloom(6.0)
@@ -27,16 +27,16 @@ func TestBloom(t *testing.T) {
 	for i := 0; i < NumTests; i++ {
 		assert.True(t, bloom.Test(fr.NextHash()))
 	}
-	
+
 	// Test with new random data to measure false positive rate
 	for i := 0; i < NumTests; i++ {
 		if bloom.Test(fr.NextHash()) {
 			falseCnt++
 		}
 	}
-	
+
 	// Assert that false positive rate is below 5%
-	fpRate := falseCnt/NumTests*100
+	fpRate := falseCnt / NumTests * 100
 	assert.True(t, falseCnt/NumTests < .05, "too many false positives, %3.1f%%", fpRate)
 	fmt.Printf("False Positives: %3.1f%%\n", fpRate)
 }

--- a/database/history_file.go
+++ b/database/history_file.go
@@ -103,6 +103,33 @@ func NewHistoryFile(OffsetCnt uint64, Directory string) (historyFile *HistoryFil
 	return hf, nil
 }
 
+// OpenHistoryFile
+// Opens an existing HistoryFile and loads its header (the KeySet offsets).
+func OpenHistoryFile(Directory string) (historyFile *HistoryFile, err error) {
+	hf := new(HistoryFile)
+	hf.Directory = Directory
+	hf.Filename = filepath.Join(Directory, historyFilename)
+	if hf.File, err = os.OpenFile(hf.Filename, os.O_RDWR, 0644); err != nil {
+		return nil, err
+	}
+
+	// The first 4 bytes hold the OffsetCnt, which sizes the header
+	var cntBuff [4]byte
+	if _, err = hf.File.ReadAt(cntBuff[:], 0); err != nil {
+		return nil, err
+	}
+	offsetCnt := binary.BigEndian.Uint32(cntBuff[:])
+	hf.OffsetCnt = int32(offsetCnt)
+	hf.HeaderSize = 4 + KeySetSize*uint64(offsetCnt)
+
+	header := make([]byte, hf.HeaderSize)
+	if _, err = hf.File.ReadAt(header, 0); err != nil {
+		return nil, err
+	}
+	hf.Unmarshal(header)
+	return hf, nil
+}
+
 // EOF
 // Return the last offset in the HistoryFile
 func (hf *HistoryFile) EOF() uint64 {
@@ -138,10 +165,18 @@ func min(a, b int) int {
 func (hf *HistoryFile) Unmarshal(data []byte) {
 	hf.OffsetCnt = int32(binary.BigEndian.Uint32(data))
 	data = data[4:]
+	// Allocate the KeySet slices if needed (e.g. when opening an existing
+	// HistoryFile rather than creating a new one)
+	if len(hf.KeySets) != int(hf.OffsetCnt) {
+		hf.KeySets = make([]*KeySet, hf.OffsetCnt)
+		hf.KeySetOffset = make([]*KeySet, hf.OffsetCnt)
+	}
 	for i := uint64(0); i < uint64(hf.OffsetCnt); i++ {
 		ks := new(KeySet)
 		ks.OffsetIndex = i
+		ks.KeySetIndex = i
 		ks.Unmarshal(data)
+		data = data[KeySetSize:] // Advance to the next KeySet entry
 		hf.KeySets[i] = ks
 		hf.KeySetOffset[i] = ks
 	}
@@ -258,7 +293,7 @@ func (hf *HistoryFile) UpdateKeySet(index int, keyList []byte) (err error) {
 	if _, err = hf.File.WriteAt(buffer[:NewLength], int64(offset)); err != nil {
 		return err
 	}
-	
+
 	// Clear the buffer to help with garbage collection
 	buffer = nil
 
@@ -295,7 +330,7 @@ func (hf *HistoryFile) Get(Key [32]byte) (dbBKey *DBBKey, err error) {
 		return nil, err
 	}
 
-	var dbKey DBBKey                    //          Search the keys by unmarshaling each key as we search
+	var dbKey DBBKey                   //          Search the keys by unmarshaling each key as we search
 	for len(buffer) >= DBKeyFullSize { //          Search all DBBKey entries, note they are not sorted.
 		if [32]byte(buffer) == Key {
 			if _, err := dbKey.Unmarshal(buffer[:DBKeyFullSize]); err != nil {

--- a/database/history_file.go
+++ b/database/history_file.go
@@ -227,8 +227,12 @@ func (hf *HistoryFile) AddKeys(keyList []byte) (err error) {
 		fmt.Printf("Update End %d to %d\n", startOff, endOff)
 		return err
 	}
-	_, err = hf.File.WriteAt(hf.Marshal(), 0)
-	return err
+	if _, err = hf.File.WriteAt(hf.Marshal(), 0); err != nil {
+		return err
+	}
+	// Sync so the caller can safely discard its copy of these keys
+	// (PushHistory resets the kfile once AddKeys returns)
+	return hf.File.Sync()
 }
 
 // OffsetSort

--- a/database/kfile.go
+++ b/database/kfile.go
@@ -60,6 +60,12 @@ func OpenKFile(directory string) (kFile *KFile, err error) {
 	kFile = new(KFile)
 
 	kFile.Directory = directory
+
+	// Remove any tmp file left behind by a crash mid-rewrite; the real
+	// kfile is only ever replaced by an atomic rename, so a lingering tmp
+	// file is always incomplete.
+	os.Remove(filepath.Join(directory, kTmpFileName))
+
 	filename := filepath.Join(directory, kFileName)
 	if kFile.File, err = OpenBFile(filename); err != nil {
 		return nil, err
@@ -159,19 +165,9 @@ func (k *KFile) PushHistory() (err error) {
 		return err
 	}
 
-	if err = os.Remove(filepath.Join(k.Directory, kFileName)); err != nil {
-		return err
-	}
-
-	if k.File, err = NewBFile(filepath.Join(k.Directory, kFileName)); err != nil {
-		return err
-	}
-
-	k.Header.Init(uint64(k.OffsetsCnt))
-	k.Close()
-	k.Open()
-
-	// Only attempt to push to history if we have keys to push
+	// Push the keys into history BEFORE resetting the kfile.  A crash
+	// between the two steps then leaves the keys in both places (a benign
+	// duplicate resolved by the next push) instead of in neither.
 	if len(keyList) > 0 {
 		// Process history synchronously to prevent memory buildup
 
@@ -188,10 +184,6 @@ func (k *KFile) PushHistory() (err error) {
 			buffPtr = buffPtr[DBKeyFullSize:]
 		}
 
-		// Clear references to help with garbage collection
-		keyValues = nil
-		keyList = nil
-
 		k.HistoryMutex.Lock()
 
 		// Double-check that History is still valid before using it
@@ -204,10 +196,26 @@ func (k *KFile) PushHistory() (err error) {
 		}
 
 		k.HistoryMutex.Unlock()
-
-		// Clear the buffer to help with garbage collection
-		buff = nil
 	}
+
+	// The keys are durable in history; now reset the kfile
+	if k.File.File != nil { // GetKeyList leaves the file open
+		if err = k.File.File.Close(); err != nil {
+			return err
+		}
+		k.File.File = nil
+	}
+	if err = os.Remove(filepath.Join(k.Directory, kFileName)); err != nil {
+		return err
+	}
+
+	if k.File, err = NewBFile(filepath.Join(k.Directory, kFileName)); err != nil {
+		return err
+	}
+
+	k.Header.Init(uint64(k.OffsetsCnt))
+	k.Close()
+	k.Open()
 
 	return nil
 }
@@ -601,31 +609,46 @@ func (k *KFile) Close() (err error) {
 	}
 	k.Header.EndOfList = currentOffset // End of List is where the currentOffset was left
 
-	err = k.File.File.Close()
+	if err = k.File.File.Close(); err != nil {
+		return err
+	}
+	k.File.File = nil
+
+	// Rewrite the kfile through a tmp file and an atomic rename so a crash
+	// mid-rewrite cannot lose the keys (the old kfile stays intact until
+	// the new one is durable).
+	tmpPath := filepath.Join(k.Directory, kTmpFileName)
+	tmp, err := NewBFile(tmpPath)
 	if err != nil {
 		return err
 	}
-	err = os.Remove(k.File.Filename)
-	if err != nil {
-		return err
-	}
-	if k.File.File, err = os.Create(k.File.Filename); err != nil {
-		return err
-	}
-	err = k.WriteHeader()
-	if err != nil {
+	if _, err = tmp.Write(k.Header.Marshal()); err != nil {
 		return err
 	}
 	// Write all the keys following the Header
 	for _, key := range keyList {
 		keyB := keyValues[key].Bytes(key)
-		_, err = k.File.Write(keyB)
-		if err != nil {
+		if _, err = tmp.Write(keyB); err != nil {
 			return err
 		}
 	}
+	if err = tmp.Flush(); err != nil {
+		return err
+	}
+	if err = tmp.File.Sync(); err != nil { // Make the new kfile durable
+		return err
+	}
+	if err = tmp.File.Close(); err != nil {
+		return err
+	}
+	if err = os.Rename(tmpPath, k.File.Filename); err != nil {
+		return err
+	}
 
-	return k.File.Close()
+	// Update the BFile state to match the file just written
+	k.File.EOB = 0
+	k.File.EOD = uint64(k.HeaderSize) + uint64(len(keyList)*DBKeyFullSize)
+	return nil
 }
 
 // GetKeyList

--- a/database/kfile.go
+++ b/database/kfile.go
@@ -23,16 +23,16 @@ const (
 // KFile can operate in two modes based on whether history is enabled or disabled:
 //
 // 1. With History Enabled (used in PermKV):
-//    - Values are immutable - once a key is associated with a value, it cannot be changed
-//    - Attempting to overwrite a key with a different value will result in an error
-//    - Overwriting a key with the same value is allowed (no-op)
-//    - Suitable for content-addressed storage where keys are derived from values (e.g., hash of value)
-//    - Uses a Bloom filter to optimize key lookups and avoid unnecessary disk I/O
+//   - Values are immutable - once a key is associated with a value, it cannot be changed
+//   - Attempting to overwrite a key with a different value will result in an error
+//   - Overwriting a key with the same value is allowed (no-op)
+//   - Suitable for content-addressed storage where keys are derived from values (e.g., hash of value)
+//   - Uses a Bloom filter to optimize key lookups and avoid unnecessary disk I/O
 //
 // 2. With History Disabled (used in DynaKV):
-//    - Values are mutable - keys can be freely associated with different values over time
-//    - Overwriting a key with a different value is allowed
-//    - Suitable for state storage where keys have an arbitrary relationship to values
+//   - Values are mutable - keys can be freely associated with different values over time
+//   - Overwriting a key with a different value is allowed
+//   - Suitable for state storage where keys have an arbitrary relationship to values
 //
 // Performance Optimizations:
 // - Uses a Bloom filter to quickly determine if a key definitely doesn't exist
@@ -40,20 +40,18 @@ const (
 // - In Put operations, uses the Bloom filter to avoid unnecessary disk lookups
 // - Memory usage is optimized by having a single Bloom filter per KFile
 type KFile struct {
-	Header                               // kFile header (what is pushed to disk)
-	Directory       string               // Directory of the BFile
-	File            *BFile               // Key File
-	History         *HistoryFile         // The History Database (nil if history is disabled)
-	Cache           map[[32]byte]*DBBKey // Cache of DBBKey Offsets
-	BlocksCached    int                  // Track blocks cached before rewritten
-	HistoryMutex    sync.Mutex           // Allow the History to be merged in background
-	KeyCnt          uint64               // Number of keys in the current KFile
-	TotalCnt        uint64               // Total number of keys processed
-	OffsetCnt       uint64               // Number of key sets in the kFile
-	KeyLimit        uint64               // How many keys triggers to send keys to History
-	MaxCachedBlocks int                  // Maximum number of keys cached before flushing to kfile
-	HistoryOffsets  int                  // History offset cnt
-	BloomFilter     *Bloom               // Bloom filter for quick key existence checks
+	Header                              // kFile header (what is pushed to disk)
+	Directory      string               // Directory of the BFile
+	File           *BFile               // Key File
+	History        *HistoryFile         // The History Database (nil if history is disabled)
+	Cache          map[[32]byte]*DBBKey // Cache of DBBKey Offsets
+	BlocksCached   int                  // Track blocks cached before rewritten
+	HistoryMutex   sync.Mutex           // Allow the History to be merged in background
+	KeyCnt         uint64               // Number of keys in the current KFile
+	TotalCnt       uint64               // Total number of keys processed
+	OffsetCnt      uint64               // Number of key sets in the kFile
+	HistoryOffsets int                  // History offset cnt
+	BloomFilter    *Bloom               // Bloom filter for quick key existence checks
 }
 
 // Open
@@ -66,38 +64,24 @@ func OpenKFile(directory string) (kFile *KFile, err error) {
 	if kFile.File, err = OpenBFile(filename); err != nil {
 		return nil, err
 	}
+
+	// Load the header so the offset table, KeyLimit, and MaxCachedBlocks
+	// reflect what is on disk.  Without this, every key lookup misses and
+	// KeyLimit=0 triggers a history push on every Put.
+	if err = kFile.LoadHeader(); err != nil {
+		return nil, err
+	}
+
 	kFile.Cache = make(map[[32]byte]*DBBKey)
-	kFile.BlocksCached = 0
+	kFile.BlocksCached = kFile.MaxCachedBlocks
 
 	// Check if there's a history file and open it
-	historyFilename := filepath.Join(directory, historyFilename)
-	if _, err := os.Stat(historyFilename); err == nil {
-		// History file exists, open it
-		hf := new(HistoryFile)
-		hf.Directory = directory
-		hf.Filename = historyFilename
-		if hf.File, err = os.OpenFile(historyFilename, os.O_RDWR, 0644); err != nil {
+	historyPath := filepath.Join(directory, historyFilename)
+	if _, err := os.Stat(historyPath); err == nil {
+		if kFile.History, err = OpenHistoryFile(directory); err != nil {
 			return nil, err
 		}
-		
-		// Read the header
-		header := make([]byte, 4)
-		if _, err = hf.File.ReadAt(header, 0); err != nil {
-			return nil, err
-		}
-		hf.OffsetCnt = int32(binary.BigEndian.Uint32(header))
-		hf.HeaderSize = 4 + KeySetSize*uint64(hf.OffsetCnt)
-		
-		// Read the KeySets
-		keySetsData := make([]byte, hf.HeaderSize-4)
-		if _, err = hf.File.ReadAt(keySetsData, 4); err != nil {
-			return nil, err
-		}
-		hf.Unmarshal(append(header, keySetsData...))
-		
 		// The Bloom filter will be initialized and populated when Open is called
-		
-		kFile.History = hf
 	}
 
 	return kFile, nil
@@ -129,20 +113,20 @@ func NewKFile(
 	if kFile.File, err = NewBFile(filepath.Join(directory, filename)); err != nil {
 		return nil, err
 	}
-	
+
 	// Only create a history file if history is enabled
 	if history {
 		if kFile.History, err = NewHistoryFile(offsetCnt, directory); err != nil {
 			return nil, err
 		}
 	}
-	
+
 	kFile.KeyLimit = keyLimit
 	kFile.MaxCachedBlocks = maxCachedBlocks
 	kFile.Header.Init(offsetCnt)
 	kFile.WriteHeader()
 	kFile.Cache = make(map[[32]byte]*DBBKey)
-	
+
 	// Initialize the Bloom filter with a reasonable size
 	// Using 10MB as a size, which is a good balance between memory usage and false positive rate
 	kFile.BloomFilter = NewBloomFilter(10.0, 3) // 10MB Bloom filter with 3 hash functions
@@ -154,57 +138,43 @@ func NewKFile(
 // Creates a new kFile height.  Merges the keys of the current kFile into the History.
 // Resets the KFile to accept more keys.
 func (k *KFile) PushHistory() (err error) {
-	// If history is disabled, just reset the KFile without pushing to history
+	// If history is disabled, the keys have nowhere to go -- they must stay
+	// in the kfile.  Close compacts the kfile (GetKeyList deduplicates
+	// overwritten keys), so a Close/Open cycle reclaims space without
+	// losing any keys.
 	if k.History == nil {
-		// Close the current file
 		if err = k.Close(); err != nil {
 			return err
 		}
-		
-		// Remove the old file
-		if err = os.Remove(filepath.Join(k.Directory, kFileName)); err != nil {
-			return err
-		}
-		
-		// Create a new file
-		if k.File, err = NewBFile(filepath.Join(k.Directory, kFileName)); err != nil {
-			return err
-		}
-		
-		// Initialize the header
-		k.Header.Init(uint64(k.OffsetsCnt))
-		k.Close()
-		k.Open()
-		
-		return nil
+		return k.File.Open()
 	}
-	
+
 	// Normal history-enabled flow
 	if err = k.Close(); err != nil {
 		return err
 	}
-	
+
 	keyValues, keyList, err := k.GetKeyList()
 	if err != nil {
 		return err
 	}
-	
+
 	if err = os.Remove(filepath.Join(k.Directory, kFileName)); err != nil {
 		return err
 	}
-	
+
 	if k.File, err = NewBFile(filepath.Join(k.Directory, kFileName)); err != nil {
 		return err
 	}
-	
+
 	k.Header.Init(uint64(k.OffsetsCnt))
 	k.Close()
 	k.Open()
-	
+
 	// Only attempt to push to history if we have keys to push
 	if len(keyList) > 0 {
 		// Process history synchronously to prevent memory buildup
-		
+
 		// Create a buffer for the keys
 		buff := make([]byte, len(keyList)*DBKeyFullSize)
 		buffPtr := buff
@@ -213,17 +183,17 @@ func (k *KFile) PushHistory() (err error) {
 			if k.BloomFilter != nil {
 				k.BloomFilter.Set(key)
 			}
-			
+
 			copy(buffPtr, (*keyValues[key]).Bytes(key))
 			buffPtr = buffPtr[DBKeyFullSize:]
 		}
-		
+
 		// Clear references to help with garbage collection
 		keyValues = nil
 		keyList = nil
-		
+
 		k.HistoryMutex.Lock()
-		
+
 		// Double-check that History is still valid before using it
 		if k.History != nil {
 			// Add keys to history
@@ -232,13 +202,13 @@ func (k *KFile) PushHistory() (err error) {
 				return fmt.Errorf("Error sending data to history: %v", err)
 			}
 		}
-		
+
 		k.HistoryMutex.Unlock()
-		
+
 		// Clear the buffer to help with garbage collection
 		buff = nil
 	}
-	
+
 	return nil
 }
 
@@ -246,20 +216,69 @@ func (k *KFile) PushHistory() (err error) {
 // Make sure the underlying File is open for adding keys.  Sets the
 // location in the file for writing to the end of the file.
 func (k *KFile) Open() error {
-	// Initialize the Bloom filter if it doesn't exist
+	// Initialize the Bloom filter if it doesn't exist.  Population is only
+	// needed when the filter is created (i.e. on reopen of an existing
+	// database); once in memory it tracks every key added by Put, so
+	// repopulating on every Open would be wasted work.
 	if k.BloomFilter == nil {
 		// Using 10MB as a size, which is a good balance between memory usage and false positive rate
 		k.BloomFilter = NewBloomFilter(10.0, 3) // 10MB Bloom filter with 3 hash functions
-	}
-	
-	// If history is enabled, populate the Bloom filter with keys from history
-	if k.History != nil {
-		if err := k.PopulateBloomFilterFromHistory(); err != nil {
+
+		// If history is enabled, populate the Bloom filter with keys from history
+		if k.History != nil {
+			if err := k.PopulateBloomFilterFromHistory(); err != nil {
+				return err
+			}
+		}
+
+		// Populate the Bloom filter with the keys still in the current
+		// kfile.  Without this, keys that have not yet been pushed to
+		// history are invisible after a reopen (Get fails the Bloom test
+		// before ever reading the disk).
+		if err := k.PopulateBloomFilterFromKFile(); err != nil {
 			return err
 		}
 	}
-	
+
 	return k.File.Open()
+}
+
+// PopulateBloomFilterFromKFile
+// Populates the Bloom filter with the keys currently stored in the kfile
+// itself (keys that have not been pushed to history).  Called when a KFile
+// is reopened.
+func (k *KFile) PopulateBloomFilterFromKFile() error {
+	if k.BloomFilter == nil {
+		return nil
+	}
+	if err := k.File.Open(); err != nil {
+		return err
+	}
+
+	start := uint64(k.HeaderSize)
+	end := k.File.EOD
+	if end <= start {
+		return nil
+	}
+
+	// Read the keys in ~1MB chunks.  The chunk size must be a multiple of
+	// the record size so records never straddle a chunk boundary.
+	const chunkSize = DBKeyFullSize * 21845
+	buffer := make([]byte, min(chunkSize, int(end-start)))
+	for offset := start; offset < end; offset += uint64(len(buffer)) {
+		if offset+uint64(len(buffer)) > end {
+			buffer = buffer[:end-offset]
+		}
+		if err := k.File.ReadAt(offset, buffer); err != nil {
+			return err
+		}
+		for keyPos := 0; keyPos+DBKeyFullSize <= len(buffer); keyPos += DBKeyFullSize {
+			var key [32]byte
+			copy(key[:], buffer[keyPos:keyPos+32])
+			k.BloomFilter.Set(key)
+		}
+	}
+	return nil
 }
 
 // Use the min function from history_file.go
@@ -271,9 +290,9 @@ func (k *KFile) PopulateBloomFilterFromHistory() error {
 	if k.History == nil || k.BloomFilter == nil {
 		return nil
 	}
-	
+
 	hf := k.History
-	
+
 	// Iterate through all KeySets in the history file
 	for i := 0; i < int(hf.OffsetCnt); i++ {
 		start := hf.KeySets[i].Start
@@ -286,8 +305,10 @@ func (k *KFile) PopulateBloomFilterFromHistory() error {
 		}
 
 		// Use a smaller buffer size to reduce memory usage
-		// Process in chunks instead of loading the entire KeySet at once
-		const chunkSize = 1024 * 1024 // 1MB chunks
+		// Process in chunks instead of loading the entire KeySet at once.
+		// The chunk size must be a multiple of the record size so records
+		// never straddle a chunk boundary.
+		const chunkSize = DBKeyFullSize * 21845 // ~1MB chunks
 		buffer := make([]byte, min(chunkSize, int(keysLen)))
 
 		// Process the KeySet in chunks
@@ -315,9 +336,16 @@ func (k *KFile) PopulateBloomFilterFromHistory() error {
 }
 
 // LoadHeader
-// Load the Header out of the Key File
+// Load the Header out of the Key File.  The header is self-describing:
+// the first 8 bytes hold OffsetsCnt and HeaderSize, which size the read
+// of the full header.
 func (k *KFile) LoadHeader() (err error) {
-	h := make([]byte, k.HeaderSize)
+	first := make([]byte, 8)
+	if err = k.File.ReadAt(0, first); err != nil {
+		return err
+	}
+	headerSize := binary.BigEndian.Uint32(first[4:])
+	h := make([]byte, headerSize)
 	if err = k.File.ReadAt(0, h); err != nil {
 		return err
 	}
@@ -342,26 +370,26 @@ func (k *KFile) Get(Key [32]byte) (dbBKey *DBBKey, err error) {
 	if value, ok := k.Cache[Key]; ok {
 		return value, nil
 	}
-	
+
 	// If we have a Bloom filter, check it before doing any disk I/O
 	// If the Bloom filter says the key doesn't exist, it's definitely not in the file or history
 	if k.BloomFilter != nil && !k.BloomFilter.Test(Key) {
 		return nil, errors.New("not found")
 	}
-	
+
 	// Try to get the key from the current file
 	dbBKey, err = k.kGet(Key)
 	if err == nil {
 		return dbBKey, nil
 	}
-	
+
 	// If not found and history is enabled, try to get from history
 	if k.History != nil {
 		k.HistoryMutex.Lock()
 		defer k.HistoryMutex.Unlock()
 		return k.History.Get(Key)
 	}
-	
+
 	// If no history or not found in history, return the original error
 	return nil, err
 }
@@ -413,16 +441,16 @@ func (k *KFile) kGet(Key [32]byte) (dbBKey *DBBKey, err error) {
 // Put a key value pair into the BFile, return the *DBBKeyFull
 //
 // Behavior depends on whether history is enabled:
-// - With history enabled (k.History != nil): Values are immutable. If the key already exists
-//   with a different value, an error is returned. Overwriting with the same value is a no-op.
-// - With history disabled (k.History == nil): Values are mutable. Keys can be freely overwritten
-//   with different values.
+//   - With history enabled (k.History != nil): Values are immutable. If the key already exists
+//     with a different value, an error is returned. Overwriting with the same value is a no-op.
+//   - With history disabled (k.History == nil): Values are mutable. Keys can be freely overwritten
+//     with different values.
 //
 // This design supports two use cases:
-// 1. Content-addressed storage (history enabled): Where keys are derived from values (e.g., hash)
-//    and immutability is required.
-// 2. State storage (history disabled): Where keys have an arbitrary relationship to values and
-//    need to be updated over time.
+//  1. Content-addressed storage (history enabled): Where keys are derived from values (e.g., hash)
+//     and immutability is required.
+//  2. State storage (history disabled): Where keys have an arbitrary relationship to values and
+//     need to be updated over time.
 func (k *KFile) Put(Key [32]byte, dbBKey *DBBKey) (err error) {
 	// If history is enabled, check if this key already exists with a different value
 	if k.History != nil {
@@ -435,7 +463,7 @@ func (k *KFile) Put(Key [32]byte, dbBKey *DBBKey) (err error) {
 			// If values are the same, this is a no-op
 			return nil
 		}
-		
+
 		// Use the Bloom filter to avoid disk lookup if possible
 		// If the Bloom filter says the key doesn't exist, we can skip the expensive disk lookup
 		if k.BloomFilter != nil && !k.BloomFilter.Test(Key) {
@@ -458,15 +486,15 @@ func (k *KFile) Put(Key [32]byte, dbBKey *DBBKey) (err error) {
 		}
 		// If key doesn't exist, proceed with the write
 	}
-	
+
 	// Add to the cache
 	k.Cache[Key] = dbBKey
-	
+
 	// Add to the Bloom filter if it exists
 	if k.BloomFilter != nil {
 		k.BloomFilter.Set(Key)
 	}
-	
+
 	k.KeyCnt++
 	k.TotalCnt++
 	update, err := k.File.Write(dbBKey.Bytes(Key)) // Write the key to the file
@@ -475,50 +503,50 @@ func (k *KFile) Put(Key [32]byte, dbBKey *DBBKey) (err error) {
 		delete(k.Cache, Key)
 		return err
 	}
-	
-	if update {                                    // If the file was updated && time to clear cache
+
+	if update { // If the file was updated && time to clear cache
 		if k.BlocksCached <= 0 {
 			if err = k.Close(); err != nil { //           In order to allow access to keys written to disk
 				return err //                               the file has to be closed and opened to update
 			} //                                            the key offsets
-			
+
 			// Save our cache
 			tempCache := make(map[[32]byte]*DBBKey)
 			for key, val := range k.Cache {
 				tempCache[key] = val
 			}
-			
+
 			// Clear the cache as required by the original implementation
 			clear(k.Cache)
-			
+
 			if err = k.File.Open(); err != nil { //       Reopen the file
 				return err
 			}
-			
+
 			// Restore our cache
 			for key, val := range tempCache {
 				k.Cache[key] = val
 			}
-			
+
 			k.BlocksCached = k.MaxCachedBlocks
 		} else {
 			k.BlocksCached--
 		}
 	}
-	
+
 	if k.KeyCnt > k.KeyLimit {
 		k.KeyCnt = 0
-		
+
 		// Push to history - we've modified PushHistory to be synchronous
 		if err = k.PushHistory(); err != nil {
 			return err
 		}
-		
+
 		// Clear the cache to reduce memory footprint
 		// We don't need to preserve the cache since all keys are now in history
 		clear(k.Cache)
 	}
-	
+
 	return nil
 }
 
@@ -652,7 +680,7 @@ func (k *KFile) GetKeyList() (keyValues map[[32]byte]*DBBKey, KeyList [][32]byte
 	sort.Slice(KeyList, func(i, j int) bool {
 		a := k.OffsetIndex(KeyList[i][:]) // Bin for a
 		b := k.OffsetIndex(KeyList[j][:]) // Bin for b
-		return a < b // Sort in ascending order
+		return a < b                      // Sort in ascending order
 	})
 
 	return keyValues, KeyList, nil

--- a/database/kfile_header.go
+++ b/database/kfile_header.go
@@ -11,10 +11,12 @@ const IndexShards = 4  // byte index to a 16 bit int used to define a shard for 
 // the key list we need to ignore.  This way, we have an offset to
 // the end of valid keys.
 type Header struct {
-	OffsetsCnt uint32   // Number of bins in the Offset Table
-	HeaderSize uint32   // Length of the header
-	Offsets    []uint64 // List of offsets
-	EndOfList  uint64   // Offset marking end of the last Key section
+	OffsetsCnt      uint32   // Number of bins in the Offset Table
+	HeaderSize      uint32   // Length of the header
+	Offsets         []uint64 // List of offsets
+	EndOfList       uint64   // Offset marking end of the last Key section
+	KeyLimit        uint64   // How many keys triggers to send keys to History
+	MaxCachedBlocks int      // Maximum number of blocks cached before flushing to kfile
 }
 
 // OffsetIndex
@@ -43,6 +45,10 @@ func (h *Header) Marshal() []byte {
 		offset += 8
 	}
 	binary.BigEndian.PutUint64(buffer[offset:], h.EndOfList) // EndOfList
+	offset += 8
+	binary.BigEndian.PutUint64(buffer[offset:], h.KeyLimit) // KeyLimit
+	offset += 8
+	binary.BigEndian.PutUint64(buffer[offset:], uint64(h.MaxCachedBlocks)) // MaxCachedBlocks
 	return buffer[:]
 }
 
@@ -53,27 +59,32 @@ func (h *Header) Unmarshal(data []byte) {
 	data = data[4:]
 	h.HeaderSize = binary.BigEndian.Uint32(data)
 	data = data[4:]
-	
+
 	// Initialize the Offsets slice if it's nil or has the wrong length
 	if h.Offsets == nil || len(h.Offsets) != int(h.OffsetsCnt) {
 		h.Offsets = make([]uint64, h.OffsetsCnt)
 	}
-	
+
 	// Read the offsets
 	for i := range h.Offsets {
 		h.Offsets[i] = binary.BigEndian.Uint64(data[i*8:])
 	}
-	
-	// Read the EndOfList value
-	h.EndOfList = binary.BigEndian.Uint64(data[len(h.Offsets)*8:])
+
+	// Read the EndOfList value, then the persisted KFile settings
+	data = data[len(h.Offsets)*8:]
+	h.EndOfList = binary.BigEndian.Uint64(data)
+	h.KeyLimit = binary.BigEndian.Uint64(data[8:])
+	h.MaxCachedBlocks = int(binary.BigEndian.Uint64(data[16:]))
 }
 
 // Init
 // Initiate a header to its default value
-// for an empty BFile
+// for an empty BFile.
+// Note: KeyLimit and MaxCachedBlocks are preserved; they are set once
+// by NewKFile and must survive the Header resets done by PushHistory.
 func (h *Header) Init(OffsetsCnt uint64) *Header {
 	h.OffsetsCnt = uint32(OffsetsCnt)
-	h.HeaderSize = uint32(OffsetsCnt)*8 + 4 + 4 + 8
+	h.HeaderSize = uint32(OffsetsCnt)*8 + 4 + 4 + 8 + 16
 	h.Offsets = make([]uint64, OffsetsCnt)
 	for i := range h.Offsets {
 		h.Offsets[i] = uint64(h.HeaderSize)

--- a/database/kfile_test.go
+++ b/database/kfile_test.go
@@ -160,50 +160,50 @@ func TestImmutabilityWithHistory(t *testing.T) {
 	// Create a test key and value
 	var key [32]byte
 	copy(key[:], []byte("test-key"))
-	
+
 	// Create original value
 	originalValue := &DBBKey{
 		Length: 100,
 		Offset: 200,
 	}
-	
+
 	// Put the original value
 	err = kf.Put(key, originalValue)
 	assert.NoError(t, err, "Should be able to write the key initially")
-	
+
 	// Verify we can get the value
 	retrievedValue, err := kf.Get(key)
 	assert.NoError(t, err, "Should be able to get the key")
 	assert.Equal(t, originalValue.Bytes(key), retrievedValue.Bytes(key), "Retrieved value should match original")
-	
+
 	// Try to overwrite with a different value
 	newValue := &DBBKey{
 		Length: 300, // Different from original
 		Offset: 400, // Different from original
 	}
-	
+
 	// Verify the values are different
 	assert.NotEqual(t, originalValue.Bytes(key), newValue.Bytes(key), "New value should be different from original")
-	
+
 	// Try to put the different value - should fail
 	err = kf.Put(key, newValue)
 	assert.Error(t, err, "Should not allow overwriting with different value when history is enabled")
 	assert.Contains(t, err.Error(), "cannot overwrite immutable value when history is enabled")
-	
+
 	// Verify the original value is still there
 	retrievedValue, err = kf.Get(key)
 	assert.NoError(t, err, "Should still be able to get the key")
 	assert.Equal(t, originalValue.Bytes(key), retrievedValue.Bytes(key), "Retrieved value should still match original")
-	
+
 	// Try to put the same value - should succeed
 	sameValue := &DBBKey{
 		Length: originalValue.Length,
 		Offset: originalValue.Offset,
 	}
-	
+
 	// Verify the values are the same
 	assert.Equal(t, originalValue.Bytes(key), sameValue.Bytes(key), "Same value should match original")
-	
+
 	// Try to put the same value - should succeed
 	err = kf.Put(key, sameValue)
 	assert.NoError(t, err, "Should allow overwriting with the same value when history is enabled")
@@ -220,35 +220,35 @@ func TestMutabilityWithoutHistory(t *testing.T) {
 	// Create a test key and value
 	var key [32]byte
 	copy(key[:], []byte("test-key"))
-	
+
 	// Create original value
 	originalValue := &DBBKey{
 		Length: 100,
 		Offset: 200,
 	}
-	
+
 	// Put the original value
 	err = kf.Put(key, originalValue)
 	assert.NoError(t, err, "Should be able to write the key initially")
-	
+
 	// Verify we can get the value
 	retrievedValue, err := kf.Get(key)
 	assert.NoError(t, err, "Should be able to get the key")
 	assert.Equal(t, originalValue.Bytes(key), retrievedValue.Bytes(key), "Retrieved value should match original")
-	
+
 	// Try to overwrite with a different value
 	newValue := &DBBKey{
 		Length: 300, // Different from original
 		Offset: 400, // Different from original
 	}
-	
+
 	// Verify the values are different
 	assert.NotEqual(t, originalValue.Bytes(key), newValue.Bytes(key), "New value should be different from original")
-	
+
 	// Try to put the different value - should succeed with history disabled
 	err = kf.Put(key, newValue)
 	assert.NoError(t, err, "Should allow overwriting with different value when history is disabled")
-	
+
 	// Verify the value has been updated
 	retrievedValue, err = kf.Get(key)
 	assert.NoError(t, err, "Should still be able to get the key")

--- a/database/kv.go
+++ b/database/kv.go
@@ -87,10 +87,13 @@ func (k *KV) Get(key [32]byte) (value []byte, err error) {
 }
 
 func (k *KV) Close() (err error) {
-	if err = k.kFile.Close(); err != nil {
+	// Close (and sync) the values first: keys reference offsets in the
+	// value file, so values must be durable before the keys that point
+	// at them.
+	if err = k.vFile.Close(); err != nil {
 		return err
 	}
-	if err = k.vFile.Close(); err != nil {
+	if err = k.kFile.Close(); err != nil {
 		return err
 	}
 	return nil

--- a/database/kv.go
+++ b/database/kv.go
@@ -9,11 +9,10 @@ const valueFilename = "values.dat"
 const valueTmpFilename = "values_tmp.dat"
 
 type KV struct {
-	Directory   string
-	vFile       *BFile
-	kFile       *KFile
-	HistoryFile *HistoryFile
-	UseHistory  bool
+	Directory  string
+	vFile      *BFile
+	kFile      *KFile
+	UseHistory bool
 }
 
 // NewKV
@@ -31,11 +30,10 @@ func NewKV(history bool, directory string, offsetsCnt, KeyLimit uint64, MaxCache
 	if kv.vFile, err = NewBFile(filepath.Join(directory, valueFilename)); err != nil {
 		return nil, err
 	}
-	if history {
-		if kv.HistoryFile, err = NewHistoryFile(1024, directory); err != nil {
-			return nil, err
-		}
-	}
+	// Note: the history file (when enabled) is owned by the kFile, which
+	// created it above.  Creating a second HistoryFile here would truncate
+	// the one the kFile is using.
+	kv.UseHistory = history
 	return kv, nil
 }
 
@@ -51,6 +49,7 @@ func OpenKV(directory string) (kv *KV, err error) {
 	if kv.kFile, err = OpenKFile(directory); err != nil {
 		return nil, err
 	}
+	kv.UseHistory = kv.kFile.History != nil
 	return kv, err
 }
 

--- a/database/kv2_profile_test.go
+++ b/database/kv2_profile_test.go
@@ -40,36 +40,36 @@ func TestBuildBigKV2(t *testing.T) {
 		// Create a key and value
 		keyStr := fmt.Sprintf("key%d", count)
 		value := fmt.Sprintf("value%d", count)
-		
+
 		// Create a 32-byte key
 		var key [32]byte
 		// Copy the string bytes into the fixed-size array
 		copy(key[:], []byte(keyStr))
-		
+
 		// Put the key-value pair
 		writes, err := kv2.Put(key, []byte(value))
 		if err != nil {
 			t.Fatal(err)
 		}
-		
+
 		// Print additional info every 100,000 entries
 		if count%100000 == 0 {
 			fmt.Printf("Writes since last compress: %d\n", writes)
 		}
-		
+
 		count++
-		
+
 		// Print progress every 10,000 entries
 		if count%10000 == 0 {
 			elapsed := time.Since(startTime)
-			fmt.Printf("Added %d entries in %v (%.2f entries/sec)\n", 
+			fmt.Printf("Added %d entries in %v (%.2f entries/sec)\n",
 				count, elapsed, float64(count)/elapsed.Seconds())
 		}
 	}
 
 	// Final stats
 	elapsed := time.Since(startTime)
-	fmt.Printf("\nFinal: Added %d entries in %v (%.2f entries/sec)\n", 
+	fmt.Printf("\nFinal: Added %d entries in %v (%.2f entries/sec)\n",
 		count, elapsed, float64(count)/elapsed.Seconds())
 
 	// Write memory profile

--- a/database/kv_2.go
+++ b/database/kv_2.go
@@ -48,13 +48,13 @@ type KV2 struct {
 // Create a two level KV file with different immutability characteristics:
 //
 // 1. PermKV: Uses KFile with history enabled (immutable values)
-//    - Created with history=true
-//    - Once a key is associated with a value, it cannot be changed
-//    - If a key in PermKV needs to be updated, it's moved to DynaKV
+//   - Created with history=true
+//   - Once a key is associated with a value, it cannot be changed
+//   - If a key in PermKV needs to be updated, it's moved to DynaKV
 //
 // 2. DynaKV: Uses KFile with history disabled (mutable values)
-//    - Created with history=false
-//    - Keys can be freely associated with different values over time
+//   - Created with history=false
+//   - Keys can be freely associated with different values over time
 //
 // This design efficiently separates immutable data (content-addressed storage)
 // from mutable data (state storage) in a blockchain-style database.

--- a/database/profile_test.go
+++ b/database/profile_test.go
@@ -38,31 +38,31 @@ func TestBuildBigFor3Minutes(t *testing.T) {
 		// Create a key and value
 		keyStr := fmt.Sprintf("key%d", count)
 		value := fmt.Sprintf("value%d", count)
-		
+
 		// Create a 32-byte key
 		var key [32]byte
 		// Copy the string bytes into the fixed-size array
 		copy(key[:], []byte(keyStr))
-		
+
 		// Put the key-value pair
 		err = kvShard.Put(key, []byte(value))
 		if err != nil {
 			t.Fatal(err)
 		}
-		
+
 		count++
-		
+
 		// Print progress every 10,000 entries
 		if count%10000 == 0 {
 			elapsed := time.Since(startTime)
-			fmt.Printf("Added %d entries in %v (%.2f entries/sec)\n", 
+			fmt.Printf("Added %d entries in %v (%.2f entries/sec)\n",
 				count, elapsed, float64(count)/elapsed.Seconds())
 		}
 	}
 
 	// Final stats
 	elapsed := time.Since(startTime)
-	fmt.Printf("\nFinal: Added %d entries in %v (%.2f entries/sec)\n", 
+	fmt.Printf("\nFinal: Added %d entries in %v (%.2f entries/sec)\n",
 		count, elapsed, float64(count)/elapsed.Seconds())
 
 	// Write memory profile

--- a/database/reopen_test.go
+++ b/database/reopen_test.go
@@ -1,0 +1,148 @@
+package blockchainDB
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The tests in this file cover the create -> write -> close -> open -> read
+// round trip.  See issues #3 and #4: no test reopened a database, which let
+// several reopen-path bugs (empty offset table, unpopulated Bloom filter,
+// nil KeySets panic, lost KeyLimit) go undetected.
+
+// putN writes n deterministic key/value pairs and returns the keys
+func putN(t *testing.T, kv *KV, seed byte, n int) (keys [][32]byte, values [][]byte) {
+	t.Helper()
+	kr := NewFastRandom([]byte{seed})
+	vr := NewFastRandom([]byte{seed, seed})
+	for i := 0; i < n; i++ {
+		key := kr.NextHash()
+		value := vr.RandBuff(10, 100)
+		require.NoError(t, kv.Put(key, value), "put failed")
+		keys = append(keys, key)
+		values = append(values, value)
+	}
+	return keys, values
+}
+
+// getN verifies that all the given key/value pairs can be read back
+func getN(t *testing.T, kv *KV, keys [][32]byte, values [][]byte) {
+	t.Helper()
+	for i, key := range keys {
+		v, err := kv.Get(key)
+		require.NoErrorf(t, err, "get failed for key %d", i)
+		assert.Equalf(t, values[i], v, "wrong value for key %d", i)
+	}
+}
+
+// TestKVReopenDyna
+// A history-disabled (mutable) KV must return its keys after close/reopen
+func TestKVReopenDyna(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	defer os.RemoveAll(dir)
+
+	kv, err := NewKV(false, dir, 16, 1000, 5)
+	require.NoError(t, err, "create kv")
+	keys, values := putN(t, kv, 1, 100)
+	getN(t, kv, keys, values)
+	require.NoError(t, kv.Close(), "close kv")
+
+	kv2, err := OpenKV(dir)
+	require.NoError(t, err, "reopen kv")
+	require.NoError(t, kv2.Open(), "open kv")
+	getN(t, kv2, keys, values)
+
+	// The reopened KV must keep accepting writes without losing anything
+	keys2, values2 := putN(t, kv2, 2, 100)
+	getN(t, kv2, keys2, values2)
+	getN(t, kv2, keys, values)
+	require.NoError(t, kv2.Close(), "close kv again")
+}
+
+// TestKVReopenPerm
+// A history-enabled (immutable) KV must return its keys after close/reopen,
+// including keys that were pushed into the history file
+func TestKVReopenPerm(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	defer os.RemoveAll(dir)
+
+	// KeyLimit of 50 forces history pushes during the 200 puts
+	kv, err := NewKV(true, dir, 16, 50, 5)
+	require.NoError(t, err, "create kv")
+	keys, values := putN(t, kv, 3, 200)
+	getN(t, kv, keys, values)
+	require.NoError(t, kv.Close(), "close kv")
+
+	kv2, err := OpenKV(dir)
+	require.NoError(t, err, "reopen kv")
+	require.NoError(t, kv2.Open(), "open kv")
+	getN(t, kv2, keys, values)
+	require.NoError(t, kv2.Close(), "close kv again")
+}
+
+// TestKV2Reopen
+// A KV2 (Perm + Dyna layers) must return keys from both layers after reopen
+func TestKV2Reopen(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	defer os.RemoveAll(dir)
+
+	kv2, err := NewKV2(dir, 16, 50, 5)
+	require.NoError(t, err, "create kv2")
+
+	kr := NewFastRandom([]byte{4})
+	vr := NewFastRandom([]byte{4, 4})
+	var keys [][32]byte
+	var values [][]byte
+	for i := 0; i < 100; i++ {
+		key := kr.NextHash()
+		value := vr.RandBuff(10, 100)
+		if i%2 == 0 {
+			_, err = kv2.PutPerm(key, value)
+		} else {
+			_, err = kv2.PutDyna(key, value)
+		}
+		require.NoError(t, err, "put failed")
+		keys = append(keys, key)
+		values = append(values, value)
+	}
+	require.NoError(t, kv2.Close(), "close kv2")
+
+	reopened, err := OpenKV2(dir)
+	require.NoError(t, err, "reopen kv2")
+	require.NoError(t, reopened.Open(), "open kv2")
+	for i, key := range keys {
+		v, err := reopened.Get(key)
+		require.NoErrorf(t, err, "get failed for key %d", i)
+		assert.Equalf(t, values[i], v, "wrong value for key %d", i)
+	}
+	require.NoError(t, reopened.Close(), "close kv2 again")
+}
+
+// TestDynaKeyLimitPreservesKeys
+// A history-disabled KV must not lose keys when KeyLimit is exceeded.
+// Regression test for issue #4: the old PushHistory deleted the kfile,
+// discarding every key, when history was disabled.
+func TestDynaKeyLimitPreservesKeys(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	defer os.RemoveAll(dir)
+
+	// KeyLimit of 10, then write 25 keys to force multiple push cycles
+	kv, err := NewKV(false, dir, 16, 10, 5)
+	require.NoError(t, err, "create kv")
+	keys, values := putN(t, kv, 5, 25)
+	getN(t, kv, keys, values)
+
+	// Overwrites must survive push cycles too (Dyna values are mutable)
+	newValue := []byte("updated value")
+	require.NoError(t, kv.Put(keys[0], newValue), "overwrite failed")
+	for i := 0; i < 15; i++ { // push past KeyLimit again
+		_, _ = putN(t, kv, byte(6+i), 1)
+	}
+	v, err := kv.Get(keys[0])
+	require.NoError(t, err, "get after overwrite")
+	assert.Equal(t, newValue, v, "overwrite lost")
+}

--- a/database/view_kv.go
+++ b/database/view_kv.go
@@ -44,6 +44,7 @@ type KVView struct {
 	Timeout     time.Duration // How long before views timeout; every access resets timeout
 	OffsetCnt   uint64        // KeyOffset number for the key files
 	KeyLimit    uint64        // KeyLimit sets when to move keys to History
+	FlushErr    error         // First error hit while flushing buffered writes to the DB
 }
 
 func NewShardDBViews(
@@ -78,10 +79,32 @@ func OpenShardDBViews(
 	return nil, err
 }
 
-func (s *KVView) Close() {
+// flushViewCache
+// Writes the key/value pairs buffered in the view cache (ActiveViews[0])
+// into the underlying DB.  While views are active, Put only buffers
+// writes; they land in the DB here, when the last view goes away.
+// The first flush error is retained in s.FlushErr and returned by Close.
+func (s *KVView) flushViewCache() {
+	if len(s.ActiveViews) == 0 {
+		return
+	}
+	for key, value := range s.ActiveViews[0].KeyValues {
+		if err := s.DB.Put(key, value); err != nil && s.FlushErr == nil {
+			s.FlushErr = err
+		}
+	}
+	s.ActiveViews[0].KeyValues = nil
+}
+
+func (s *KVView) Close() error {
+	s.flushViewCache()
 	s.ActiveViews = nil
 	s.Map = nil
-	s.DB.Close()
+	err := s.DB.Close()
+	if s.FlushErr != nil {
+		return s.FlushErr
+	}
+	return err
 }
 
 // Active Views
@@ -105,8 +128,9 @@ func (s *KVView) Put(key [32]byte, value []byte) error {
 		return s.DB.Put(key, value)
 	}
 
-	s.ActiveViews[len(s.ActiveViews)-1].KeyValues[key] = value // Put key/value in last view
-	s.ActiveViews[0].KeyValues[key] = value                    // And put the key value in the cache
+	s.ActiveViews[len(s.ActiveViews)-1].KeyValues[key] = value  // Put key/value in last view
+	s.ActiveViews[len(s.ActiveViews)-1].LastAccess = time.Now() // Writing counts as activity
+	s.ActiveViews[0].KeyValues[key] = value                     // And put the key value in the cache
 	return nil
 }
 
@@ -150,36 +174,41 @@ func (s *KVView) NewView() *View {
 
 // GetViewIndex
 // Returns the view index for a view.  Returns 0 if view is closed.
+// Also expires views that have not been accessed within the timeout,
+// prunes closed views from the old end of the stack, and flushes the
+// buffered writes to the DB when the last view goes away.
 func (s *KVView) GetViewIndex(view *View) int {
-	if view.Closed || len(s.ActiveViews) == 0 {
+	if len(s.ActiveViews) == 0 {
 		return 0
 	}
 
-	// Look for and mark all the views that have timed out
+	// Mark all the views that have timed out.  Note this checks each
+	// view's own LastAccess (checking the queried view's LastAccess here
+	// would close every other view as soon as one view went stale).
 	for _, v := range s.ActiveViews[1:] {
-		if v.Closed {
-			return 0
-		}
-		if dt := time.Since(view.LastAccess); dt > s.Timeout {
+		if time.Since(v.LastAccess) > s.Timeout {
 			v.Closed = true
 		}
 	}
 
-	// First clear ActiveViews if no active view exists
-	if len(s.ActiveViews) == 2 && s.ActiveViews[1].Closed { // Clear ActiveViews if none exist
-		s.ActiveViews = s.ActiveViews[:0]
-		return 0
-	}
-	for s.ActiveViews[1].Closed { // While the oldest ActiveView is closed, delete it
+	// Remove closed views from the old end of the stack.  Closed views in
+	// the middle must be retained: newer views still look up buffered
+	// writes through them.
+	for len(s.ActiveViews) >= 2 && s.ActiveViews[1].Closed {
 		n := len(s.ActiveViews)
-		if n <= 2 { // If Removing the last view, clear ActiveViews
-			s.ActiveViews = s.ActiveViews[:0] // No index exists for the View
-			return 0
+		if n <= 2 { // Removing the last view: flush buffered writes, clear all
+			s.flushViewCache()
+			s.ActiveViews = s.ActiveViews[:0]
+			break
 		}
 		copy(s.ActiveViews[1:], s.ActiveViews[2:]) // Remove the closed View
+		s.ActiveViews[n-1] = nil
 		s.ActiveViews = s.ActiveViews[:n-1]
 	}
 
+	if view.Closed {
+		return 0
+	}
 	for i, v := range s.ActiveViews[1:] { // Look for the view in the Views that remain
 		if v.ID == view.ID {
 			return i + 1
@@ -194,14 +223,14 @@ func (s *KVView) GetViewIndex(view *View) int {
 // active views that were created before this view are searched in turn.  If no
 // key value pair is found in the view or older views, then return what the DB has
 func (s *KVView) ViewGet(view *View, key [32]byte) (value []byte, err error) {
-	//
-	view.LastAccess = time.Now()
-	// Check if the view provided is active.  If not, return an error that the
-	// view has expired
+	// Check if the view provided is active.  If not, return an error that
+	// the view has expired.  Only refresh LastAccess for a still-valid
+	// view; refreshing first would resurrect views that already expired.
 	viewIdx := s.GetViewIndex(view)
 	if viewIdx == 0 {
 		return nil, fmt.Errorf("view invalid")
 	}
+	view.LastAccess = time.Now()
 
 	// Check the view and all the older views for a key value pair.  Note that even
 	// if an older view has expired, we still need its key value pair rather than

--- a/database/view_kv_test.go
+++ b/database/view_kv_test.go
@@ -114,70 +114,63 @@ func TestView(t *testing.T) {
 	Vr := NewFastRandom([]byte{1, 2, 3, 4})
 
 	// Make sure we can read and write keys
+	keys := make([][32]byte, NumKeys)
+	original := make([][]byte, NumKeys)
 	for i := 0; i < NumKeys; i++ {
-		key := Kr.NextHash()
-		value := Vr.RandBuff(10, 10)
-		sdbv.Put(key, value)
-		v, err := sdbv.Get(key)
+		keys[i] = Kr.NextHash()
+		original[i] = Vr.RandBuff(10, 10)
+		sdbv.Put(keys[i], original[i])
+		v, err := sdbv.Get(keys[i])
 		assert.NoError(t, err, "get failed")
-		assert.Equal(t, value, v, "failed to get data")
+		assert.Equal(t, original[i], v, "failed to get data")
 	}
 
-	// Make sure we can read the keys
-	Kr.Reset()
-	Vr.Reset()
-	for i := 0; i < NumKeys; i++ {
-		key := Kr.NextHash()
-		value := Vr.RandBuff(10, 10)
-		v, err := sdbv.Get(key)
-		assert.NoError(t, err, "get failed")
-		assert.Equal(t, value, v, "failed to get data")
-	}
-
-	// Create a view and modify half the keys (Don't reset the value sequence)
-	Kr.Reset()
+	// Create a view and modify half the keys
 	view := sdbv.NewView()
+	changed := make([][]byte, NumKeys/2)
 	for i := 0; i < NumKeys/2; i++ {
-		key := Kr.NextHash()
-		value := Vr.RandBuff(10, 10)
-		err := sdbv.Put(key, value)
+		changed[i] = Vr.RandBuff(10, 10)
+		err := sdbv.Put(keys[i], changed[i])
 		assert.NoError(t, err, "put failed")
 	}
 
-	// No values changed above should change in the view
-	Kr.Reset()
-	Vr.Reset()
+	// The view must still see the original values for every key
 	for i := 0; i < NumKeys; i++ {
-		key := Kr.NextHash()
-		value := Vr.RandBuff(10, 10)
-		v, err := view.Get(key)
+		v, err := view.Get(keys[i])
 		assert.NoError(t, err, "get failed")
-		assert.Equal(t, value, v, "failed to get data")
+		assert.Equal(t, original[i], v, "view saw a write made after its creation")
 	}
-	assert.Equal(t, 1, len(sdbv.ActiveViews), "Should have one active view")
-	sdbv.Close()
 
-	// Check the DB; first half should have changed values, last half not changed
-	Kr.Reset()
-	Vr.Reset()
-	for i := 0; i < NumKeys; i++ {
-		key := Kr.NextHash()
-		value := Vr.RandBuff(10, 10)
-		v, err := view.Get(key)
+	// The view stack holds the write cache (index 0) plus the one view
+	assert.Equal(t, 2, len(sdbv.ActiveViews), "should have the cache and one active view")
+
+	// While the view is active, non-view reads see the new values (from
+	// the write cache)
+	for i := 0; i < NumKeys/2; i++ {
+		v, err := sdbv.Get(keys[i])
 		assert.NoError(t, err, "get failed")
-		if i >= NumKeys/2 {
-			assert.Equal(t, value, v, "failed to get data")
+		assert.Equal(t, changed[i], v, "read of a buffered write failed")
+	}
+
+	// Let the view time out.  The buffered writes must flush to the DB
+	time.Sleep(Timeout + 100*time.Millisecond)
+	assert.False(t, sdbv.IsViewActive(), "view should have expired")
+	assert.NoError(t, sdbv.FlushErr, "flushing buffered writes failed")
+
+	// An expired view is no longer usable
+	_, err = view.Get(keys[0])
+	assert.Error(t, err, "expired view should return an error")
+
+	// The DB must have the changed values for the first half and the
+	// original values for the second half
+	for i := 0; i < NumKeys; i++ {
+		v, err := sdbv.Get(keys[i])
+		assert.NoError(t, err, "get failed")
+		if i < NumKeys/2 {
+			assert.Equal(t, changed[i], v, "buffered write was not flushed to the DB")
 		} else {
-			assert.NotEqual(t, value, v, "failed to update value")
+			assert.Equal(t, original[i], v, "unmodified key changed")
 		}
 	}
-	// Check the first half to be equal to the changed values
-	Kr.Reset()
-	for i := 0; i < NumKeys/2; i++ {
-		key := Kr.NextHash()
-		value := Vr.RandBuff(10, 10)
-		v, err := sdbv.Get(key)
-		assert.NoError(t, err, "put failed")
-		assert.Equal(t, value, v, "failed to get data")
-	}
+	assert.NoError(t, sdbv.Close(), "close failed")
 }


### PR DESCRIPTION
Fixes #3, fixes #4, fixes #6, and addresses the core of #5.

## Commit 1 — Reopen path and Dyna key loss (#3, #4)
- `OpenKFile` loads the header (the offset table was empty after reopen; every lookup missed)
- `LoadHeader` is self-sizing — it previously sized its read from `HeaderSize`, which is 0 before the header is read
- `KeyLimit` and `MaxCachedBlocks` are persisted in the kfile header (**file format change**: header grows by 16 bytes), so a reopened KFile doesn't run with `KeyLimit=0`
- The Bloom filter is populated from the current kfile as well as history on open; keys not yet pushed to history were failing the Bloom test and invisible
- New `OpenHistoryFile`; the old inline open path panicked on nil `KeySets`
- `HistoryFile.Unmarshal` never advanced its data pointer — every KeySet loaded bin 0's offsets, so most history records were lost on reopen
- Bloom population chunks are record-aligned (1MB chunks made 48-byte records straddle chunk boundaries and misparse)
- `PushHistory` with history disabled now compacts the kfile instead of **deleting it with all its keys** (verified: 22/25 keys lost past KeyLimit before the fix)
- Removed write-only `KV.HistoryFile`, which truncated the KFile's history file with a hardcoded 1024 bin count
- New `reopen_test.go`: round-trip tests for KV (Dyna/Perm), KV2, and a Dyna-KeyLimit regression test — no test previously reopened a database

## Commit 2 — Crash durability (#5, partial)
- `KFile.Close` rewrites via `kfile_tmp.dat` + fsync + atomic rename (previously: delete, then rewrite from memory — a crash in between lost every key)
- `PushHistory` pushes keys into history (synced) **before** resetting the kfile; a crash now duplicates keys (benign) instead of losing them
- `HistoryFile.AddKeys` and `BFile.Close` sync; `KV.Close` syncs values before the keys that reference them
- Still open on #5: directory-entry fsync, and a defined recovery procedure for unclean shutdown — leaving the issue open

## Commit 3 — Views (#6)
- Buffered writes flush to the DB when the last view goes away (they were silently discarded)
- Expiry checks each view's own `LastAccess` (one stale view was closing all the others)
- `ViewGet` validates before refreshing `LastAccess` (no more resurrecting expired views)
- `KVView.Close` flushes and returns an error
- `TestView` rewritten to the documented semantics — its old expectations contradicted the design (please review the intended lifecycle)

## Testing
Full unit suite passes, including the previously failing `TestView`. Load tests (`TestBuildBig*`) not run here — they exceed the suite timeout (worth moving behind a flag).

Not addressed here: #7 (Compress no-op), #8 (concurrency), #9 (HistoryFile.Get linear scan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1MpZq22uwNyJ8w2HWuRyJ