### PR TITLE
Crash recovery: fsyncs, atomic resets, replay semantics, kill-injection test

### DIFF
--- a/database/bfile.go
+++ b/database/bfile.go
@@ -226,3 +226,16 @@ func (b *BFile) ReadAt(offset uint64, data []byte) (err error) {
 	}
 	return err
 }
+
+// syncDir
+// Sync a directory so that renames and file creations within it are
+// durable.  An fsync on a file makes its content durable; the rename
+// that put it in place lives in the directory, which needs its own sync.
+func syncDir(directory string) error {
+	d, err := os.Open(directory)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
+}

--- a/database/bloomset.go
+++ b/database/bloomset.go
@@ -118,7 +118,10 @@ func (b *BloomSet) Save(directory string) (err error) {
 		return err
 	}
 	f = nil
-	return os.Rename(tmpPath, filepath.Join(directory, bloomFilename))
+	if err = os.Rename(tmpPath, filepath.Join(directory, bloomFilename)); err != nil {
+		return err
+	}
+	return syncDir(directory)
 }
 
 // LoadBloomSet

--- a/database/crash_test.go
+++ b/database/crash_test.go
@@ -1,0 +1,173 @@
+package blockchainDB
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Crash-injection test for issue #5.
+//
+// The durability contract under test:
+//
+//	KV.Close() is a durability point.  After a process is SIGKILLed at
+//	an arbitrary moment, OpenKV must succeed and every key written
+//	before the last completed Close must be readable with its correct
+//	value.  Writes after the last Close may or may not be present, but
+//	must never corrupt the database.
+//
+// TestCrashChildProcess is the workload: it opens the DB, writes
+// deterministic keys, and prints "CHECKPOINT n" after each completed
+// Close.  TestCrashRecovery runs it as a child process, kills it at a
+// random moment, reopens the database, and verifies the contract -
+// several rounds, so kills land in different code paths (buffered
+// writes, kfile rewrite, history push, bloom save).
+
+const crashChildEnv = "BDB_CRASH_CHILD_DIR"
+const crashChildStartEnv = "BDB_CRASH_CHILD_START"
+
+// crashKV generates the deterministic key/value sequence, skipping the
+// first `skip` pairs
+func crashKV(skip int) (kr, vr *FastRandom) {
+	kr = NewFastRandom([]byte{81})
+	vr = NewFastRandom([]byte{81, 81})
+	for i := 0; i < skip; i++ {
+		kr.NextHash()
+		vr.RandBuff(10, 50)
+	}
+	return kr, vr
+}
+
+// TestCrashChildProcess
+// Helper process for TestCrashRecovery; skipped unless launched by it
+func TestCrashChildProcess(t *testing.T) {
+	dir := os.Getenv(crashChildEnv)
+	if dir == "" {
+		t.Skip("helper process for TestCrashRecovery")
+	}
+	start, _ := strconv.Atoi(os.Getenv(crashChildStartEnv))
+
+	kv, err := OpenKV(dir)
+	require.NoError(t, err, "child: open")
+	require.NoError(t, kv.Open(), "child: open files")
+
+	kr, vr := crashKV(start)
+	const batch = 20
+	for i := start; i < start+100_000; i++ {
+		require.NoError(t, kv.Put(kr.NextHash(), vr.RandBuff(10, 50)), "child: put")
+		if (i+1)%batch == 0 {
+			require.NoError(t, kv.Close(), "child: close")
+			fmt.Printf("CHECKPOINT %d\n", i+1) // Durability point reached
+			require.NoError(t, kv.Open(), "child: reopen")
+		}
+	}
+}
+
+// TestCrashRecovery
+// Kill the child at random moments; verify the durability contract
+func TestCrashRecovery(t *testing.T) {
+	if os.Getenv(crashChildEnv) != "" {
+		t.Skip("running as child")
+	}
+	dir := filepath.Join(os.TempDir(), "CrashRecovery")
+	os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
+
+	// Create the database once, durably, before any crashing starts.
+	// (Initial creation itself is not crash-atomic; see the durability
+	// design notes.)
+	// KeyLimit 50 forces history pushes; MaxCachedBlocks 2 forces
+	// frequent kfile rewrites - both are crash windows we want kills
+	// to land in.
+	kv, err := NewKV(true, dir, 16, 50, 2)
+	require.NoError(t, err)
+	require.NoError(t, kv.Close())
+
+	durable := 0
+	rng := NewFastRandom([]byte{82})
+	for round := 0; round < 6; round++ {
+		var lastCheckpoint atomic.Int64
+		lastCheckpoint.Store(int64(durable))
+
+		cmd := exec.Command(os.Args[0], "-test.run", "TestCrashChildProcess$")
+		cmd.Env = append(os.Environ(),
+			crashChildEnv+"="+dir,
+			crashChildStartEnv+"="+strconv.Itoa(durable))
+		stdout, err := cmd.StdoutPipe()
+		require.NoError(t, err)
+		var childErr bytes.Buffer
+		cmd.Stderr = &childErr
+		require.NoError(t, cmd.Start())
+
+		done := make(chan struct{})
+		progressed := make(chan struct{})
+		var childOut []string
+		var outMu sync.Mutex
+		go func() {
+			defer close(done)
+			signaled := false
+			sc := bufio.NewScanner(stdout)
+			for sc.Scan() {
+				line := sc.Text()
+				outMu.Lock()
+				childOut = append(childOut, line)
+				outMu.Unlock()
+				if n, ok := strings.CutPrefix(line, "CHECKPOINT "); ok {
+					if v, err := strconv.Atoi(n); err == nil {
+						lastCheckpoint.Store(int64(v))
+						if !signaled {
+							signaled = true
+							close(progressed)
+						}
+					}
+				}
+			}
+		}()
+
+		// Wait until the child is past startup and actually writing
+		// (first new checkpoint), then kill it a random moment later so
+		// the kill lands inside the write/rewrite/push/bloom-save paths
+		select {
+		case <-progressed:
+		case <-time.After(10 * time.Second):
+			cmd.Process.Kill()
+			cmd.Wait()
+			<-done
+			outMu.Lock()
+			t.Fatalf("child made no progress (durable=%d)\nchild stdout:\n%s\nchild stderr:\n%s",
+				durable, strings.Join(childOut, "\n"), childErr.String())
+		}
+		time.Sleep(time.Duration(rng.UintN(120)) * time.Millisecond)
+		require.NoError(t, cmd.Process.Kill())
+		cmd.Wait()
+		<-done
+		durable = int(lastCheckpoint.Load())
+
+		// The contract: the DB opens, and every checkpointed key reads
+		// back correctly
+		kv, err := OpenKV(dir)
+		require.NoErrorf(t, err, "round %d: reopen after kill (durable=%d)", round, durable)
+		require.NoErrorf(t, kv.Open(), "round %d: open files", round)
+		kr, vr := crashKV(0)
+		for i := 0; i < durable; i++ {
+			key := kr.NextHash()
+			value := vr.RandBuff(10, 50)
+			got, err := kv.Get(key)
+			require.NoErrorf(t, err, "round %d: durable key %d lost (durable=%d)", round, i, durable)
+			require.Equalf(t, value, got, "round %d: durable key %d corrupt", round, i)
+		}
+		require.NoError(t, kv.Close())
+		t.Logf("round %d: killed with %d durable keys; all verified", round, durable)
+	}
+}

