### PR TITLE
Sorted history bins with binary-search lookups (5.6x, O(log n))

### DIFF
--- a/database/history_bench_test.go
+++ b/database/history_bench_test.go
@@ -1,0 +1,60 @@
+package blockchainDB
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// BenchmarkHistoryGet measures key lookups against a HistoryFile loaded
+// with a realistic number of records (the dominant cost in the profile;
+// see issue #9).
+func BenchmarkHistoryGet(b *testing.B) {
+	dir := filepath.Join(os.TempDir(), "BenchHistoryGet")
+	os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
+
+	hf, err := NewHistoryFile(1024, dir)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Load 1M keys the way PushHistory does: batches sorted by bin
+	const totalKeys = 1_000_000
+	const batch = 100_000
+	fr := NewFastRandom([]byte{42})
+	var keys [][32]byte
+	kf := new(KFile) // borrow OffsetIndex via a header
+	kf.Header.Init(1024)
+	for n := 0; n < totalKeys; n += batch {
+		buff := make([]byte, 0, batch*DBKeyFullSize)
+		batchKeys := make([][32]byte, batch)
+		for i := range batchKeys {
+			batchKeys[i] = fr.NextHash()
+		}
+		// sort by bin as GetKeyList does
+		sort.Slice(batchKeys, func(i, j int) bool {
+			return kf.OffsetIndex(batchKeys[i][:]) < kf.OffsetIndex(batchKeys[j][:])
+		})
+		dbb := new(DBBKey)
+		for _, k := range batchKeys {
+			dbb.Offset += 100
+			dbb.Length = 100
+			buff = append(buff, dbb.Bytes(k)...)
+		}
+		if err := hf.AddKeys(buff); err != nil {
+			b.Fatal(err)
+		}
+		keys = append(keys, batchKeys...)
+	}
+
+	fr2 := NewFastRandom([]byte{43})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		key := keys[int(fr2.UintN(uint(len(keys))))]
+		if _, err := hf.Get(key); err != nil {
+			b.Fatal("key not found")
+		}
+	}
+}

--- a/database/history_file.go
+++ b/database/history_file.go
@@ -1,12 +1,14 @@
 package blockchainDB
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
+	"sort"
 	"sync"
 )
 
@@ -256,25 +258,77 @@ func (hf *HistoryFile) OffsetSort() {
 	}
 }
 
+// recordSort
+// Sorts a buffer of 48-byte key records in place by their 32-byte key
+type recordSort []byte
+
+func (r recordSort) Len() int { return len(r) / DBKeyFullSize }
+func (r recordSort) Less(i, j int) bool {
+	return bytes.Compare(r[i*DBKeyFullSize:i*DBKeyFullSize+32], r[j*DBKeyFullSize:j*DBKeyFullSize+32]) < 0
+}
+func (r recordSort) Swap(i, j int) {
+	var tmp [DBKeyFullSize]byte
+	copy(tmp[:], r[i*DBKeyFullSize:])
+	copy(r[i*DBKeyFullSize:(i+1)*DBKeyFullSize], r[j*DBKeyFullSize:])
+	copy(r[j*DBKeyFullSize:(j+1)*DBKeyFullSize], tmp[:])
+}
+
+// mergeRecords
+// Merges two key-sorted record buffers into one sorted buffer.  Records
+// with equal keys are deduplicated; the record from incoming wins.
+// (Duplicates arise when a crash between a history push and the kfile
+// reset leaves keys in both places; the next push re-sends them.)
+func mergeRecords(existing, incoming []byte) []byte {
+	merged := make([]byte, 0, len(existing)+len(incoming))
+	for len(existing) > 0 && len(incoming) > 0 {
+		switch bytes.Compare(existing[:32], incoming[:32]) {
+		case -1:
+			merged = append(merged, existing[:DBKeyFullSize]...)
+			existing = existing[DBKeyFullSize:]
+		case 1:
+			merged = append(merged, incoming[:DBKeyFullSize]...)
+			incoming = incoming[DBKeyFullSize:]
+		default: // Same key: the incoming record wins
+			merged = append(merged, incoming[:DBKeyFullSize]...)
+			existing = existing[DBKeyFullSize:]
+			incoming = incoming[DBKeyFullSize:]
+		}
+	}
+	merged = append(merged, existing...)
+	merged = append(merged, incoming...)
+	return merged
+}
+
 // UpdateKeySet
 // Add the given entries to the KeySet at the given index and update
-// the History File
+// the History File.
 //
