### PR TITLE
Re-enable Compress: Dyna layer reclaims space again

### DIFF
--- a/database/compress_test.go
+++ b/database/compress_test.go
@@ -1,0 +1,103 @@
+package blockchainDB
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCompress
+// Overwrite keys many times, compress, and verify the values file
+// shrinks while every key still returns its latest value.
+// Regression test for issue #7 (Compress was a no-op).
+func TestCompress(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
+
+	kv, err := NewKV(false, dir, 16, 100_000, 5)
+	require.NoError(t, err, "create kv")
+
+	// Write 100 keys, then overwrite each 9 more times: ~90% of the
+	// values file is trash
+	kr := NewFastRandom([]byte{11})
+	vr := NewFastRandom([]byte{11, 11})
+	keys := make([][32]byte, 100)
+	latest := make([][]byte, 100)
+	for i := range keys {
+		keys[i] = kr.NextHash()
+	}
+	for round := 0; round < 10; round++ {
+		for i := range keys {
+			latest[i] = vr.RandBuff(50, 200)
+			require.NoError(t, kv.Put(keys[i], latest[i]))
+		}
+	}
+	require.NoError(t, kv.vFile.Flush())
+
+	before, err := os.Stat(filepath.Join(dir, valueFilename))
+	require.NoError(t, err)
+
+	require.NoError(t, kv.Compress(), "compress failed")
+
+	after, err := os.Stat(filepath.Join(dir, valueFilename))
+	require.NoError(t, err)
+	assert.Lessf(t, after.Size(), before.Size()/5,
+		"values file did not shrink (before %d, after %d)", before.Size(), after.Size())
+
+	// Every key must return its latest value
+	for i := range keys {
+		v, err := kv.Get(keys[i])
+		require.NoErrorf(t, err, "get failed for key %d after compress", i)
+		assert.Equalf(t, latest[i], v, "wrong value for key %d after compress", i)
+	}
+
+	// And the DB must still work across close/reopen after a compress
+	require.NoError(t, kv.Close())
+	kv2, err := OpenKV(dir)
+	require.NoError(t, err, "reopen after compress")
+	require.NoError(t, kv2.Open())
+	for i := range keys {
+		v, err := kv2.Get(keys[i])
+		require.NoErrorf(t, err, "get failed for key %d after reopen", i)
+		assert.Equalf(t, latest[i], v, "wrong value for key %d after reopen", i)
+	}
+
+	// New writes after compress must work
+	newVal := []byte("post-compress value")
+	require.NoError(t, kv2.Put(keys[0], newVal))
+	v, err := kv2.Get(keys[0])
+	require.NoError(t, err)
+	assert.Equal(t, newVal, v)
+	require.NoError(t, kv2.Close())
+}
+
+// TestCompressPermIsNoop
+// A history-enabled KV holds immutable values; Compress must be a no-op
+// and must not disturb the data.
+func TestCompressPermIsNoop(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
+
+	kv, err := NewKV(true, dir, 16, 1000, 5)
+	require.NoError(t, err, "create kv")
+	kr := NewFastRandom([]byte{12})
+	vr := NewFastRandom([]byte{12, 12})
+	keys := make([][32]byte, 50)
+	values := make([][]byte, 50)
+	for i := range keys {
+		keys[i] = kr.NextHash()
+		values[i] = vr.RandBuff(10, 50)
+		require.NoError(t, kv.Put(keys[i], values[i]))
+	}
+	require.NoError(t, kv.Compress())
+	for i := range keys {
+		v, err := kv.Get(keys[i])
+		require.NoError(t, err)
+		assert.Equal(t, values[i], v)
+	}
+}

--- a/database/kv.go
+++ b/database/kv.go
@@ -110,18 +110,24 @@ func (k *KV) Open() (err error) {
 }
 
 // Compress