--- a/database/kfile.go
+++ b/database/kfile.go
@@ -218,26 +218,38 @@ func (k *KFile) PushHistory() (err error) {
 		}
 	}
 
-	// The keys are durable in history; now reset the kfile
+	// The keys are durable in history; now reset the kfile.  The reset
+	// is atomic: a fresh header-only kfile is written to the tmp name
+	// and renamed over the old one, so kfile.dat always exists no
+	// matter where a crash lands.
 	if k.File.File != nil { // GetKeyList leaves the file open
 		if err = k.File.File.Close(); err != nil {
 			return err
 		}
 		k.File.File = nil
 	}
-	if err = os.Remove(filepath.Join(k.Directory, kFileName)); err != nil {
-		return err
-	}
-
-	if k.File, err = NewBFile(filepath.Join(k.Directory, kFileName)); err != nil {
-		return err
-	}
 
 	k.Header.Init(uint64(k.OffsetsCnt))
-	k.Close()
-	k.Open()
-
-	return nil
+	tmpPath := filepath.Join(k.Directory, kTmpFileName)
+	tmp, err := NewBFile(tmpPath)
+	if err != nil {
+		return err
+	}
+	if _, err = tmp.Write(k.Header.Marshal()); err != nil {
+		return err
+	}
+	if err = tmp.Close(); err != nil { // Flush + sync + close
+		return err
+	}
+	if err = os.Rename(tmpPath, k.File.Filename); err != nil {
+		return err
+	}
+	if err = syncDir(k.Directory); err != nil {
+		return err
+	}
+	k.File.EOB = 0
+	k.File.EOD = uint64(k.HeaderSize)
+	return k.File.Open()
 }
 
 // Open
