### PR TITLE
Concurrency safety: per-shard locking for KV2, KVShard, KVView

### DIFF
--- a/database/concurrency_test.go
+++ b/database/concurrency_test.go
@@ -1,0 +1,123 @@
+package blockchainDB
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConcurrentShardAccess
+// Hammers a KVShard from many goroutines (run under -race in CI to
+// catch data races).  Each goroutine owns a disjoint key space; all
+// values are verified at the end.  Regression test for issue #8.
+func TestConcurrentShardAccess(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
+
+	kvs, err := NewKVShard(dir, 64, 10_000, 5)
+	require.NoError(t, err, "create kvshard")
+
+	const workers = 8
+	const opsPerWorker = 500
+
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	allKeys := make([][][32]byte, workers)
+	allVals := make([][][]byte, workers)
+
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			kr := NewFastRandom([]byte{byte(w), 1})
+			vr := NewFastRandom([]byte{byte(w), 2})
+			keys := make([][32]byte, opsPerWorker)
+			vals := make([][]byte, opsPerWorker)
+			for i := 0; i < opsPerWorker; i++ {
+				keys[i] = kr.NextHash()
+				vals[i] = vr.RandBuff(10, 100)
+				var err error
+				if i%2 == 0 {
+					err = kvs.PutPerm(keys[i], vals[i])
+				} else {
+					err = kvs.PutDyna(keys[i], vals[i])
+				}
+				if err != nil {
+					errs <- fmt.Errorf("worker %d put %d: %v", w, i, err)
+					return
+				}
+				// Interleave reads of this worker's earlier writes
+				if i > 0 {
+					j := int(kr.UintN(uint(i)))
+					v, err := kvs.Get(keys[j])
+					if err != nil {
+						errs <- fmt.Errorf("worker %d get %d: %v", w, j, err)
+						return
+					}
+					if string(v) != string(vals[j]) {
+						errs <- fmt.Errorf("worker %d got wrong value for key %d", w, j)
+						return
+					}
+				}
+			}
+			allKeys[w] = keys
+			allVals[w] = vals
+		}(w)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+
+	// Verify every key from every worker
+	for w := 0; w < workers; w++ {
+		for i, key := range allKeys[w] {
+			v, err := kvs.Get(key)
+			require.NoErrorf(t, err, "worker %d key %d missing after concurrent writes", w, i)
+			assert.Equalf(t, allVals[w][i], v, "worker %d key %d wrong value", w, i)
+		}
+	}
+	require.NoError(t, kvs.Close())
+}
+
+// TestConcurrentViewAccess
+// Concurrent Put/Get through the KVView wrapper while views are being
+// created and expiring (run under -race).
+func TestConcurrentViewAccess(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
+
+	sdbv, err := NewShardDBViews(dir, 200*time.Millisecond, 1, 256, 1, 64, 10_000, 5)
+	require.NoError(t, err, "create views")
+
+	const workers = 4
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			kr := NewFastRandom([]byte{byte(w), 3})
+			vr := NewFastRandom([]byte{byte(w), 4})
+			for i := 0; i < 200; i++ {
+				key := kr.NextHash()
+				_ = sdbv.Put(key, vr.RandBuff(10, 50))
+				_, _ = sdbv.Get(key)
+				if i%50 == 0 {
+					view := sdbv.NewView()
+					_, _ = view.Get(key)
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+	require.NoError(t, sdbv.Close())
+}

--- a/database/kv_2.go
+++ b/database/kv_2.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"sync"
 )
 
 const PermDirName = "perm"
@@ -37,11 +38,12 @@ const DynaDirName = "dyna"
 // could then be used to rapidly sync partially synced nodes
 
 type KV2 struct {
-	Directory string // Directory where the PermKV and DynaKV directories are
-	PermKV    *KV    // The Perm KV
-	DynaKV    *KV    // the Dyna KV
-	DWrites   int    // Number of writes to the DynaKV since the last compress
-	PWrites   int    // Number of writes to the PermKV since the last compress
+	Mutex     sync.Mutex // Serializes access; KV2 methods are safe for concurrent use
+	Directory string     // Directory where the PermKV and DynaKV directories are
+	PermKV    *KV        // The Perm KV
+	DynaKV    *KV        // the Dyna KV
+	DWrites   int        // Number of writes to the DynaKV since the last compress
+	PWrites   int        // Number of writes to the PermKV since the last compress
 }
 
 // NewKV2
@@ -90,6 +92,8 @@ func OpenKV2(directory string) (kv2 *KV2, err error) {
 }
 
 func (k *KV2) Open() error {
+	k.Mutex.Lock()
+	defer k.Mutex.Unlock()
 	if err := k.PermKV.Open(); err != nil {
 		return err
 	}
@@ -97,6 +101,8 @@ func (k *KV2) Open() error {
 }
 
 func (k *KV2) Close() error {
+	k.Mutex.Lock()
+	defer k.Mutex.Unlock()
 	if err := k.PermKV.Close(); err != nil {
 		return err
 	}
@@ -106,6 +112,8 @@ func (k *KV2) Close() error {
 // GetDyna
 // Get a k/v from the DynaKV db.  Doesn't check the PermKV.
 func (k *KV2) GetDyna(key [32]byte) (value []byte, err error) {
+	k.Mutex.Lock()
+	defer k.Mutex.Unlock()
 
 	if value, err = k.DynaKV.Get(key); err != nil { // Not in DynaKV, then return whatever
 		return nil, err
@@ -116,6 +124,8 @@ func (k *KV2) GetDyna(key [32]byte) (value []byte, err error) {
 // GetPerm
 // Get a k/v from the PermKV db.  Doesn't check the DynaKV.
 func (k *KV2) GetPerm(key [32]byte) (value []byte, err error) {
+	k.Mutex.Lock()
+	defer k.Mutex.Unlock()
 
 	if value, err = k.PermKV.Get(key); err != nil { // Not in PermKV, then return whatever
 		return nil, err
@@ -126,6 +136,8 @@ func (k *KV2) GetPerm(key [32]byte) (value []byte, err error) {
 // Get
 // Get a value from the KV2.  Checks the DynaKV first, then the PermKV
 func (k *KV2) Get(key [32]byte) (value []byte, err error) {
+	k.Mutex.Lock()
+	defer k.Mutex.Unlock()
 
 	// Check and see if this is a key that has been changed
 	if value, err = k.DynaKV.Get(key); err == nil { // Not in DynaKV, then return whatever
@@ -138,6 +150,8 @@ func (k *KV2) Get(key [32]byte) (value []byte, err error) {
 // PutDyna
 // Use when the k/v is known to be a dynamic k/v
 func (k *KV2) PutDyna(key [32]byte, value []byte) (writes int, err error) {
+	k.Mutex.Lock()
+	defer k.Mutex.Unlock()
 	k.DWrites++
 	err = k.DynaKV.Put(key, value)
 	return k.DWrites, err
@@ -146,6 +160,8 @@ func (k *KV2) PutDyna(key [32]byte, value []byte) (writes int, err error) {
 // PutPerm
 // Use when the k/v is known to be a dynamic k/v
 func (k *KV2) PutPerm(key [32]byte, value []byte) (writes int, err error) {
+	k.Mutex.Lock()
+	defer k.Mutex.Unlock()
 	k.PWrites++
 	err = k.PermKV.Put(key, value)
 	return k.DWrites, err
@@ -154,6 +170,8 @@ func (k *KV2) PutPerm(key [32]byte, value []byte) (writes int, err error) {
 // Put
 // Returns the number of writes since the last compress, and an err if the put failed
 func (k *KV2) Put(key [32]byte, value []byte) (writes int, err error) {
+	k.Mutex.Lock()
+	defer k.Mutex.Unlock()
 
 	if value2, err2 := k.DynaKV.Get(key); err2 == nil { // Check.  Is this a DynaKV key?
 		if bytes.Equal(value, value2) { // If the key is in DynaKV, it stays there.
@@ -183,6 +201,8 @@ func (k *KV2) Put(key [32]byte, value []byte) (writes int, err error) {
 //
 // TODO: Cleanse PermKV of keys in DynaKV
 func (k *KV2) Compress() error {
+	k.Mutex.Lock()
+	defer k.Mutex.Unlock()
 	err := k.DynaKV.Compress()
 	k.DWrites = 0 // Clear write counts
 	k.PWrites = 0

--- a/database/kv_shard.go
+++ b/database/kv_shard.go
@@ -8,6 +8,16 @@ import (
 
 const NumShards = 512
 
+// KVShard
+// A sharded KV database.  Keys route to one of NumShards KV2 instances
+// by ShardIndex.
+//
+// Concurrency: KVShard methods are safe for concurrent use.  The Shards
+// array is fixed after creation, and each KV2 serializes access with its
+// own mutex - so operations on different shards run in parallel, while
+// operations on the same shard are serialized.  (KV, KFile, and BFile
+// are NOT safe for concurrent use on their own; they rely on the KV2
+// lock when accessed through this layer.)
 type KVShard struct {
 	Directory string
 	Shards    [NumShards]*KV2

--- a/database/view_kv.go
+++ b/database/view_kv.go
@@ -2,6 +2,7 @@ package blockchainDB
 
 import (
 	"fmt"
+	"sync"
 	"time"
 )
 
@@ -37,6 +38,7 @@ func (v *View) Get(key [32]byte) (value []byte, err error) {
 // More recent views lookup values in their cache, and then in the views that come
 // before.  Later views are ignored.
 type KVView struct {
+	Mutex       sync.Mutex    // Serializes access; KVView methods are safe for concurrent use
 	DB          *KVShard      // The underlying DB
 	ViewID      int           // The next ViewID
 	ActiveViews []*View       // List of all active Views, newest first
@@ -97,6 +99,8 @@ func (s *KVView) flushViewCache() {
 }
 
 func (s *KVView) Close() error {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
 	s.flushViewCache()
 	s.ActiveViews = nil
 	s.Map = nil
@@ -111,20 +115,30 @@ func (s *KVView) Close() error {
 // Returns true if a valid active view exists.  If old views
 // exist, but none are active, the active views are tossed.
 func (s *KVView) IsViewActive() bool {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+	return s.isViewActive()
+}
+
+// isViewActive
+// Internal version of IsViewActive; the caller must hold the Mutex.
+func (s *KVView) isViewActive() bool {
 	// The first entry in the ActiveViews is the View Cache
 	// ActiveViews with a length less than two means no active views
 	if len(s.ActiveViews) < 2 {
 		return false
 	}
 
-	s.GetViewIndex(s.ActiveViews[1]) // This will clear ActiveViews if none are valid
+	s.getViewIndex(s.ActiveViews[1]) // This will clear ActiveViews if none are valid
 	return len(s.ActiveViews) > 0    // If any remain, then a View is Active
 }
 
 func (s *KVView) Put(key [32]byte, value []byte) error {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
 
 	// If not view is active, then write to the DB
-	if !s.IsViewActive() {
+	if !s.isViewActive() {
 		return s.DB.Put(key, value)
 	}
 
@@ -135,9 +149,11 @@ func (s *KVView) Put(key [32]byte, value []byte) error {
 }
 
 func (s *KVView) Get(key [32]byte) (value []byte, err error) {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
 
 	// If no view is active, just get the DB value
-	if !s.IsViewActive() {
+	if !s.isViewActive() {
 		return s.DB.Get(key)
 	}
 
@@ -151,9 +167,12 @@ func (s *KVView) Get(key [32]byte) (value []byte, err error) {
 }
 
 func (s *KVView) NewView() *View {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+
 	// If no view is active, we have to cache DB updates so
 	// create a "DB Update View" at s.ActiveViews[0]
-	if !s.IsViewActive() {
+	if !s.isViewActive() {
 		view := new(View)
 		view.ID = 0
 		view.KeyValues = make(map[[32]byte][]byte)
@@ -178,6 +197,14 @@ func (s *KVView) NewView() *View {
 // prunes closed views from the old end of the stack, and flushes the
 // buffered writes to the DB when the last view goes away.
 func (s *KVView) GetViewIndex(view *View) int {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+	return s.getViewIndex(view)
+}
+
+// getViewIndex
+// Internal version of GetViewIndex; the caller must hold the Mutex.
+func (s *KVView) getViewIndex(view *View) int {
 	if len(s.ActiveViews) == 0 {
 		return 0
 	}
@@ -223,10 +250,13 @@ func (s *KVView) GetViewIndex(view *View) int {
 // active views that were created before this view are searched in turn.  If no
 // key value pair is found in the view or older views, then return what the DB has
 func (s *KVView) ViewGet(view *View, key [32]byte) (value []byte, err error) {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+
 	// Check if the view provided is active.  If not, return an error that
 	// the view has expired.  Only refresh LastAccess for a still-valid
 	// view; refreshing first would resurrect views that already expired.
-	viewIdx := s.GetViewIndex(view)
+	viewIdx := s.getViewIndex(view)
 	if viewIdx == 0 {
 		return nil, fmt.Errorf("view invalid")
 	}


### PR DESCRIPTION
Fixes #8. Replaces #14, which was auto-closed when its base branch (`fix/compress`, merged as #13) was deleted. Same commits; see #14 for the original description.

- **KV2**: one mutex covering all public methods — operations on different shards run in parallel, same-shard operations serialize.
- **KVShard**: no lock needed (fixed Shards array; each KV2 locks itself); contract documented on the type.
- **KVView**: mutex with unlocked internal helpers; lock order KVView → KV2.
- `TestConcurrentShardAccess` and `TestConcurrentViewAccess` pass under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1MpZq22uwNyJ8w2HWuRyJ