-// Re-write the values file to remove trash values
+// Re-write the values file to remove trash values (values that have been
+// overwritten and are no longer referenced by any key).
+//
+// Only meaningful for a mutable (history-disabled) KV: with history
+// enabled values are immutable, so the values file holds no trash.
+//
+// TODO(#5): the swap of the values file and the kfile rewrite are two
+// separate steps; a crash between them leaves the keys and values
+// inconsistent.  Making compaction crash-atomic needs the recovery
+// design tracked in issue #5.
 func (k *KV) Compress() (err error) {
-	k.Open()
-	k.Close()
-	k.Open()
-
-	if true {
-		return nil
+	if k.UseHistory {
+		return nil // Immutable values are never trash; nothing to reclaim
 	}
-
-	tvFile, err := NewBFile(filepath.Join(k.Directory, valueTmpFilename))
-	if err != nil {
+	if err = k.Open(); err != nil {
+		return err
+	}
+	if err = k.vFile.Flush(); err != nil { // All values must be on disk to copy them
 		return err
 	}
 
@@ -129,33 +135,61 @@ func (k *KV) Compress() (err error) {
 	if err != nil {
 		return err
 	}
+	if len(ks) == 0 {
+		return nil // Nothing to compress
+	}
 
-	var buffer [10000]byte
+	tvFile, err := NewBFile(filepath.Join(k.Directory, valueTmpFilename))
+	if err != nil {
+		return err
+	}
+
+	// Copy the live values into the tmp file, assigning new offsets
+	var buffer []byte
+	var newOffset uint64
 	for _, key := range ks {
 		dbbKey := kvs[key]
+		if uint64(cap(buffer)) < dbbKey.Length {
+			buffer = make([]byte, dbbKey.Length)
+		}
+		buffer = buffer[:dbbKey.Length]
 		// Read the current key value
-		if err := k.vFile.ReadAt(dbbKey.Offset, buffer[:dbbKey.Length]); err != nil {
+		if err := k.vFile.ReadAt(dbbKey.Offset, buffer); err != nil {
 			return err
 		}
-		// Put the new offset in the tvFile into the dbbKey (length does not change)
-		dbbKey.Offset, err = tvFile.Offset()
-		if err != nil {
+		// Write the value into the tvFile and point the key at it
+		if _, err = tvFile.Write(buffer); err != nil {
 			return err
 		}
-		// Update the key in the kFile
-		if err = k.kFile.Put(key, dbbKey); err != nil {
+		dbbKey.Offset = newOffset
+		newOffset += dbbKey.Length
+	}
+	if err = tvFile.Close(); err != nil { // Flush + sync the compacted values
+		return err
+	}
+
+	// Swap the compacted values file into place
+	if k.vFile.File != nil {
+		if err = k.vFile.File.Close(); err != nil {
 			return err
 		}
-		// Write the value into the tvFile
-		if _, err = tvFile.Write(buffer[:dbbKey.Length]); err != nil {
+		k.vFile.File = nil
+	}
+	if err = os.Rename(tvFile.Filename, k.vFile.Filename); err != nil {
+		return err
+	}
+	k.vFile.EOB = 0
+	k.vFile.EOD = newOffset
+
+	// Update the keys with their new offsets
+	for _, key := range ks {
+		if err = k.kFile.Put(key, kvs[key]); err != nil {
 			return err
 		}
 	}
+	if err = k.kFile.Close(); err != nil { // Persist the updated keys
+		return err
+	}
 
-	k.vFile.Close()
-	tvFile.Close()
-	k.kFile.Close()
-	os.Remove(k.vFile.Filename)
-	os.Rename(tvFile.Filename, k.vFile.Filename)
-	return nil
+	return k.Open()
 }

--- a/database/kv_2.go
+++ b/database/kv_2.go
@@ -182,8 +182,9 @@ func (k *KV2) Put(key [32]byte, value []byte) (writes int, err error) {
 // bogus DynaKV key will exist in PermKV.
 //
 // TODO: Cleanse PermKV of keys in DynaKV
-func (k *KV2) Compress() {
-	k.DynaKV.Compress()
+func (k *KV2) Compress() error {
+	err := k.DynaKV.Compress()
 	k.DWrites = 0 // Clear write counts
 	k.PWrites = 0
+	return err
 }

--- a/database/kv_shard.go
+++ b/database/kv_shard.go
@@ -64,7 +64,7 @@ func (k *KVShard) PutDyna(key [32]byte, value []byte) (err error) {
 	if writes, err := k.Shards[index].PutDyna(key, value); err != nil {
 		return err
 	} else if writes > 5000 {
-		k.Shards[index].Compress()
+		return k.Shards[index].Compress()
 	}
 	return nil
 }
@@ -77,7 +77,7 @@ func (k *KVShard) PutPerm(key [32]byte, value []byte) (err error) {
 	if writes, err := k.Shards[index].PutPerm(key, value); err != nil {
 		return err
 	} else if writes > 5000 {
-		k.Shards[index].Compress()
+		return k.Shards[index].Compress()
 	}
 	return nil
 }
@@ -90,7 +90,7 @@ func (k *KVShard) Put(key [32]byte, value []byte) (err error) {
 	if writes, err := k.Shards[index].Put(key, value); err != nil {
 		return err
 	} else if writes > 5000 {
-		k.Shards[index].Compress()
+		return k.Shards[index].Compress()
 	}
 	return nil
 }
@@ -132,7 +132,7 @@ func (k *KVShard) Get(key [32]byte) (value []byte, err error) {
 // Compress all the shards
 func (k *KVShard) Compress() (err error) {
 	for _, kvs := range k.Shards {
-		if err = kvs.Close(); err != nil {
+		if err = kvs.Compress(); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Fixes #7.

- `KV.Compress` actually compacts now: live values are copied to `values_tmp.dat` (synced), swapped into place, and the keys rewritten with new offsets. The dead code's fixed 10KB value buffer is replaced with a growable one (values larger than 10KB would have overflowed it).
- History-enabled KVs return immediately — immutable values are never trash, so there is nothing to reclaim in the Perm layer.
- `KV2.Compress` returns its error; `KVShard.Compress` compresses shards instead of just closing them; the `writes > 5000` triggers in the shard Put paths now do real work and propagate errors.

**Known limitation** (documented in the code, tracked in #5): the values-file swap and the kfile rewrite are two separate steps, so a crash between them leaves keys and values inconsistent. Crash-atomic compaction needs the recovery design from #5's remainder.

Tests: `TestCompress` verifies ~90% trash is reclaimed with all data intact, across the compress and across a close/reopen; `TestCompressPermIsNoop` covers the immutable layer. Affected suite (KV/KV2/KVShard/views/reopen) passes.

Independent of PR #11 (no shared files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1MpZq22uwNyJ8w2HWuRyJ