@@ -485,15 +497,23 @@ func (k *KFile) kGet(Key [32]byte) (dbBKey *DBBKey, err error) {
 		return nil, err
 	}
 
-	var dbKey DBBKey                 //          Search the keys by unmarshaling each key as we search
-	for len(keys) >= DBKeyFullSize { //          Search all DBBKey entries, note they are not sorted.
+	// Search all DBBKey entries.  The kfile is append-ordered within a
+	// bin, and the same key can appear more than once (an overwrite, or
+	// a replayed write after a crash), so the NEWEST record -- the last
+	// match -- wins.
+	var dbKey DBBKey
+	found := false
+	for len(keys) >= DBKeyFullSize {
 		if [32]byte(keys) == Key {
 			if _, err := dbKey.Unmarshal(keys); err != nil {
 				return nil, err
 			}
-			return &dbKey, nil
+			found = true
 		}
 		keys = keys[DBKeyFullSize:] //       Move to the next DBBKey
+	}
+	if found {
+		return &dbKey, nil
 	}
 	return nil, errors.New("not found")
 }
@@ -711,6 +731,9 @@ func (k *KFile) Close() (err error) {
 		return err
 	}
 	if err = os.Rename(tmpPath, k.File.Filename); err != nil {
+		return err
+	}
+	if err = syncDir(k.Directory); err != nil {
 		return err
 	}
 

