### PR TITLE
Layered, self-sizing, persisted Bloom filters (2.9x single-thread puts)

### DIFF
--- a/database/bloom.go
+++ b/database/bloom.go
@@ -6,8 +6,19 @@ type Bloom struct {
 	SizeOfMap float64
 	NumBytes  uint64
 	Map       []byte
-	K         int // Number of hash functions
+	K         int    // Number of hash functions
+	Capacity  uint64 // Number of keys the filter is sized for
+	Count     uint64 // Number of keys added (duplicates counted; corrected on rebuild)
 }
+
+// BloomBitsPerKey
+// Bits per key the filter is sized with.  At K=3 hash functions,
+// 12 bits/key gives roughly a 1% false positive rate at capacity:
+// p = (1 - e^(-3/12))^3 ~ 0.011
+const BloomBitsPerKey = 12
+
+// minBloomBytes keeps tiny filters from thrashing on rebuilds (4KB ~ 2,700 keys)
+const minBloomBytes = 4096
 
 // NewBloom
 // Create a Bloom Filter of the given size in MB
@@ -29,6 +40,36 @@ func NewBloomFilter(size float64, k int) *Bloom {
 	bloom.NumBytes = uint64(1024 * 1024 * bloom.SizeOfMap)
 	bloom.Map = make([]byte, bloom.NumBytes)
 	bloom.K = k
+	bloom.Capacity = bloom.NumBytes * 8 / BloomBitsPerKey
+	return bloom
+}
+
+// NewBloomSizedForKeys
+// Create a Bloom Filter sized for the given number of keys with k hash
+// functions.  Sizing is BloomBitsPerKey bits per key (~1% false
+// positives at capacity with k=3); past capacity the false positive
+// rate degrades gracefully.
+func NewBloomSizedForKeys(nKeys uint64, k int) *Bloom {
+	return newBloomSized(nKeys, BloomBitsPerKey, k)
+}
+
+// newBloomSized
+// Sized constructor with explicit bits per key (BloomSet uses more
+// bits per key on later layers to bound the aggregate false positive
+// rate).
+func newBloomSized(nKeys, bitsPerKey uint64, k int) *Bloom {
+	if k < 1 {
+		panic("bloom filters must have at least one hash function")
+	}
+	bloom := new(Bloom)
+	bloom.NumBytes = nKeys * bitsPerKey / 8
+	if bloom.NumBytes < minBloomBytes {
+		bloom.NumBytes = minBloomBytes
+	}
+	bloom.SizeOfMap = float64(bloom.NumBytes) / (1024 * 1024)
+	bloom.Map = make([]byte, bloom.NumBytes)
+	bloom.K = k
+	bloom.Capacity = bloom.NumBytes * 8 / bitsPerKey
 	return bloom
 }
 
