### PR TITLE
Block segmentation: sealed, hashed node-sync units

### DIFF
--- a/database/segment.go
+++ b/database/segment.go
@@ -1,0 +1,375 @@
+package blockchainDB
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// Block segmentation: the node-sync half of the BlockchainDB design.
+//
+// The Perm layer is append-only: values.dat only grows, and every key
+// maps to an immutable value at a fixed offset.  That makes "everything
+// written since offset X" a well-defined, never-changing set -- a
+// SEGMENT.  Sealing a segment per (major) block and hashing it yields
+// verifiable units a new node can fetch to sync:
+//
+//   1. Fetch the manifests up to the current height.
+//   2. Fetch each block's segment files; verify each against its
+//      SHA-256 in the manifest.
+//   3. Import the segments in height order.  Imports are idempotent
+//      (replay-safe immutability), so interrupted syncs just resume.
+//
+// A segment file is a stream:
+//
+//	header:  magic(4) version(4) sinceOffset(8) count(8)
+//	records: key(32) valueLen(8) value(valueLen)  ... repeated count times
+//
+// The manifest records, per shard: the segment file name, its record
+// count, the values.dat end offset it reached, and the SHA-256 of the
+// whole segment file.  The end offsets chain manifests together: block
+// N+1 exports from block N's end offsets.
+
+const (
+	segmentMagic   = 0x53454731 // "SEG1"
+	segmentVersion = 1
+	manifestName   = "manifest.json"
+)
+
+// SegmentInfo
+// One shard's segment within a block export
+type SegmentInfo struct {
+	Shard     int    `json:"shard"`
+	File      string `json:"file"`      // Segment file name within the block directory
+	Count     uint64 `json:"count"`     // Number of key/value records
+	EndOffset uint64 `json:"endOffset"` // values.dat offset the segment reaches
+	Hash      string `json:"hash"`      // SHA-256 of the segment file, hex
+}
+
+// Manifest
+// The manifest for one exported block
+type Manifest struct {
+	Height   uint64        `json:"height"`
+	Segments []SegmentInfo `json:"segments"`
+}
+
+// segRecord pairs a key with its DBBKey for offset-sorted export
+type segRecord struct {
+	key [32]byte
+	dbb *DBBKey
+}
+
+// permKeys
+// Collect every Perm key with a value offset >= sinceOffset, sorted by
+// offset so the values read sequentially from values.dat
+func (k *KV) permKeys(sinceOffset uint64) (records []segRecord, err error) {
+	// The kfile holds the keys since the last history push
+	keyValues, keyList, err := k.kFile.GetKeyList()
+	if err != nil {
+		return nil, err
+	}
+	for _, key := range keyList {
+		if keyValues[key].Offset >= sinceOffset {
+			records = append(records, segRecord{key, keyValues[key]})
+		}
+	}
+
+	// History holds the rest.  Bins are read whole; records are fixed
+	// size, so this is one sequential pass over history.dat.
+	hf := k.kFile.History
+	if hf != nil {
+		seen := make(map[[32]byte]bool, len(records))
+		for _, r := range records {
+			seen[r.key] = true
+		}
+		for _, ks := range hf.KeySets {
+			length := ks.End - ks.Start
+			if length == 0 {
+				continue
+			}
+			buff := make([]byte, length)
+			if _, err := hf.File.ReadAt(buff, int64(ks.Start)); err != nil {
+				return nil, err
+			}
+			for pos := 0; pos+DBKeyFullSize <= len(buff); pos += DBKeyFullSize {
+				key, dbb, err := GetDBBKey(buff[pos : pos+DBKeyFullSize])
+				if err != nil {
+					return nil, err
+				}
+				if dbb.Offset >= sinceOffset && !seen[key] {
+					records = append(records, segRecord{key, dbb})
+				}
+			}
+		}
+	}
+
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].dbb.Offset < records[j].dbb.Offset
+	})
+	return records, nil
+}
+
+// ExportSegment
+// Write every Perm key/value with a value offset >= sinceOffset to w
+// as a segment stream.  Returns the values.dat end offset the segment
+// reaches (pass it as sinceOffset of the next export), the record
+// count, and the SHA-256 of the bytes written.
+func (k *KV) ExportSegment(w io.Writer, sinceOffset uint64) (endOffset uint64, count uint64, hash [32]byte, err error) {
+	if !k.UseHistory {
+		return 0, 0, hash, errors.New("segments are exported from the Perm (history-enabled) layer")
+	}
+	if err = k.vFile.Flush(); err != nil {
+		return 0, 0, hash, err
+	}
+	endOffset = k.vFile.EOD
+
+	records, err := k.permKeys(sinceOffset)
+	if err != nil {
+		return 0, 0, hash, err
+	}
+
+	h := sha256.New()
+	out := bufio.NewWriter(io.MultiWriter(w, h))
+
+	var header [24]byte
+	binary.BigEndian.PutUint32(header[:], segmentMagic)
+	binary.BigEndian.PutUint32(header[4:], segmentVersion)
+	binary.BigEndian.PutUint64(header[8:], sinceOffset)
+	binary.BigEndian.PutUint64(header[16:], uint64(len(records)))
+	if _, err = out.Write(header[:]); err != nil {
+		return 0, 0, hash, err
+	}
+
+	value := make([]byte, 0, 1024)
+	var lenBuff [8]byte
+	for _, r := range records {
+		if uint64(cap(value)) < r.dbb.Length {
+			value = make([]byte, r.dbb.Length)
+		}
+		value = value[:r.dbb.Length]
+		if err = k.vFile.ReadAt(r.dbb.Offset, value); err != nil {
+			return 0, 0, hash, fmt.Errorf("reading value for key %x: %w", r.key, err)
+		}
+		if _, err = out.Write(r.key[:]); err != nil {
+			return 0, 0, hash, err
+		}
+		binary.BigEndian.PutUint64(lenBuff[:], r.dbb.Length)
+		if _, err = out.Write(lenBuff[:]); err != nil {
+			return 0, 0, hash, err
+		}
+		if _, err = out.Write(value); err != nil {
+			return 0, 0, hash, err
+		}
+	}
+	if err = out.Flush(); err != nil {
+		return 0, 0, hash, err
+	}
+	copy(hash[:], h.Sum(nil))
+	return endOffset, uint64(len(records)), hash, nil
+}
+
+// ImportSegment
+// Read a segment stream and put every record into the Perm layer.
+// Imports are idempotent: records already present with identical
+// values are no-ops, so an interrupted import can simply be re-run.
+func (k *KV) ImportSegment(r io.Reader) (count uint64, err error) {
+	if !k.UseHistory {
+		return 0, errors.New("segments are imported into the Perm (history-enabled) layer")
+	}
+	in := bufio.NewReader(r)
+
+	var header [24]byte
+	if _, err = io.ReadFull(in, header[:]); err != nil {
+		return 0, err
+	}
+	if binary.BigEndian.Uint32(header[:]) != segmentMagic {
+		return 0, errors.New("not a segment stream (bad magic)")
+	}
+	if v := binary.BigEndian.Uint32(header[4:]); v != segmentVersion {
+		return 0, fmt.Errorf("unsupported segment version %d", v)
+	}
+	total := binary.BigEndian.Uint64(header[16:])
+
+	var key [32]byte
+	var lenBuff [8]byte
+	value := make([]byte, 0, 1024)
+	for i := uint64(0); i < total; i++ {
+		if _, err = io.ReadFull(in, key[:]); err != nil {
+			return count, err
+		}
+		if _, err = io.ReadFull(in, lenBuff[:]); err != nil {
+			return count, err
+		}
+		length := binary.BigEndian.Uint64(lenBuff[:])
+		if uint64(cap(value)) < length {
+			value = make([]byte, length)
+		}
+		value = value[:length]
+		if _, err = io.ReadFull(in, value); err != nil {
+			return count, err
+		}
+		// Put copies through the value file, so the reused buffer is safe
+		if err = k.Put(key, value); err != nil {
+			return count, fmt.Errorf("importing key %x: %w", key, err)
+		}
+		count++
+	}
+	return count, nil
+}
+
+// VerifySegmentFile
+// Compute the SHA-256 of a segment file and compare it to wantHex
+func VerifySegmentFile(path string, wantHex string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err = io.Copy(h, f); err != nil {
+		return err
+	}
+	got := fmt.Sprintf("%x", h.Sum(nil))
+	if got != wantHex {
+		return fmt.Errorf("segment %s hash mismatch: have %s want %s", filepath.Base(path), got, wantHex)
+	}
+	return nil
+}
+
+// ExportBlock
+// Seal a block: export every shard's Perm data written since the
+// previous block into <exportDir>/block-<height>/ and write a manifest
+// with the record counts, end offsets, and SHA-256 of each segment.
+// prev is the previous block's manifest (nil for the first block); it
+// supplies the offsets to export from.
+func (k *KVShard) ExportBlock(exportDir string, height uint64, prev *Manifest) (m *Manifest, err error) {
+	blockDir := filepath.Join(exportDir, fmt.Sprintf("block-%08d", height))
+	if err = os.MkdirAll(blockDir, os.ModePerm); err != nil {
+		return nil, err
+	}
+
+	since := make([]uint64, NumShards)
+	if prev != nil {
+		for _, s := range prev.Segments {
+			if s.Shard >= 0 && s.Shard < NumShards {
+				since[s.Shard] = s.EndOffset
+			}
+		}
+	}
+
+	m = &Manifest{Height: height}
+	for i, shard := range k.Shards {
+		name := fmt.Sprintf("shard-%04d.seg", i)
+		f, err := os.Create(filepath.Join(blockDir, name))
+		if err != nil {
+			return nil, err
+		}
+		end, count, hash, err := shard.ExportPermSegment(f, since[i])
+		if err != nil {
+			f.Close()
+			return nil, fmt.Errorf("shard %d: %w", i, err)
+		}
+		if err = f.Sync(); err != nil {
+			f.Close()
+			return nil, err
+		}
+		if err = f.Close(); err != nil {
+			return nil, err
+		}
+		m.Segments = append(m.Segments, SegmentInfo{
+			Shard: i, File: name, Count: count, EndOffset: end,
+			Hash: fmt.Sprintf("%x", hash),
+		})
+	}
+
+	// Write the manifest last: its presence marks a complete export
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	tmp := filepath.Join(blockDir, manifestName+".tmp")
+	if err = os.WriteFile(tmp, data, 0644); err != nil {
+		return nil, err
+	}
+	if err = os.Rename(tmp, filepath.Join(blockDir, manifestName)); err != nil {
+		return nil, err
+	}
+	return m, syncDir(blockDir)
+}
+
+// ExportPermSegment
+// KV2-level export of the Perm layer, serialized with the shard's
+// other operations by the KV2 mutex
+func (k *KV2) ExportPermSegment(w io.Writer, sinceOffset uint64) (endOffset uint64, count uint64, hash [32]byte, err error) {
+	k.Mutex.Lock()
+	defer k.Mutex.Unlock()
+	return k.PermKV.ExportSegment(w, sinceOffset)
+}
+
+// ImportPermSegment
+// KV2-level import into the Perm layer, serialized with the shard's
+// other operations by the KV2 mutex
+func (k *KV2) ImportPermSegment(r io.Reader) (count uint64, err error) {
+	k.Mutex.Lock()
+	defer k.Mutex.Unlock()
+	return k.PermKV.ImportSegment(r)
+}
+
+// LoadManifest
+// Read the manifest of an exported block directory
+func LoadManifest(blockDir string) (m *Manifest, err error) {
+	data, err := os.ReadFile(filepath.Join(blockDir, manifestName))
+	if err != nil {
+		return nil, err
+	}
+	m = new(Manifest)
+	if err = json.Unmarshal(data, m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// ImportBlock
+// Verify and import one exported block directory into this KVShard.
+// Every segment is checked against its manifest hash before any record
+// is imported.  Idempotent: re-importing a block is a no-op.
+func (k *KVShard) ImportBlock(blockDir string) (count uint64, err error) {
+	m, err := LoadManifest(blockDir)
+	if err != nil {
+		return 0, err
+	}
+
+	// Verify everything before importing anything
+	for _, s := range m.Segments {
+		if err = VerifySegmentFile(filepath.Join(blockDir, s.File), s.Hash); err != nil {
+			return 0, err
+		}
+	}
+
+	for _, s := range m.Segments {
+		if s.Shard < 0 || s.Shard >= NumShards {
+			return count, fmt.Errorf("manifest references invalid shard %d", s.Shard)
+		}
+		f, err := os.Open(filepath.Join(blockDir, s.File))
+		if err != nil {
+			return count, err
+		}
+		n, err := k.Shards[s.Shard].ImportPermSegment(f)
+		f.Close()
+		count += n
+		if err != nil {
+			return count, fmt.Errorf("shard %d: %w", s.Shard, err)
+		}
+		if n != s.Count {
+			return count, fmt.Errorf("shard %d: imported %d records, manifest says %d", s.Shard, n, s.Count)
+		}
+	}
+	return count, nil
+}

--- a/database/segment_test.go
+++ b/database/segment_test.go
@@ -1,0 +1,171 @@
+package blockchainDB
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSegmentRoundTrip
+// The node-sync flow: node A exports two blocks; a fresh node B
+// verifies and imports them and ends with identical data.
+func TestSegmentRoundTrip(t *testing.T) {
+	dirA := filepath.Join(os.TempDir(), t.Name()+"_A")
+	dirB := filepath.Join(os.TempDir(), t.Name()+"_B")
+	exportDir := filepath.Join(os.TempDir(), t.Name()+"_export")
+	for _, d := range []string{dirA, dirB, exportDir} {
+		os.RemoveAll(d)
+		defer os.RemoveAll(d)
+	}
+
+	// Node A: two "blocks" of writes.  KeyLimit 50 forces history
+	// pushes, so exported keys come from both the kfile and history.
+	nodeA, err := NewKVShard(dirA, 16, 50, 5)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{91})
+	vr := NewFastRandom([]byte{91, 91})
+	var keys [][32]byte
+	var values [][]byte
+	writeBlock := func(n int) {
+		for i := 0; i < n; i++ {
+			key := kr.NextHash()
+			value := vr.RandBuff(20, 200)
+			require.NoError(t, nodeA.PutPerm(key, value))
+			keys = append(keys, key)
+			values = append(values, value)
+		}
+	}
+
+	writeBlock(400)
+	m1, err := nodeA.ExportBlock(exportDir, 1, nil)
+	require.NoError(t, err, "export block 1")
+
+	writeBlock(300)
+	m2, err := nodeA.ExportBlock(exportDir, 2, m1)
+	require.NoError(t, err, "export block 2")
+
+	// The two blocks must partition the data: block 2 exports only what
+	// came after block 1
+	var c1, c2 uint64
+	for _, s := range m1.Segments {
+		c1 += s.Count
+	}
+	for _, s := range m2.Segments {
+		c2 += s.Count
+	}
+	assert.Equal(t, uint64(400), c1, "block 1 record count")
+	assert.Equal(t, uint64(300), c2, "block 2 record count")
+
+	// Node B: verify + import in height order
+	nodeB, err := NewKVShard(dirB, 16, 50, 5)
+	require.NoError(t, err)
+	n1, err := nodeB.ImportBlock(filepath.Join(exportDir, "block-00000001"))
+	require.NoError(t, err, "import block 1")
+	assert.Equal(t, uint64(400), n1)
+	n2, err := nodeB.ImportBlock(filepath.Join(exportDir, "block-00000002"))
+	require.NoError(t, err, "import block 2")
+	assert.Equal(t, uint64(300), n2)
+
+	// Node B must now hold every key with the correct value
+	for i, key := range keys {
+		v, err := nodeB.GetPerm(key)
+		require.NoErrorf(t, err, "key %d missing on node B", i)
+		assert.Equalf(t, values[i], v, "key %d wrong on node B", i)
+	}
+
+	// Re-importing a block is a no-op (idempotent sync resume)
+	_, err = nodeB.ImportBlock(filepath.Join(exportDir, "block-00000002"))
+	require.NoError(t, err, "re-import should be idempotent")
+	for i, key := range keys {
+		v, err := nodeB.GetPerm(key)
+		require.NoError(t, err)
+		assert.Equal(t, values[i], v, "value changed by re-import (key %d)", i)
+	}
+
+	require.NoError(t, nodeA.Close())
+	require.NoError(t, nodeB.Close())
+}
+
+// TestSegmentTamperDetection
+// A modified segment file must fail verification before anything is
+// imported.
+func TestSegmentTamperDetection(t *testing.T) {
+	dirA := filepath.Join(os.TempDir(), t.Name()+"_A")
+	dirB := filepath.Join(os.TempDir(), t.Name()+"_B")
+	exportDir := filepath.Join(os.TempDir(), t.Name()+"_export")
+	for _, d := range []string{dirA, dirB, exportDir} {
+		os.RemoveAll(d)
+		defer os.RemoveAll(d)
+	}
+
+	nodeA, err := NewKVShard(dirA, 16, 1000, 5)
+	require.NoError(t, err)
+	kr := NewFastRandom([]byte{92})
+	vr := NewFastRandom([]byte{92, 92})
+	for i := 0; i < 100; i++ {
+		require.NoError(t, nodeA.PutPerm(kr.NextHash(), vr.RandBuff(20, 100)))
+	}
+	m, err := nodeA.ExportBlock(exportDir, 1, nil)
+	require.NoError(t, err)
+	require.NoError(t, nodeA.Close())
+
+	// Flip one byte in the first non-empty segment
+	blockDir := filepath.Join(exportDir, "block-00000001")
+	var target string
+	for _, s := range m.Segments {
+		if s.Count > 0 {
+			target = filepath.Join(blockDir, s.File)
+			break
+		}
+	}
+	require.NotEmpty(t, target, "no non-empty segment found")
+	data, err := os.ReadFile(target)
+	require.NoError(t, err)
+	data[len(data)/2] ^= 0xFF
+	require.NoError(t, os.WriteFile(target, data, 0644))
+
+	nodeB, err := NewKVShard(dirB, 16, 1000, 5)
+	require.NoError(t, err)
+	_, err = nodeB.ImportBlock(blockDir)
+	require.Error(t, err, "tampered segment must fail verification")
+	assert.Contains(t, err.Error(), "hash mismatch")
+	require.NoError(t, nodeB.Close())
+}
+
+// TestSegmentImmutableConflict
+// Importing a segment whose key conflicts with a different local value
+// must fail rather than silently overwrite.
+func TestSegmentImmutableConflict(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	exportDir := filepath.Join(os.TempDir(), t.Name()+"_export")
+	os.RemoveAll(dir)
+	os.RemoveAll(exportDir)
+	defer os.RemoveAll(dir)
+	defer os.RemoveAll(exportDir)
+
+	nodeA, err := NewKVShard(filepath.Join(dir, "A"), 16, 1000, 5)
+	require.NoError(t, err)
+	kr := NewFastRandom([]byte{93})
+	key := kr.NextHash()
+	require.NoError(t, nodeA.PutPerm(key, []byte("the true value")))
+	_, err = nodeA.ExportBlock(exportDir, 1, nil)
+	require.NoError(t, err)
+	require.NoError(t, nodeA.Close())
+
+	nodeB, err := NewKVShard(filepath.Join(dir, "B"), 16, 1000, 5)
+	require.NoError(t, err)
+	require.NoError(t, nodeB.PutPerm(key, []byte("a conflicting value")))
+	_, err = nodeB.ImportBlock(filepath.Join(exportDir, "block-00000001"))
+	require.Error(t, err, "conflicting immutable value must fail the import")
+	require.NoError(t, nodeB.Close())
+}
+
+// The export naming convention used by the tests
+func TestSegmentBlockDirName(t *testing.T) {
+	assert.Equal(t, "block-00000007", fmt.Sprintf("block-%08d", 7))
+}

--- a/docs/design/block-segmentation.md
+++ b/docs/design/block-segmentation.md
@@ -1,0 +1,69 @@
+# Block Segmentation & Node Sync
+
+Status: v1 implemented (`database/segment.go`), 2026-08-24.
+
+## Why
+
+The original design thesis: data organized so blocks can be copied to
+efficiently sync new nodes. The Perm layer makes this natural — it is
+append-only (`values.dat` only grows) and immutable (a key's value
+never changes) — so *"everything written since offset X"* is a
+well-defined set that never changes after the fact. That set, sealed
+and hashed, is a **segment**: the verifiable unit of node sync.
+
+## The flow
+
+**Sealing (producing node):**
+
+    m1, _ := kvs.ExportBlock(exportDir, 1, nil)   // block 1: everything so far
+    ...more writes...
+    m2, _ := kvs.ExportBlock(exportDir, 2, m1)    // block 2: only what's new
+
+Each block directory holds one segment file per shard plus a
+`manifest.json` recording, per shard: record count, the `values.dat`
+end offset reached, and the SHA-256 of the segment file. Manifests
+chain: block N+1 exports from block N's end offsets, so consecutive
+blocks partition the data exactly. The manifest is written last (tmp +
+rename), so its presence marks a complete export.
+
+**Syncing (new node):**
+
+    for each height in order:
+        count, err := kvs.ImportBlock(blockDir)
+
+`ImportBlock` verifies every segment against its manifest hash *before*
+importing anything, then applies the records. Imports are **idempotent**
+(replay-safe immutability from the durability work): an interrupted
+sync is resumed by re-running it, and re-importing an already-applied
+block is a no-op. A key conflicting with a *different* local value
+fails the import — divergent nodes are detected, not silently merged.
+
+## Format
+
+Segment file (streamed, hashed whole):
+
+    header:  magic(4) version(4) sinceOffset(8) count(8)
+    records: key(32) valueLen(8) value(valueLen)   ... × count
+
+Records are sorted by value offset, so the export reads `values.dat`
+sequentially and the import writes it sequentially.
+
+## Scope and future work
+
+- **v1 export cost**: selecting "keys since offset X" scans the shard's
+  key records (kfile + one sequential pass of history.dat) per export.
+  Fine at major-block cadence; for per-minor-block sealing, add a
+  per-put segment journal so the export reads only the new records.
+- **Dyna layer**: state is mutable and belongs to a *snapshot*, not a
+  segment chain. A state snapshot export (same file format, whole
+  layer) composes with segments: sync = latest snapshot + segments
+  since.
+- **Sealed segments as storage** (v2 direction): today segments are a
+  transport format and the DB re-indexes on import. The deeper design —
+  keeping sealed segments as the storage itself with per-segment key
+  indexes — would make sync a file copy plus manifest update, remove
+  the history file's move-and-rewrite costs, and make Compress
+  crash-atomic (#19) by replacing in-place swaps with new sealed
+  generations.
+- Transport (fetching manifests/segments from peers) is the
+  application's concern; the DB provides the sealed, verifiable units.


### PR DESCRIPTION
Implements the sync half of the original design thesis — the ToDo in `kv_2.go` ("the PermKV can build databases that are blocked by major blocks... used to rapidly sync partially synced nodes"). Stacked on #18 (it depends on replay-safe imports); GitHub will retarget to `main` when #18 merges.

Design notes: `docs/design/block-segmentation.md`.

## The mechanism
The Perm layer is append-only and immutable, so *"everything written since offset X"* is a well-defined set that never changes — a **segment**. Per block:

- `ExportBlock(dir, height, prevManifest)` seals each shard's new Perm data into a segment file (records sorted by value offset → sequential reads) and writes a `manifest.json` with per-shard counts, end offsets, and SHA-256 hashes. Manifests chain — block N+1 exports from block N's end offsets, so consecutive blocks partition the data exactly. The manifest is written last (tmp+rename): its presence marks a complete export.
- `ImportBlock(blockDir)` verifies **every** segment hash before importing anything, then applies the records. Idempotent — interrupted syncs resume by re-running, re-imports are no-ops — and a key conflicting with a *different* local value fails the import (divergence detected, not merged).

A new node syncs by fetching block directories and importing in height order; transport is the application's concern, the DB provides the sealed verifiable units.

## Tests
- `TestSegmentRoundTrip`: node A exports 2 blocks (400/300 records, exact partition asserted) → fresh node B verifies+imports → byte-identical values for all 700 keys; re-import proven a no-op.
- `TestSegmentTamperDetection`: one flipped byte fails verification before any record is imported.
- `TestSegmentImmutableConflict`: divergent local value fails the import.

## Noted for later (in the design doc)
- v1 export scans the shard's key records per seal — fine at major-block cadence; a per-put segment journal enables per-minor-block sealing.
- Dyna state syncs as a snapshot (same format, whole layer), composing with the segment chain.
- v2 direction: sealed segments *as* storage — makes sync a file copy, retires history-file rewrites, and fixes #19 structurally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1MpZq22uwNyJ8w2HWuRyJ