-// # If the new keys fit where the KeySet is, just add them to the HistoryFile
-//
-// If a KeySet does not fit where it is in the HistoryFile,
-// Update it's start and end to where it can fit, and update the
-// KeySets offsets, and the HistoryFile. Mem
+// The records in a KeySet are kept sorted by key (Get relies on this to
+// binary search).  The incoming records are sorted, then merged with the
+// KeySet's existing records; the merged KeySet is written wherever it
+// first fits (which may mean relocating it).
 func (hf *HistoryFile) UpdateKeySet(index int, keyList []byte) (err error) {
 
 	if len(keyList) == 0 { // Ignore nil lists
 		return nil
 	}
 
+	// Sort the incoming records by key.  Sorting is in place; callers do
+	// not reuse the buffer.
+	sort.Sort(recordSort(keyList))
+
 	keySet := hf.KeySets[index]
 	CurrentLength := keySet.End - keySet.Start
-	NewLength := CurrentLength + uint64(len(keyList))
 
+	// Read the existing (sorted) records and merge the new ones in
+	existing := make([]byte, CurrentLength)
+	if _, err = hf.File.ReadAt(existing, int64(keySet.Start)); err != nil {
+		return err
+	}
+	merged := mergeRecords(existing, keyList)
+	NewLength := uint64(len(merged))
+
+	// First fit: find the first gap the merged KeySet fits in
 	offset := uint64(hf.HeaderSize)
 	iAfter := 0
 	for iAfter = 0; iAfter < int(hf.OffsetCnt); iAfter++ {
@@ -284,22 +338,9 @@ func (hf *HistoryFile) UpdateKeySet(index int, keyList []byte) (err error) {
 		offset = hf.KeySetOffset[iAfter].End
 	}
 
-	// Create a local buffer for this operation instead of using a shared buffer
-	// This reduces memory usage and prevents memory growth
-	buffer := make([]byte, NewLength)
-
-	// If we have to move the keySet, read in the keySet
-	if _, err = hf.File.ReadAt(buffer[:CurrentLength], int64(keySet.Start)); err != nil {
+	if _, err = hf.File.WriteAt(merged, int64(offset)); err != nil {
 		return err
 	}
-	// And tack on the keyList
-	copy(buffer[CurrentLength:NewLength], keyList)
-	if _, err = hf.File.WriteAt(buffer[:NewLength], int64(offset)); err != nil {
-		return err
-	}
-
-	// Clear the buffer to help with garbage collection
-	buffer = nil
 
 	// Update position of keySet in the HistoryFile
 	keySet.Start = offset
@@ -320,29 +361,62 @@ func (hf *HistoryFile) Get(Key [32]byte) (dbBKey *DBBKey, err error) {
 	index := hf.Index(Key)
 	start := hf.KeySets[index].Start // The index is where the section starts
 	end := hf.KeySets[index].End
-	keysLen := end - start
+	numRecords := int64(end-start) / DBKeyFullSize
 
-	if keysLen == 0 { //                     If the start is the end, the section is empty
-		return nil, errors.New("not found") // TODO use buffer...
+	if numRecords == 0 { //                  If the start is the end, the section is empty
+		return nil, errors.New("not found")
 	}
 
-	// Use a local buffer instead of growing the shared buffer
-	// This prevents memory growth over time
-	buffer := make([]byte, keysLen)
+	// The records in a KeySet are sorted by key (see UpdateKeySet), so
+	// binary search, reading one 48-byte record per probe rather than the
+	// entire KeySet.  Once the remaining range is small, read it in one
+	// gulp and finish the search in memory to save syscalls.
+	const inMemRecords = 64 // 3KB; the range read in one gulp
 
-	if _, err = hf.File.ReadAt(buffer, int64(start)); err != nil { // Read the section
-		return nil, err
-	}
-
-	var dbKey DBBKey                   //          Search the keys by unmarshaling each key as we search
-	for len(buffer) >= DBKeyFullSize { //          Search all DBBKey entries, note they are not sorted.
-		if [32]byte(buffer) == Key {
-			if _, err := dbKey.Unmarshal(buffer[:DBKeyFullSize]); err != nil {
+	var record [DBKeyFullSize]byte
+	lo, hi := int64(0), numRecords-1
+	for hi-lo+1 > inMemRecords {
+		mid := (lo + hi) / 2
+		if _, err = hf.File.ReadAt(record[:], int64(start)+mid*DBKeyFullSize); err != nil {
+			return nil, err
+		}
+		switch bytes.Compare(Key[:], record[:32]) {
+		case 0:
+			var dbKey DBBKey
+			if _, err := dbKey.Unmarshal(record[:]); err != nil {
 				return nil, err
 			}
 			return &dbKey, nil
+		case -1:
+			hi = mid - 1
+		default:
+			lo = mid + 1
 		}
-		buffer = buffer[DBKeyFullSize:] //       Move to the next DBBKey
+	}
+
+	// Read the remaining range and binary search it in memory
+	var gulp [inMemRecords * DBKeyFullSize]byte
+	n := hi - lo + 1
+	buff := gulp[:n*DBKeyFullSize]
+	if _, err = hf.File.ReadAt(buff, int64(start)+lo*DBKeyFullSize); err != nil {
+		return nil, err
+	}
+	i, j := int64(0), n-1
+	for i <= j {
+		mid := (i + j) / 2
+		rec := buff[mid*DBKeyFullSize:]
+		switch bytes.Compare(Key[:], rec[:32]) {
+		case 0:
+			var dbKey DBBKey
+			if _, err := dbKey.Unmarshal(rec[:DBKeyFullSize]); err != nil {
+				return nil, err
+			}
+			return &dbKey, nil
+		case -1:
+			j = mid - 1
+		default:
+			i = mid + 1
+		}
 	}
 	return nil, errors.New("not found")
 }

--- a/database/history_sorted_test.go
+++ b/database/history_sorted_test.go
@@ -1,0 +1,93 @@
+package blockchainDB
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHistoryKeySetsSorted
+// Verifies the KeySet sorting invariant Get's binary search relies on:
+// after multiple pushes, every KeySet's records are sorted by key, and
+// every key is still found.
+func TestHistoryKeySetsSorted(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
+
+	// Small KeyLimit forces many history pushes
+	kv, err := NewKV(true, dir, 16, 100, 5)
+	require.NoError(t, err, "create kv")
+
+	kr := NewFastRandom([]byte{7})
+	vr := NewFastRandom([]byte{7, 7})
+	keys := make([][32]byte, 1000)
+	values := make([][]byte, 1000)
+	for i := range keys {
+		keys[i] = kr.NextHash()
+		values[i] = vr.RandBuff(10, 50)
+		require.NoError(t, kv.Put(keys[i], values[i]))
+	}
+
+	// Every KeySet must be sorted by key with no duplicates
+	hf := kv.kFile.History
+	require.NotNil(t, hf, "history must exist")
+	for bin, ks := range hf.KeySets {
+		length := ks.End - ks.Start
+		if length == 0 {
+			continue
+		}
+		buff := make([]byte, length)
+		_, err := hf.File.ReadAt(buff, int64(ks.Start))
+		require.NoError(t, err)
+		for pos := DBKeyFullSize; pos < len(buff); pos += DBKeyFullSize {
+			prev := buff[pos-DBKeyFullSize : pos-DBKeyFullSize+32]
+			cur := buff[pos : pos+32]
+			assert.Negativef(t, bytes.Compare(prev, cur),
+				"bin %d not strictly sorted at record %d", bin, pos/DBKeyFullSize)
+		}
+	}
+
+	// And every key must still resolve to its value
+	for i := range keys {
+		v, err := kv.Get(keys[i])
+		require.NoErrorf(t, err, "key %d not found", i)
+		assert.Equalf(t, values[i], v, "wrong value for key %d", i)
+	}
+}
+
+// TestImmutabilityThroughHistory
+// A key that has been pushed to history must still be immutable: a Put
+// with a different value must fail even though the key is no longer in
+// the current kfile.  (Previously the Put existence check only looked at
+// the current kfile, so pushed keys could be silently overwritten.)
+func TestImmutabilityThroughHistory(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(dir)
+	require.NoError(t, os.MkdirAll(dir, os.ModePerm))
+	defer os.RemoveAll(dir)
+
+	kFile, err := NewKFile(true, dir, 16, 10, 5)
+	require.NoError(t, err, "create kfile")
+
+	kr := NewFastRandom([]byte{8})
+	first := kr.NextHash()
+	firstVal := &DBBKey{Offset: 1, Length: 10}
+	require.NoError(t, kFile.Put(first, firstVal))
+
+	// Push the first key into history by exceeding KeyLimit
+	for i := 0; i < 20; i++ {
+		require.NoError(t, kFile.Put(kr.NextHash(), &DBBKey{Offset: uint64(i + 2), Length: 10}))
+	}
+
+	// Overwriting with a different value must fail
+	err = kFile.Put(first, &DBBKey{Offset: 999, Length: 10})
+	assert.Error(t, err, "immutable key in history was overwritten")
+
+	// Overwriting with the same value is a no-op
+	assert.NoError(t, kFile.Put(first, firstVal), "same-value rewrite should be a no-op")
+}

--- a/database/kfile.go
+++ b/database/kfile.go
@@ -491,6 +491,22 @@ func (k *KFile) Put(Key [32]byte, dbBKey *DBBKey) (err error) {
 				// If there was an error other than "not found", return it
 				return err
 			}
+
+			// Not in the current kfile; the key may have been pushed to
+			// history.  Immutability must hold for pushed keys too.
+			// (KeySets are sorted, so this check is a cheap binary search.)
+			k.HistoryMutex.Lock()
+			existingKey, err = k.History.Get(Key)
+			k.HistoryMutex.Unlock()
+			if err == nil {
+				if !bytes.Equal(existingKey.Bytes(Key), dbBKey.Bytes(Key)) {
+					return errors.New("cannot overwrite immutable value when history is enabled")
+				}
+				k.Cache[Key] = dbBKey // Update cache with the existing value
+				return nil
+			} else if err.Error() != "not found" {
+				return err
+			}
 		}
 		// If key doesn't exist, proceed with the write
 	}
@@ -696,14 +712,17 @@ func (k *KFile) GetKeyList() (keyValues map[[32]byte]*DBBKey, KeyList [][32]byte
 		offset++
 	}
 
-	// Sort the keys into their offset bins.
-	// They won't be sorted inside the bins.
-	// The order will not be the same over multiple machines.
-	// Note: Keys must be sorted in ascending order by bin for HistoryFile.AddKeys to work correctly
+	// Sort the keys by their offset bins, and by key within each bin.
+	// Bin order is required by HistoryFile.AddKeys; key order within bins
+	// keeps KeySets sorted so lookups can binary search, and makes the
+	// order deterministic across machines.
 	sort.Slice(KeyList, func(i, j int) bool {
 		a := k.OffsetIndex(KeyList[i][:]) // Bin for a
 		b := k.OffsetIndex(KeyList[j][:]) // Bin for b
-		return a < b                      // Sort in ascending order
+		if a != b {
+			return a < b // Sort by bin in ascending order
+		}
+		return bytes.Compare(KeyList[i][:], KeyList[j][:]) < 0
 	})
 
 	return keyValues, KeyList, nil


### PR DESCRIPTION
Fixes #9 — the dominant CPU cost in the profiles (82% under `HistoryFile.Get`).

## What changed
- **`GetKeyList` sorts keys within each bin** (bin order was already required by `AddKeys`; in-bin key order is new). Side benefit: the on-disk order is now deterministic across machines — a prerequisite for the block-sync story.
- **`UpdateKeySet` merge-sorts** incoming records with the bin's existing sorted records, deduplicating equal keys — which also reclaims the benign duplicates left by a crash between a history push and the kfile reset (from #10's durability ordering).
- **`HistoryFile.Get` binary searches**: 48-byte `ReadAt` probes until the range narrows to 64 records, then one 3KB read finishes in memory. No more whole-bin reads (`memclr` was 12% of CPU on its own).
- **Immutability now holds through history**: `KFile.Put`'s existence check only looked at the current kfile, so a key already pushed to history could be silently overwritten. With cheap history lookups, the check now extends to history. New regression test covers it.

## Numbers
`BenchmarkHistoryGet` (new), 1M keys / 1024 bins, same machine:

| | ns/op |
|---|---|
| before (linear scan) | 18,114 |
| binary search | 4,696 |
| + in-memory tail read | **3,233 (5.6×)** |

The bigger win is the complexity class: lookups are now **O(log n)** per bin instead of O(n), so `Get`/`Put` cost no longer decays as the database grows (the measured 297K→266K puts/s decay in `TestBuildBig` was this path).

## Notes
- Existing history files with unsorted bins are incompatible with binary search — like #10's header change, this assumes fresh databases (pre-release format).
- Deliberately **not** included: right-sizing the fixed 10MB-per-KFile Bloom filters (also mentioned in #9) — that's an API/sizing decision worth its own discussion; filing separately.

## Testing
Full unit suite passes (428s, including `TestHistory`). New tests: `TestHistoryKeySetsSorted`, `TestImmutabilityThroughHistory`, plus the `BenchmarkHistoryGet` benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1MpZq22uwNyJ8w2HWuRyJ