@@ -73,6 +114,7 @@ func (b *Bloom) Test(key [32]byte) bool {
 // Set a bit in the Bloom Filter, because a Key is being added to
 // the DB.
 func (b *Bloom) Set(key [32]byte) {
+	b.Count++
 	// Set bits for all hash functions
 	for i := 0; i < b.K; i++ {
 		index, bitMask := b.ByteMask(key, i)

--- a/database/bloomset.go
+++ b/database/bloomset.go
@@ -1,0 +1,167 @@
+package blockchainDB
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+const (
+	bloomFilename    = "bloom.dat"     // Persisted BloomSet
+	bloomTmpFilename = "bloom_tmp.dat" // Tmp file for atomic replace
+	bloomMagic       = 0x424C4D31      // "BLM1"
+)
+
+// BloomSet
+// A scalable Bloom filter: a stack of layers where only the newest
+// layer accepts keys.  When the active layer reaches its capacity it is
+// frozen and a new layer roughly double the total size is started, so
+// the layer count stays logarithmic in the key count and NO existing
+// key is ever re-read or re-hashed to grow the filter.
+//
+// Test checks every layer; a key is possibly present if any layer says
+// so.  Later layers get more bits per key so the aggregate false
+// positive rate stays near the single-layer design point (~1-3%)
+// instead of adding ~1% per layer.
+//
+// Frozen layers are immutable, which makes the set cheap to persist:
+// see Save/LoadBloomSet.
+type BloomSet struct {
+	Layers []*Bloom
+}
+
+// NewBloomSet
+// Create a BloomSet whose first layer is sized for initialCapacity
+// keys with k hash functions
+func NewBloomSet(initialCapacity uint64, k int) *BloomSet {
+	return &BloomSet{Layers: []*Bloom{NewBloomSizedForKeys(initialCapacity, k)}}
+}
+
+// Count
+// Total number of keys added across all layers (duplicates counted)
+func (b *BloomSet) Count() (n uint64) {
+	for _, l := range b.Layers {
+		n += l.Count
+	}
+	return n
+}
+
+// Set
+// Add a key.  Grows a new layer when the active one is full.
+func (b *BloomSet) Set(key [32]byte) {
+	active := b.Layers[len(b.Layers)-1]
+	if active.Count >= active.Capacity {
+		// Freeze the active layer; the new layer is sized for double
+		// everything so far, with more bits per key to keep the
+		// aggregate false positive rate bounded
+		bitsPerKey := BloomBitsPerKey + 4*uint64(len(b.Layers))
+		active = newBloomSized(2*b.Count(), bitsPerKey, active.K)
+		b.Layers = append(b.Layers, active)
+	}
+	active.Set(key)
+}
+
+// Test
+// Returns false if the key is definitely not present; true if it might be
+func (b *BloomSet) Test(key [32]byte) bool {
+	for _, l := range b.Layers {
+		if l.Test(key) {
+			return true
+		}
+	}
+	return false
+}
+
+// Save
+// Persist the BloomSet to directory/bloom.dat via a tmp file and an
+// atomic rename.  Layers are written verbatim; loading is a read, not
+// a rebuild.
+func (b *BloomSet) Save(directory string) (err error) {
+	tmpPath := filepath.Join(directory, bloomTmpFilename)
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if f != nil {
+			f.Close()
+			os.Remove(tmpPath)
+		}
+	}()
+
+	var header [8]byte
+	binary.BigEndian.PutUint32(header[:], bloomMagic)
+	binary.BigEndian.PutUint32(header[4:], uint32(len(b.Layers)))
+	if _, err = f.Write(header[:]); err != nil {
+		return err
+	}
+	var lh [28]byte
+	for _, l := range b.Layers {
+		binary.BigEndian.PutUint32(lh[:], uint32(l.K))
+		binary.BigEndian.PutUint64(lh[4:], l.NumBytes)
+		binary.BigEndian.PutUint64(lh[12:], l.Capacity)
+		binary.BigEndian.PutUint64(lh[20:], l.Count)
+		if _, err = f.Write(lh[:]); err != nil {
+			return err
+		}
+		if _, err = f.Write(l.Map); err != nil {
+			return err
+		}
+	}
+	if err = f.Sync(); err != nil {
+		return err
+	}
+	if err = f.Close(); err != nil {
+		f = nil
+		return err
+	}
+	f = nil
+	return os.Rename(tmpPath, filepath.Join(directory, bloomFilename))
+}
+
+// LoadBloomSet
+// Load a persisted BloomSet from directory/bloom.dat
+func LoadBloomSet(directory string) (b *BloomSet, err error) {
+	f, err := os.Open(filepath.Join(directory, bloomFilename))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var header [8]byte
+	if _, err = io.ReadFull(f, header[:]); err != nil {
+		return nil, err
+	}
+	if binary.BigEndian.Uint32(header[:]) != bloomMagic {
+		return nil, fmt.Errorf("bloom.dat has the wrong magic number")
+	}
+	layerCnt := binary.BigEndian.Uint32(header[4:])
+	if layerCnt == 0 || layerCnt > 64 {
+		return nil, fmt.Errorf("bloom.dat has an invalid layer count %d", layerCnt)
+	}
+
+	b = new(BloomSet)
+	var lh [28]byte
+	for i := uint32(0); i < layerCnt; i++ {
+		if _, err = io.ReadFull(f, lh[:]); err != nil {
+			return nil, err
+		}
+		l := new(Bloom)
+		l.K = int(binary.BigEndian.Uint32(lh[:]))
+		l.NumBytes = binary.BigEndian.Uint64(lh[4:])
+		l.Capacity = binary.BigEndian.Uint64(lh[12:])
+		l.Count = binary.BigEndian.Uint64(lh[20:])
+		if l.K < 1 || l.NumBytes < minBloomBytes || l.NumBytes > 1<<32 {
+			return nil, fmt.Errorf("bloom.dat layer %d is invalid", i)
+		}
+		l.SizeOfMap = float64(l.NumBytes) / (1024 * 1024)
+		l.Map = make([]byte, l.NumBytes)
+		if _, err = io.ReadFull(f, l.Map); err != nil {
+			return nil, err
+		}
+		b.Layers = append(b.Layers, l)
+	}
+	return b, nil
+}

--- a/database/bloomset_test.go
+++ b/database/bloomset_test.go
@@ -1,0 +1,108 @@
+package blockchainDB
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBloomSetGrowth
+// Layers must grow as keys outrun capacity, no key may be lost across
+// growth, and the false positive rate must stay bounded.
+func TestBloomSetGrowth(t *testing.T) {
+	bs := NewBloomSet(1, 3) // Floor capacity (~2,700 keys); forces growth
+
+	fr := NewFastRandom([]byte{71})
+	const n = 100_000
+	keys := make([][32]byte, n)
+	for i := range keys {
+		keys[i] = fr.NextHash()
+		bs.Set(keys[i])
+	}
+	assert.Greater(t, len(bs.Layers), 1, "the set should have grown layers")
+	assert.Equal(t, uint64(n), bs.Count(), "count should track adds")
+
+	// No false negatives, ever
+	for i := range keys {
+		require.Truef(t, bs.Test(keys[i]), "key %d lost after growth", i)
+	}
+
+	// False positive rate stays bounded (~3% design point; assert < 6%)
+	fp := 0
+	const probes = 100_000
+	for i := 0; i < probes; i++ {
+		if bs.Test(fr.NextHash()) {
+			fp++
+		}
+	}
+	assert.Lessf(t, float64(fp)/probes, 0.06, "false positive rate too high: %d/%d", fp, probes)
+}
+
+// TestBloomSetSaveLoad
+// A saved BloomSet must load back with identical behavior
+func TestBloomSetSaveLoad(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(dir)
+	require.NoError(t, os.MkdirAll(dir, os.ModePerm))
+	defer os.RemoveAll(dir)
+
+	bs := NewBloomSet(1, 3)
+	fr := NewFastRandom([]byte{72})
+	keys := make([][32]byte, 10_000)
+	for i := range keys {
+		keys[i] = fr.NextHash()
+		bs.Set(keys[i])
+	}
+	require.NoError(t, bs.Save(dir))
+
+	loaded, err := LoadBloomSet(dir)
+	require.NoError(t, err)
+	assert.Equal(t, len(bs.Layers), len(loaded.Layers), "layer count differs")
+	assert.Equal(t, bs.Count(), loaded.Count(), "count differs")
+	for i := range keys {
+		require.Truef(t, loaded.Test(keys[i]), "key %d missing after load", i)
+	}
+	// A loaded set keeps accepting keys and growing
+	extra := fr.NextHash()
+	loaded.Set(extra)
+	assert.True(t, loaded.Test(extra))
+}
+
+// TestBloomPersistedOpen
+// After history pushes, bloom.dat must exist, and a reopened KFile
+// must find keys via the loaded filter (covering both the persisted
+// layers and the kfile scan for keys added after the last push).
+func TestBloomPersistedOpen(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
+
+	kv, err := NewKV(true, dir, 16, 50, 5)
+	require.NoError(t, err)
+	kr := NewFastRandom([]byte{73})
+	vr := NewFastRandom([]byte{73, 73})
+	keys := make([][32]byte, 220) // 220 keys, KeyLimit 50 -> several pushes
+	values := make([][]byte, 220)
+	for i := range keys {
+		keys[i] = kr.NextHash()
+		values[i] = vr.RandBuff(10, 50)
+		require.NoError(t, kv.Put(keys[i], values[i]))
+	}
+	require.NoError(t, kv.Close())
+
+	_, err = os.Stat(filepath.Join(dir, bloomFilename))
+	require.NoError(t, err, "bloom.dat should exist after history pushes")
+
+	kv2, err := OpenKV(dir)
+	require.NoError(t, err)
+	require.NoError(t, kv2.Open())
+	for i := range keys {
+		v, err := kv2.Get(keys[i])
+		require.NoErrorf(t, err, "key %d missing after reopen with persisted bloom", i)
+		assert.Equal(t, values[i], v)
+	}
+	require.NoError(t, kv2.Close())
+}

--- a/database/kfile.go
+++ b/database/kfile.go
@@ -15,6 +15,12 @@ import (
 const (
 	kFileName    string = "kfile.dat"     // Name of Key File
 	kTmpFileName string = "kfile_tmp.dat" // Name of the tmp file
+
+	// DefaultBloomCapacity is the key capacity a fresh KFile's Bloom
+	// filter is sized for (~150KB at 12 bits/key).  The filter rebuilds
+	// at double capacity whenever the key count outgrows it, so this is
+	// a starting point, not a limit.
+	DefaultBloomCapacity uint64 = 100_000
 )
 
 // Block File
@@ -51,7 +57,7 @@ type KFile struct {
 	TotalCnt       uint64               // Total number of keys processed
 	OffsetCnt      uint64               // Number of key sets in the kFile
 	HistoryOffsets int                  // History offset cnt
-	BloomFilter    *Bloom               // Bloom filter for quick key existence checks
+	BloomFilter    *BloomSet            // Layered Bloom filter for quick key existence checks
 }
 
 // Open
@@ -61,10 +67,11 @@ func OpenKFile(directory string) (kFile *KFile, err error) {
 
 	kFile.Directory = directory
 
-	// Remove any tmp file left behind by a crash mid-rewrite; the real
-	// kfile is only ever replaced by an atomic rename, so a lingering tmp
-	// file is always incomplete.
+	// Remove any tmp files left behind by a crash mid-rewrite; the real
+	// files are only ever replaced by an atomic rename, so a lingering
+	// tmp file is always incomplete.
 	os.Remove(filepath.Join(directory, kTmpFileName))
+	os.Remove(filepath.Join(directory, bloomTmpFilename))
 
 	filename := filepath.Join(directory, kFileName)
 	if kFile.File, err = OpenBFile(filename); err != nil {
@@ -133,9 +140,11 @@ func NewKFile(
 	kFile.WriteHeader()
 	kFile.Cache = make(map[[32]byte]*DBBKey)
 
-	// Initialize the Bloom filter with a reasonable size
-	// Using 10MB as a size, which is a good balance between memory usage and false positive rate
-	kFile.BloomFilter = NewBloomFilter(10.0, 3) // 10MB Bloom filter with 3 hash functions
+	// The Bloom filter is layered: the first layer is sized here, and
+	// new layers grow automatically as keys outrun the capacity -- no
+	// key is ever re-read to grow the filter
+	capacity := max(DefaultBloomCapacity, 2*keyLimit)
+	kFile.BloomFilter = NewBloomSet(capacity, 3)
 
 	return kFile, err
 }
@@ -196,6 +205,17 @@ func (k *KFile) PushHistory() (err error) {
 		}
 
 		k.HistoryMutex.Unlock()
+
+		// Persist the Bloom filter now that history holds the keys.
+		// Ordering matters: if we crash before this write, the stale
+		// bloom.dat misses the pushed keys, but they are still in the
+		// kfile (not yet reset) and the open path scans the kfile -- so
+		// every crash window leaves the filter complete.
+		if k.BloomFilter != nil {
+			if err = k.BloomFilter.Save(k.Directory); err != nil {
+				return err
+			}
+		}
 	}
 
 	// The keys are durable in history; now reset the kfile
@@ -229,26 +249,59 @@ func (k *KFile) Open() error {
 	// database); once in memory it tracks every key added by Put, so
 	// repopulating on every Open would be wasted work.
 	if k.BloomFilter == nil {
-		// Using 10MB as a size, which is a good balance between memory usage and false positive rate
-		k.BloomFilter = NewBloomFilter(10.0, 3) // 10MB Bloom filter with 3 hash functions
-
-		// If history is enabled, populate the Bloom filter with keys from history
-		if k.History != nil {
-			if err := k.PopulateBloomFilterFromHistory(); err != nil {
-				return err
-			}
-		}
-
-		// Populate the Bloom filter with the keys still in the current
-		// kfile.  Without this, keys that have not yet been pushed to
-		// history are invisible after a reopen (Get fails the Bloom test
-		// before ever reading the disk).
-		if err := k.PopulateBloomFilterFromKFile(); err != nil {
+		if err := k.buildBloomFilter(); err != nil {
 			return err
 		}
 	}
 
 	return k.File.Open()
+}
+
+// expectedKeys
+// The number of key records currently stored on disk (kfile plus
+// history), derived from the file sizes -- no scanning required.
+func (k *KFile) expectedKeys() uint64 {
+	var n uint64
+	kfileBytes := k.File.EOD + k.File.EOB
+	if kfileBytes > uint64(k.HeaderSize) {
+		n += (kfileBytes - uint64(k.HeaderSize)) / DBKeyFullSize
+	}
+	if k.History != nil {
+		for _, ks := range k.History.KeySets {
+			n += (ks.End - ks.Start) / DBKeyFullSize
+		}
+	}
+	return n
+}
+
+// buildBloomFilter
+// Reconstruct the Bloom filter on reopen.  The persisted bloom.dat is
+// loaded when present (a read, not a rebuild); it covers everything in
+// history as of the last push, and the keys added since then are still
+// in the kfile, so a scan of the (small) kfile completes the filter.
+// Without bloom.dat the filter is built by scanning history and the
+// kfile once.
+func (k *KFile) buildBloomFilter() (err error) {
+	if bs, err := LoadBloomSet(k.Directory); err == nil {
+		k.BloomFilter = bs
+		return k.PopulateBloomFilterFromKFile()
+	}
+
+	capacity := max(2*k.expectedKeys(), DefaultBloomCapacity, 2*k.KeyLimit)
+	k.BloomFilter = NewBloomSet(capacity, 3)
+
+	// If history is enabled, populate the Bloom filter with keys from history
+	if k.History != nil {
+		if err := k.PopulateBloomFilterFromHistory(); err != nil {
+			return err
+		}
+	}
+
+	// Populate the Bloom filter with the keys still in the current
+	// kfile.  Without this, keys that have not yet been pushed to
+	// history are invisible after a reopen (Get fails the Bloom test
+	// before ever reading the disk).
+	return k.PopulateBloomFilterFromKFile()
 }
 
 // PopulateBloomFilterFromKFile
@@ -264,7 +317,7 @@ func (k *KFile) PopulateBloomFilterFromKFile() error {
 	}
 
 	start := uint64(k.HeaderSize)
-	end := k.File.EOD
+	end := k.File.EOD + k.File.EOB // Include keys still in the write buffer
 	if end <= start {
 		return nil
 	}

--- a/docs/design/multicore-ingest.md
+++ b/docs/design/multicore-ingest.md
@@ -74,14 +74,14 @@ Notes:
   goroutine generating and queuing writes is the ceiling, independent
   of worker count. That ceiling is far above current chain throughput
   needs; if it ever matters, batch the queue sends.
-- Cold-start caveat: a fresh `KVShard` allocates 1,024 × 10 MB Bloom
-  filters, and first-touch page faults dominate until they are warm —
-  hard evidence for right-sizing the filters (issue #12).
+- Cold-start caveat (resolved by #12): fixed 10 MB Bloom filters made
+  first-touch page faults dominate a cold `KVShard`. Filters are now
+  layered and sized from the key count (~300 KB initial per KFile),
+  and persisted at push time so opens load them instead of scanning
+  history.
 
 ## Future work
 
-- Right-size Bloom filters (#12): shrinks the cold-start fault storm
-  and ~10 GB reserved memory.
 - Crash-consistent flush: `Flush` is an application barrier, not a
   durability barrier — it does not fsync. Couple it with the recovery
   design (#5) so a block boundary can be made durable atomically.


### PR DESCRIPTION
Fixes #12 — and answers the two design questions raised there without adding any API surface:

**"Isn't sizing just math?"** Yes: 12 bits/key at k=3 ≈ 1% fpr, and the key count is derivable from the file sizes (KeySet offsets + kfile length), so filters size themselves. The wrinkle was growth — n is unbounded and Bloom filters can't resize incrementally.

**"Rebuilds need the keys, so they're expensive."** Right — so there are no rebuilds. Filters are **layered** (scalable Bloom): when the active layer fills, it's frozen and a new layer sized at 2× the running key count starts. Growth never re-reads a key; keys pass through memory exactly once, when written. Later layers use more bits/key (12 + 4/layer) so the aggregate fpr stays ~1–3% instead of accumulating ~1% per layer. Layer count is logarithmic; `Test` is a few extra memory probes.

**Persistence** falls out of immutability: frozen layers never change, so `bloom.dat` is written (tmp + fsync + atomic rename) during `PushHistory` — after history durably accepts the keys, before the kfile resets. Every crash window is covered: a stale `bloom.dat` can only be missing keys that are still in the kfile, and the open path scans the kfile regardless. **Opens now load the filter instead of scanning all of history.**

## Numbers
- Memory: ~300KB initial per KFile vs fixed 10MB → ~300MB vs ~10GB across 512 shards, growing only with real keys.
- **Single-threaded puts: 232K → 683K/s (2.9×)** in `TestMultiCoreScaling` — Set/Test stay cache-resident instead of scattering across 10MB maps. Parallel peak unchanged (~3.6M/s at 16 workers).
- Also fixed in passing: `PopulateBloomFilterFromKFile` now includes buffered (EOB) keys.

## Testing
`TestBloomSetGrowth` (multi-layer growth, zero false negatives across 100K keys, fpr < 6% asserted), `TestBloomSetSaveLoad`, `TestBloomPersistedOpen` (pushes → close → reopen via persisted filter). Affected suite (reopen/history/compress/concurrency/writer) passes under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1MpZq22uwNyJ8w2HWuRyJ