--- a/database/kv.go
+++ b/database/kv.go
@@ -1,6 +1,8 @@
 package blockchainDB
 
 import (
+	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 )
@@ -55,7 +57,26 @@ func OpenKV(directory string) (kv *KV, err error) {
 
 // Put
 // Put the key into the kFile, and the value in the vFile
+//
+// With history enabled, values are immutable: a Put of a key that
+// already exists is a no-op when the value is identical (this is what
+// makes crash recovery by replay work -- a node re-applying writes
+// after a restart must not fail on the ones that were already durable)
+// and an error when the value differs.
 func (k *KV) Put(key [32]byte, value []byte) (err error) {
+
+	if k.UseHistory {
+		if existing, err := k.Get(key); err == nil {
+			if bytes.Equal(existing, value) {
+				return nil // Same value: no-op (e.g. replay after a crash)
+			}
+			return errors.New("cannot overwrite immutable value when history is enabled")
+		}
+		// Not found -- or unreadable, as when a crash persisted the key
+		// but not its value bytes.  Either way the write proceeds; the
+		// new record supersedes any dangling one (kGet prefers the
+		// newest record).
+	}
 
 	dbbKey := new(DBBKey)
 	dbbKey.Offset, err = k.vFile.Offset()
@@ -176,6 +197,9 @@ func (k *KV) Compress() (err error) {
 		k.vFile.File = nil
 	}
 	if err = os.Rename(tvFile.Filename, k.vFile.Filename); err != nil {
+		return err
+	}
+	if err = syncDir(k.Directory); err != nil {
 		return err
 	}
 	k.vFile.EOB = 0

--- a/docs/design/durability.md
+++ b/docs/design/durability.md
@@ -1,0 +1,65 @@
+# Durability & Crash Recovery
+
+Status: implemented and crash-tested (`database/crash_test.go`), 2026-08-24.
+Tracks issue #5.
+
+## The contract
+
+**`KV.Close()` and `KFile.PushHistory()` are durability points.** After
+a process dies (SIGKILL, power loss) at an arbitrary moment:
+
+1. `OpenKV` succeeds — the database is never left unopenable.
+2. Every key written before the last completed durability point is
+   readable with its correct value.
+3. Writes after the last durability point may be wholly present,
+   partially present, or absent — but they never corrupt the database,
+   and **replaying them succeeds** (see below).
+
+`TestCrashRecovery` enforces this: a child process writes with
+checkpoints at each `Close`, the parent SIGKILLs it at random moments
+and verifies all checkpointed keys, across rounds that land kills in
+the buffered-write, kfile-rewrite, history-push, and bloom-save paths.
+
+## How the windows are covered
+
+Every multi-step rewrite follows write-new → fsync → atomic rename →
+fsync directory, so the old state survives until the new state is
+durable:
+
+| operation | mechanism |
+|---|---|
+| kfile rewrite (`KFile.Close`) | `kfile_tmp.dat` + rename |
+| kfile reset (`PushHistory`) | header-only tmp + rename — kfile.dat always exists |
+| history push ordering | keys land (and fsync) in `history.dat` **before** the kfile resets; a crash between leaves benign duplicates that the next push's merge dedups |
+| Bloom filter (`bloom.dat`) | written after history accepts the keys, before the kfile reset — a stale filter can only be missing keys that are still in the kfile, which the open path scans |
+| values before keys | `KV.Close` syncs `values.dat` before the kfile, so durable keys never reference lost values |
+| stale tmp files | removed on open; a tmp file is by construction always incomplete |
+
+## Recovery by replay
+
+A blockchain node recovers by re-applying writes since its last
+committed block. Two mechanics make that safe:
+
+- **Immutability compares values, not offsets.** A replayed `KV.Put`
+  of an identical value is a no-op even though the value bytes would
+  land at a new offset. (Previously the check compared `DBBKey`
+  offsets, so every replay of a durable key errored.)
+- **The newest record wins.** A crash can persist a key record whose
+  value bytes were still buffered. The replayed write appends a fresh
+  record, and `kGet` resolves a key to its newest record, superseding
+  the dangling one. The next kfile rewrite discards old records
+  entirely.
+
+## Known gaps (accepted, documented)
+
+- **`KV.Compress` is not crash-atomic**: the values-file swap and the
+  kfile offset rewrite are two steps; a crash between them leaves keys
+  pointing into the wrong values layout. Compress the Dyna layer at
+  quiet moments, or wait for block segmentation, which removes the
+  in-place swap entirely. Tracked separately.
+- **Initial creation** (`NewKV`) is not crash-atomic — a crash during
+  first-time setup can leave a partial directory. Create once, verify,
+  then rely on the contract. Recovery: delete and recreate.
+- `Flush` on the `ShardWriter` is an application barrier, not an
+  fsync; pair it with `Close` (or a future `SyncFlush`) at block
+  boundaries that must be durable.


### PR DESCRIPTION
Fixes #5 (the remainder). Contract documented in `docs/design/durability.md`.

## The contract, now enforced by test
**`KV.Close()` / `PushHistory()` are durability points.** After SIGKILL at any moment: the DB opens, every checkpointed key reads back correctly, and later writes never corrupt anything — `TestCrashRecovery` runs a child workload process and kills it at random mid-flight moments across 6 rounds, verifying all durable keys each time.

## What the test found (and this PR fixes)
1. **PushHistory's kfile reset wasn't atomic** — `Remove` + `Create` meant a crash in between left no `kfile.dat` and an unopenable DB. Now a header-only tmp is renamed over it.
2. **Replay failed on immutable keys** — a node re-applying writes after a restart (the standard blockchain recovery) got "cannot overwrite immutable value", because the check compared value-file *offsets* rather than values. `KV.Put` now compares values: identical → no-op, different → error.
3. **Dangling records** — a crash can persist a key record whose value bytes were still buffered; `kGet` now resolves to the *newest* record so the replayed write supersedes the dangling one.
4. **Renames weren't directory-durable** — `syncDir` now follows every atomic rename.

## Known gaps (documented, accepted)
- `Compress` remains non-crash-atomic (two-file swap) — filing separately; block segmentation removes the in-place swap entirely.
- Initial `NewKV` creation is not crash-atomic — create once, verify.

Full affected suite passes under `-race` (202s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1MpZq22uwNyJ8w2HWuRyJ