### PR TITLE
SegmentStore: sealed segments as storage (crash-atomic compaction, sync by file copy)

### DIFF
--- a/database/segstore.go
+++ b/database/segstore.go
@@ -1,0 +1,1042 @@
+package blockchainDB
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// Sealed segments as storage.
+//
+// The transport format from segment.go becomes the storage format: a
+// SegmentStore keeps its data in a chain of immutable sealed segment
+// files plus one live tail that accepts writes.  Nothing already
+// written is ever moved or rewritten.
+//
+//	live.dat            records accepted since the last seal
+//	seg-<height>.dat    a sealed, immutable segment (transport format)
+//	seg-<height>.idx    its key index: sorted 48-byte records + a bloom
+//	segments.json       the manifest: the segments, counts, and hashes
+//
+// What this buys over the kfile/history/values arrangement:
+//
+//   - Sync is a file copy.  A sealed .dat is byte-identical to what a
+//     peer sends; importing means copying the file, building its index,
+//     and committing one manifest update -- no re-inserting records.
+//   - No move-and-rewrite.  history.dat relocates whole key bins when
+//     they grow (UpdateKeySet); sealed segments never move, so writes
+//     cost what they weigh.
+//   - Compaction is crash-atomic (issue #19).  A compaction writes a
+//     new sealed generation and commits by replacing the manifest --
+//     one atomic rename.  There is no window where keys and values
+//     disagree; a crash simply leaves the old generation in force.
+//
+// Lookups check the live tail, then segments newest to oldest.  Each
+// segment's bloom filter (sized from its key count) keeps that to
+// about one binary search in the common case.  A mutable store lets a
+// newer segment shadow an older one; an immutable store rejects a
+// conflicting value and treats an identical rewrite as a no-op.
+
+const (
+	segManifestName = "segments.json"
+	segLiveName     = "live.dat"
+	segFilePrefix   = "seg-"
+	segDataSuffix   = ".dat"
+	segIndexSuffix  = ".idx"
+	segTmpSuffix    = ".tmp"
+	segCompactName  = "compact"
+
+	segIndexMagic   = 0x53494458 // "SIDX"
+	segIndexVersion = 1
+	segIndexHdrSize = 32 // magic(4) version(4) count(8) bloomBytes(8) bloomK(4) reserved(4)
+	segDataHdrSize  = 24 // magic(4) version(4) sinceOffset(8) count(8) -- segment.go's stream header
+	segRecHdrSize   = 40 // key(32) valueLen(8) precede each value in a .dat
+)
+
+// SegmentMeta
+// One sealed segment as recorded in the manifest
+type SegmentMeta struct {
+	Height uint64 `json:"height"` // Block height the segment was sealed at
+	File   string `json:"file"`   // Data file name within the store directory
+	Count  uint64 `json:"count"`  // Number of keys indexed
+	Hash   string `json:"hash"`   // SHA-256 of the data file, hex
+}
+
+// StoreManifest
+// The authoritative list of a store's sealed segments.  Replacing it
+// is the commit point for both sealing and compaction.
+type StoreManifest struct {
+	Mutable  bool          `json:"mutable"`
+	Segments []SegmentMeta `json:"segments"` // Oldest first
+}
+
+// segment
+// An open sealed segment
+type segment struct {
+	meta  SegmentMeta
+	data  *os.File
+	index *os.File
+	count int64  // Indexed keys
+	bloom *Bloom // Membership filter over this segment's keys
+}
+
+// close releases a segment's file handles
+func (s *segment) close() {
+	if s.data != nil {
+		s.data.Close()
+		s.data = nil
+	}
+	if s.index != nil {
+		s.index.Close()
+		s.index = nil
+	}
+}
+
+// lookup
+// Find a key in this segment.  Returns where its value lives in the
+// segment's data file.
+func (s *segment) lookup(key [32]byte) (dbb *DBBKey, found bool, err error) {
+	if s.bloom != nil && !s.bloom.Test(key) {
+		return nil, false, nil // Definitely not in this segment
+	}
+	var rec [DBKeyFullSize]byte
+	lo, hi := int64(0), s.count-1
+	for lo <= hi { //                        Index records are sorted by key
+		mid := (lo + hi) / 2
+		if _, err = s.index.ReadAt(rec[:], segIndexHdrSize+mid*DBKeyFullSize); err != nil {
+			return nil, false, err
+		}
+		switch bytes.Compare(key[:], rec[:32]) {
+		case 0:
+			d := new(DBBKey)
+			if _, err = d.Unmarshal(rec[:]); err != nil {
+				return nil, false, err
+			}
+			return d, true, nil
+		case -1:
+			hi = mid - 1
+		default:
+			lo = mid + 1
+		}
+	}
+	return nil, false, nil
+}
+
+// value reads a value out of the segment's data file
+func (s *segment) value(dbb *DBBKey) (value []byte, err error) {
+	value = make([]byte, dbb.Length)
+	if _, err = s.data.ReadAt(value, int64(dbb.Offset)); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+// SegmentStore
+// A key/value store built from sealed segments and a live tail.
+// Methods are safe for concurrent use.
+type SegmentStore struct {
+	Mutex     sync.Mutex
+	Directory string
+	Mutable   bool // Mutable: newer segments shadow older; immutable: conflicts error
+
+	segments    []*segment           // Sealed segments, oldest first
+	live        map[[32]byte]*DBBKey // Keys written since the last seal
+	liveFile    *BFile               // Their records
+	liveRecords uint64               // Physical records in liveFile (>= len(live) if keys repeat)
+}
+
+// NewSegmentStore
+// Create an empty store.  An existing directory is replaced.
+func NewSegmentStore(directory string, mutable bool) (store *SegmentStore, err error) {
+	os.RemoveAll(directory)
+	if err = os.MkdirAll(directory, os.ModePerm); err != nil {
+		return nil, err
+	}
+	store = &SegmentStore{Directory: directory, Mutable: mutable}
+	store.live = make(map[[32]byte]*DBBKey)
+	if err = store.newLiveFile(); err != nil {
+		return nil, err
+	}
+	if err = store.writeManifest(); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+// newLiveFile
+// Start a fresh live tail, reserving room for the data header that
+// Seal fills in
+func (s *SegmentStore) newLiveFile() (err error) {
+	if s.liveFile, err = NewBFile(filepath.Join(s.Directory, segLiveName)); err != nil {
+		return err
+	}
+	var header [segDataHdrSize]byte // Filled in by Seal, when the count is known
+	if _, err = s.liveFile.Write(header[:]); err != nil {
+		return err
+	}
+	s.liveRecords = 0
+	return nil
+}
+
+// OpenSegmentStore
+// Open an existing store: load the manifest, adopt any segment left by
+// an interrupted seal, and replay the live tail.
+func OpenSegmentStore(directory string) (store *SegmentStore, err error) {
+	store = &SegmentStore{Directory: directory}
+	store.live = make(map[[32]byte]*DBBKey)
+
+	m, err := store.readManifest()
+	if err != nil {
+		return nil, err
+	}
+	store.Mutable = m.Mutable
+
+	for _, meta := range m.Segments {
+		seg, err := store.openSegment(meta)
+		if err != nil {
+			return nil, err
+		}
+		store.segments = append(store.segments, seg)
+	}
+
+	if err = store.recoverOrphans(); err != nil {
+		return nil, err
+	}
+	if err = store.openLive(); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+// openSegment opens a sealed segment's data and index files
+func (s *SegmentStore) openSegment(meta SegmentMeta) (seg *segment, err error) {
+	seg = &segment{meta: meta}
+	dataPath := filepath.Join(s.Directory, meta.File)
+	if seg.data, err = os.Open(dataPath); err != nil {
+		return nil, err
+	}
+	indexPath := strings.TrimSuffix(dataPath, segDataSuffix) + segIndexSuffix
+	if _, err = os.Stat(indexPath); err != nil { // Rebuild a missing index
+		if err = buildIndexFor(dataPath, indexPath); err != nil {
+			seg.close()
+			return nil, err
+		}
+	}
+	if seg.index, err = os.Open(indexPath); err != nil {
+		seg.close()
+		return nil, err
+	}
+
+	var header [segIndexHdrSize]byte
+	if _, err = seg.index.ReadAt(header[:], 0); err != nil {
+		seg.close()
+		return nil, err
+	}
+	if binary.BigEndian.Uint32(header[:]) != segIndexMagic {
+		seg.close()
+		return nil, fmt.Errorf("%s is not a segment index", indexPath)
+	}
+	seg.count = int64(binary.BigEndian.Uint64(header[8:]))
+	bloomBytes := binary.BigEndian.Uint64(header[16:])
+	bloomK := int(binary.BigEndian.Uint32(header[24:]))
+	if bloomBytes > 0 {
+		bitmap := make([]byte, bloomBytes)
+		if _, err = seg.index.ReadAt(bitmap, segIndexHdrSize+seg.count*DBKeyFullSize); err != nil {
+			seg.close()
+			return nil, err
+		}
+		seg.bloom = &Bloom{
+			SizeOfMap: float64(bloomBytes) / (1024 * 1024),
+			NumBytes:  bloomBytes,
+			Map:       bitmap,
+			K:         bloomK,
+			Capacity:  bloomBytes * 8 / BloomBitsPerKey,
+			Count:     uint64(seg.count),
+		}
+	}
+	return seg, nil
+}
+
+// openLive
+// Replay the live tail into memory.  Records are read in order, so for
+// a mutable store the last record for a key wins -- the same rule
+// lookups use.
+func (s *SegmentStore) openLive() (err error) {
+	path := filepath.Join(s.Directory, segLiveName)
+	if _, err = os.Stat(path); err != nil {
+		return s.newLiveFile() // No live tail (e.g. crash right after a seal)
+	}
+	if s.liveFile, err = OpenBFile(path); err != nil {
+		return err
+	}
+
+	offset := uint64(segDataHdrSize)
+	var recHdr [segRecHdrSize]byte
+	for offset+segRecHdrSize <= s.liveFile.EOD {
+		if err = s.liveFile.ReadAt(offset, recHdr[:]); err != nil {
+			return err
+		}
+		var key [32]byte
+		copy(key[:], recHdr[:32])
+		length := binary.BigEndian.Uint64(recHdr[32:])
+		valueOffset := offset + segRecHdrSize
+		if valueOffset+length > s.liveFile.EOD {
+			break // Torn tail record from a crash mid-write; drop it
+		}
+		s.live[key] = &DBBKey{Offset: valueOffset, Length: length}
+		s.liveRecords++
+		offset = valueOffset + length
+	}
+	return nil
+}
+
+// recoverOrphans
+// Adopt a sealed segment whose manifest update did not complete, and
+// delete leftovers a completed compaction made unreachable.
+//
+// The rule is the manifest's newest height: a data file above it is a
+// seal (or compaction) that reached disk but not the manifest, and is
+// complete by construction -- it was fsynced before being renamed into
+// place.  A data file at or below that height was superseded by a
+// committed compaction.
+func (s *SegmentStore) recoverOrphans() (err error) {
+	entries, err := os.ReadDir(s.Directory)
+	if err != nil {
+		return err
+	}
+
+	known := make(map[string]bool)
+	for _, seg := range s.segments {
+		known[seg.meta.File] = true
+	}
+	newest, haveSegments := s.newestHeight()
+
+	var adopted []SegmentMeta
+	for _, e := range entries {
+		name := e.Name()
+		if strings.HasSuffix(name, segTmpSuffix) { // Never complete
+			os.Remove(filepath.Join(s.Directory, name))
+			continue
+		}
+		if !strings.HasPrefix(name, segFilePrefix) || !strings.HasSuffix(name, segDataSuffix) || known[name] {
+			continue
+		}
+		height, err := heightFromName(name)
+		if err != nil {
+			continue // Not ours
+		}
+		path := filepath.Join(s.Directory, name)
+		if haveSegments && height <= newest { // Superseded by a committed compaction
+			os.Remove(path)
+			os.Remove(strings.TrimSuffix(path, segDataSuffix) + segIndexSuffix)
+			continue
+		}
+		hash, count, err := hashAndCount(path)
+		if err != nil {
+			return err
+		}
+		adopted = append(adopted, SegmentMeta{Height: height, File: name, Count: count, Hash: hash})
+	}
+	if len(adopted) == 0 {
+		return nil
+	}
+
+	sort.Slice(adopted, func(i, j int) bool { return adopted[i].Height < adopted[j].Height })
+	for _, meta := range adopted {
+		seg, err := s.openSegment(meta)
+		if err != nil {
+			return err
+		}
+		meta.Count = uint64(seg.count) // Indexed keys, not physical records
+		seg.meta = meta
+		s.segments = append(s.segments, seg)
+	}
+	return s.writeManifest()
+}
+
+// heightFromName parses seg-<height>.dat
+func heightFromName(name string) (height uint64, err error) {
+	body := strings.TrimSuffix(strings.TrimPrefix(name, segFilePrefix), segDataSuffix)
+	_, err = fmt.Sscanf(body, "%d", &height)
+	return height, err
+}
+
+// segmentFileName is the data file name for a height
+func segmentFileName(height uint64) string {
+	return fmt.Sprintf("%s%08d%s", segFilePrefix, height, segDataSuffix)
+}
+
+// readManifest loads segments.json
+func (s *SegmentStore) readManifest() (m *StoreManifest, err error) {
+	data, err := os.ReadFile(filepath.Join(s.Directory, segManifestName))
+	if err != nil {
+		return nil, err
+	}
+	m = new(StoreManifest)
+	if err = json.Unmarshal(data, m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// writeManifest
+// Replace the manifest atomically.  This is the commit point for
+// sealing, importing, and compaction.
+func (s *SegmentStore) writeManifest() (err error) {
+	m := StoreManifest{Mutable: s.Mutable}
+	for _, seg := range s.segments {
+		m.Segments = append(m.Segments, seg.meta)
+	}
+	data, err := json.MarshalIndent(&m, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := filepath.Join(s.Directory, segManifestName+segTmpSuffix)
+	f, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+	if _, err = f.Write(data); err != nil {
+		f.Close()
+		return err
+	}
+	if err = f.Sync(); err != nil {
+		f.Close()
+		return err
+	}
+	if err = f.Close(); err != nil {
+		return err
+	}
+	if err = os.Rename(tmp, filepath.Join(s.Directory, segManifestName)); err != nil {
+		return err
+	}
+	return syncDir(s.Directory)
+}
+
+// Get
+// Return the value for a key.  Checks the live tail, then the sealed
+// segments newest to oldest.
+func (s *SegmentStore) Get(key [32]byte) (value []byte, err error) {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+	return s.get(key)
+}
+
+// get is Get; the caller must hold the Mutex
+func (s *SegmentStore) get(key [32]byte) (value []byte, err error) {
+	if dbb, ok := s.live[key]; ok {
+		value = make([]byte, dbb.Length)
+		if err = s.liveFile.ReadAt(dbb.Offset, value); err != nil {
+			return nil, err
+		}
+		return value, nil
+	}
+	for i := len(s.segments) - 1; i >= 0; i-- { // Newest segment wins
+		dbb, found, err := s.segments[i].lookup(key)
+		if err != nil {
+			return nil, err
+		}
+		if found {
+			return s.segments[i].value(dbb)
+		}
+	}
+	return nil, errors.New("not found")
+}
+
+// Put
+// Write a key/value pair into the live tail.
+//
+// In an immutable store, rewriting a key with the same value is a
+// no-op (this is what makes replay and re-import idempotent) and
+// rewriting it with a different value is an error.
+func (s *SegmentStore) Put(key [32]byte, value []byte) (err error) {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+	return s.put(key, value)
+}
+
+// put is Put; the caller must hold the Mutex
+func (s *SegmentStore) put(key [32]byte, value []byte) (err error) {
+	if !s.Mutable {
+		if existing, err := s.get(key); err == nil {
+			if bytes.Equal(existing, value) {
+				return nil // Same value: no-op
+			}
+			return errors.New("cannot overwrite immutable value")
+		}
+	}
+
+	offset := s.liveFile.EOD + s.liveFile.EOB
+	var recHdr [segRecHdrSize]byte
+	copy(recHdr[:32], key[:])
+	binary.BigEndian.PutUint64(recHdr[32:], uint64(len(value)))
+	if _, err = s.liveFile.Write(recHdr[:]); err != nil {
+		return err
+	}
+	if _, err = s.liveFile.Write(value); err != nil {
+		return err
+	}
+	s.live[key] = &DBBKey{Offset: offset + segRecHdrSize, Length: uint64(len(value))}
+	s.liveRecords++
+	return nil
+}
+
+// Seal
+// Seal the live tail into an immutable segment at the given height and
+// start a fresh tail.  Sealing is the store's durability point.
+//
+// When the tail holds no shadowed records -- the usual case for an
+// immutable store -- the file is renamed into place rather than
+// copied, so sealing costs a header write, an index build, and a hash.
+func (s *SegmentStore) Seal(height uint64) (meta SegmentMeta, err error) {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+
+	if len(s.live) == 0 {
+		return meta, nil // Nothing to seal
+	}
+	if newest, ok := s.newestHeight(); ok && height <= newest {
+		return meta, fmt.Errorf("seal height %d is not above the newest segment height %d", height, newest)
+	}
+
+	dataName := segmentFileName(height)
+	dataPath := filepath.Join(s.Directory, dataName)
+
+	var count uint64
+	var hash string
+	if uint64(len(s.live)) == s.liveRecords {
+		// No shadowed records: promote the live file as it stands
+		if hash, count, err = s.promoteLiveFile(dataPath); err != nil {
+			return meta, err
+		}
+	} else {
+		// Shadowed records present (overwrites): write a compacted copy
+		if hash, count, err = s.rewriteLiveFile(dataPath); err != nil {
+			return meta, err
+		}
+	}
+
+	indexPath := strings.TrimSuffix(dataPath, segDataSuffix) + segIndexSuffix
+	if err = buildIndexFor(dataPath, indexPath); err != nil {
+		return meta, err
+	}
+
+	meta = SegmentMeta{Height: height, File: dataName, Count: count, Hash: hash}
+	seg, err := s.openSegment(meta)
+	if err != nil {
+		return meta, err
+	}
+	s.segments = append(s.segments, seg)
+
+	if err = s.writeManifest(); err != nil { // Commit
+		return meta, err
+	}
+
+	// The sealed data is committed; start a fresh tail
+	s.live = make(map[[32]byte]*DBBKey)
+	if err = s.newLiveFile(); err != nil {
+		return meta, err
+	}
+	return meta, nil
+}
+
+// newestHeight
+// The height of the newest sealed segment.  ok is false when the store
+// has no sealed segments, so that height 0 (a genesis block) is a
+// usable height rather than a sentinel.
+func (s *SegmentStore) newestHeight() (newest uint64, ok bool) {
+	for _, seg := range s.segments {
+		if !ok || seg.meta.Height > newest {
+			newest, ok = seg.meta.Height, true
+		}
+	}
+	return newest, ok
+}
+
+// promoteLiveFile
+// Finish the live file's header, make it durable, and rename it into
+// place as a sealed segment.  No record is copied.
+func (s *SegmentStore) promoteLiveFile(dataPath string) (hash string, count uint64, err error) {
+	count = s.liveRecords
+	if err = s.liveFile.Flush(); err != nil {
+		return "", 0, err
+	}
+	var header [segDataHdrSize]byte
+	binary.BigEndian.PutUint32(header[:], segmentMagic)
+	binary.BigEndian.PutUint32(header[4:], segmentVersion)
+	binary.BigEndian.PutUint64(header[16:], count)
+	if err = s.liveFile.WriteAt(0, header[:]); err != nil {
+		return "", 0, err
+	}
+	if err = s.liveFile.File.Sync(); err != nil {
+		return "", 0, err
+	}
+	livePath := s.liveFile.Filename
+	if err = s.liveFile.File.Close(); err != nil {
+		return "", 0, err
+	}
+	s.liveFile.File = nil
+	if err = os.Rename(livePath, dataPath); err != nil {
+		return "", 0, err
+	}
+	if err = syncDir(s.Directory); err != nil {
+		return "", 0, err
+	}
+	if hash, _, err = hashAndCount(dataPath); err != nil {
+		return "", 0, err
+	}
+	return hash, count, nil
+}
+
+// rewriteLiveFile
+// Write the live tail's newest record per key to a new sealed segment,
+// dropping records shadowed by later writes
+func (s *SegmentStore) rewriteLiveFile(dataPath string) (hash string, count uint64, err error) {
+	keys := make([][32]byte, 0, len(s.live))
+	for key := range s.live {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i][:], keys[j][:]) < 0 })
+
+	tmpPath := dataPath + segTmpSuffix
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return "", 0, err
+	}
+	defer func() {
+		if f != nil {
+			f.Close()
+			os.Remove(tmpPath)
+		}
+	}()
+
+	h := sha256.New()
+	out := io.MultiWriter(f, h)
+	var header [segDataHdrSize]byte
+	binary.BigEndian.PutUint32(header[:], segmentMagic)
+	binary.BigEndian.PutUint32(header[4:], segmentVersion)
+	binary.BigEndian.PutUint64(header[16:], uint64(len(keys)))
+	if _, err = out.Write(header[:]); err != nil {
+		return "", 0, err
+	}
+
+	var recHdr [segRecHdrSize]byte
+	value := make([]byte, 0, 1024)
+	for _, key := range keys {
+		dbb := s.live[key]
+		if uint64(cap(value)) < dbb.Length {
+			value = make([]byte, dbb.Length)
+		}
+		value = value[:dbb.Length]
+		if err = s.liveFile.ReadAt(dbb.Offset, value); err != nil {
+			return "", 0, err
+		}
+		copy(recHdr[:32], key[:])
+		binary.BigEndian.PutUint64(recHdr[32:], dbb.Length)
+		if _, err = out.Write(recHdr[:]); err != nil {
+			return "", 0, err
+		}
+		if _, err = out.Write(value); err != nil {
+			return "", 0, err
+		}
+	}
+	if err = f.Sync(); err != nil {
+		return "", 0, err
+	}
+	if err = f.Close(); err != nil {
+		f = nil
+		return "", 0, err
+	}
+	f = nil
+	if err = os.Rename(tmpPath, dataPath); err != nil {
+		return "", 0, err
+	}
+	if err = syncDir(s.Directory); err != nil {
+		return "", 0, err
+	}
+
+	// The old live file is superseded by the sealed segment
+	if s.liveFile.File != nil {
+		s.liveFile.File.Close()
+		s.liveFile.File = nil
+	}
+	os.Remove(s.liveFile.Filename)
+	return fmt.Sprintf("%x", h.Sum(nil)), uint64(len(keys)), nil
+}
+
+// Compact
+// Replace every sealed segment with one new segment holding only the
+// keys that are still live, and commit it by replacing the manifest.
+//
+// Crash-atomic: the new generation is fully durable before the
+// manifest names it, and a crash before that leaves the old generation
+// in force (issue #19).  The live tail is untouched.
+func (s *SegmentStore) Compact(height uint64) (meta SegmentMeta, err error) {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+
+	if len(s.segments) == 0 {
+		return meta, nil
+	}
+	if newest, ok := s.newestHeight(); ok && height <= newest {
+		return meta, fmt.Errorf("compaction height %d is not above the newest segment height %d", height, newest)
+	}
+
+	// Newest wins: walk segments newest to oldest, keeping the first
+	// value seen for each key
+	type liveVal struct {
+		seg *segment
+		dbb *DBBKey
+	}
+	winners := make(map[[32]byte]liveVal)
+	for i := len(s.segments) - 1; i >= 0; i-- {
+		seg := s.segments[i]
+		entries := make([]byte, seg.count*DBKeyFullSize)
+		if _, err = seg.index.ReadAt(entries, segIndexHdrSize); err != nil {
+			return meta, err
+		}
+		for pos := 0; pos+DBKeyFullSize <= len(entries); pos += DBKeyFullSize {
+			key, dbb, err := GetDBBKey(entries[pos : pos+DBKeyFullSize])
+			if err != nil {
+				return meta, err
+			}
+			if _, seen := winners[key]; !seen {
+				winners[key] = liveVal{seg, dbb}
+			}
+		}
+	}
+
+	keys := make([][32]byte, 0, len(winners))
+	for key := range winners {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i][:], keys[j][:]) < 0 })
+
+	dataName := segmentFileName(height)
+	dataPath := filepath.Join(s.Directory, dataName)
+	tmpPath := filepath.Join(s.Directory, segCompactName+segTmpSuffix)
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return meta, err
+	}
+	defer func() {
+		if f != nil {
+			f.Close()
+			os.Remove(tmpPath)
+		}
+	}()
+
+	h := sha256.New()
+	out := io.MultiWriter(f, h)
+	var header [segDataHdrSize]byte
+	binary.BigEndian.PutUint32(header[:], segmentMagic)
+	binary.BigEndian.PutUint32(header[4:], segmentVersion)
+	binary.BigEndian.PutUint64(header[16:], uint64(len(keys)))
+	if _, err = out.Write(header[:]); err != nil {
+		return meta, err
+	}
+	var recHdr [segRecHdrSize]byte
+	for _, key := range keys {
+		w := winners[key]
+		value, err := w.seg.value(w.dbb)
+		if err != nil {
+			return meta, err
+		}
+		copy(recHdr[:32], key[:])
+		binary.BigEndian.PutUint64(recHdr[32:], uint64(len(value)))
+		if _, err = out.Write(recHdr[:]); err != nil {
+			return meta, err
+		}
+		if _, err = out.Write(value); err != nil {
+			return meta, err
+		}
+	}
+	if err = f.Sync(); err != nil {
+		return meta, err
+	}
+	if err = f.Close(); err != nil {
+		f = nil
+		return meta, err
+	}
+	f = nil
+	if err = os.Rename(tmpPath, dataPath); err != nil {
+		return meta, err
+	}
+	if err = syncDir(s.Directory); err != nil {
+		return meta, err
+	}
+	indexPath := strings.TrimSuffix(dataPath, segDataSuffix) + segIndexSuffix
+	if err = buildIndexFor(dataPath, indexPath); err != nil {
+		return meta, err
+	}
+
+	meta = SegmentMeta{Height: height, File: dataName, Count: uint64(len(keys)), Hash: fmt.Sprintf("%x", h.Sum(nil))}
+	seg, err := s.openSegment(meta)
+	if err != nil {
+		return meta, err
+	}
+
+	// Commit: the manifest now names only the new generation
+	old := s.segments
+	s.segments = []*segment{seg}
+	if err = s.writeManifest(); err != nil {
+		s.segments = old // Uncommitted; keep serving the old generation
+		seg.close()
+		return meta, err
+	}
+
+	// Committed.  The old files are unreachable; removing them is
+	// cleanup, and anything left behind is swept on the next open.
+	for _, o := range old {
+		path := filepath.Join(s.Directory, o.meta.File)
+		o.close()
+		os.Remove(path)
+		os.Remove(strings.TrimSuffix(path, segDataSuffix) + segIndexSuffix)
+	}
+	return meta, nil
+}
+
+// SegmentPaths
+// The sealed segment files backing this store, oldest first, with the
+// manifest metadata that identifies and verifies each one.  Syncing a
+// peer is copying these files.
+func (s *SegmentStore) SegmentPaths() (metas []SegmentMeta, paths []string) {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+	for _, seg := range s.segments {
+		metas = append(metas, seg.meta)
+		paths = append(paths, filepath.Join(s.Directory, seg.meta.File))
+	}
+	return metas, paths
+}
+
+// ImportSegmentFile
+// Adopt a peer's segment file: verify it against the expected hash,
+// copy it in, build its index, and commit one manifest update.  No
+// record is re-inserted, which is what makes sync a file copy.
+//
+// Importing a segment already present is a no-op, so an interrupted
+// sync resumes by re-running.
+func (s *SegmentStore) ImportSegmentFile(path string, meta SegmentMeta) (err error) {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+
+	for _, seg := range s.segments {
+		if seg.meta.Height == meta.Height && seg.meta.Hash == meta.Hash {
+			return nil // Already have it
+		}
+	}
+	if newest, ok := s.newestHeight(); ok && meta.Height <= newest {
+		return fmt.Errorf("segment height %d is not above the newest segment height %d", meta.Height, newest)
+	}
+	if err = VerifySegmentFile(path, meta.Hash); err != nil {
+		return err
+	}
+
+	dataName := segmentFileName(meta.Height)
+	dataPath := filepath.Join(s.Directory, dataName)
+	tmpPath := dataPath + segTmpSuffix
+	if err = copyFileSynced(path, tmpPath); err != nil {
+		return err
+	}
+	if err = os.Rename(tmpPath, dataPath); err != nil {
+		return err
+	}
+	if err = syncDir(s.Directory); err != nil {
+		return err
+	}
+	indexPath := strings.TrimSuffix(dataPath, segDataSuffix) + segIndexSuffix
+	if err = buildIndexFor(dataPath, indexPath); err != nil {
+		return err
+	}
+
+	meta.File = dataName
+	seg, err := s.openSegment(meta)
+	if err != nil {
+		return err
+	}
+	meta.Count = uint64(seg.count)
+	seg.meta = meta
+	s.segments = append(s.segments, seg)
+	return s.writeManifest() // Commit
+}
+
+// Close
+// Flush the live tail and release the segment files.  Records in the
+// live tail survive: they are replayed on open.
+func (s *SegmentStore) Close() (err error) {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+	if s.liveFile != nil && s.liveFile.File != nil {
+		if err = s.liveFile.Close(); err != nil {
+			return err
+		}
+	}
+	for _, seg := range s.segments {
+		seg.close()
+	}
+	s.segments = nil
+	return nil
+}
+
+// buildIndexFor
+// Scan a sealed segment and write its index: the newest record per key
+// as sorted 48-byte entries, followed by a bloom filter over the keys.
+// Written to a tmp file and renamed, so an index is either absent or
+// complete.
+func buildIndexFor(dataPath, indexPath string) (err error) {
+	f, err := os.Open(dataPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	var header [segDataHdrSize]byte
+	if _, err = f.ReadAt(header[:], 0); err != nil {
+		return err
+	}
+	if binary.BigEndian.Uint32(header[:]) != segmentMagic {
+		return fmt.Errorf("%s is not a segment file", dataPath)
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	size := uint64(info.Size())
+
+	// Scan the records.  Later records win, matching lookup order.
+	entries := make(map[[32]byte]*DBBKey)
+	var order [][32]byte
+	offset := uint64(segDataHdrSize)
+	var recHdr [segRecHdrSize]byte
+	for offset+segRecHdrSize <= size {
+		if _, err = f.ReadAt(recHdr[:], int64(offset)); err != nil {
+			return err
+		}
+		var key [32]byte
+		copy(key[:], recHdr[:32])
+		length := binary.BigEndian.Uint64(recHdr[32:])
+		valueOffset := offset + segRecHdrSize
+		if valueOffset+length > size {
+			return fmt.Errorf("%s is truncated at offset %d", dataPath, offset)
+		}
+		if _, seen := entries[key]; !seen {
+			order = append(order, key)
+		}
+		entries[key] = &DBBKey{Offset: valueOffset, Length: length}
+		offset = valueOffset + length
+	}
+
+	buff := make([]byte, 0, len(order)*DBKeyFullSize)
+	bloom := NewBloomSizedForKeys(uint64(len(order)), 3)
+	for _, key := range order {
+		buff = append(buff, entries[key].Bytes(key)...)
+		bloom.Set(key)
+	}
+	sort.Sort(recordSort(buff)) // Sorted by key, for binary search
+
+	tmpPath := indexPath + segTmpSuffix
+	out, err := os.Create(tmpPath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if out != nil {
+			out.Close()
+			os.Remove(tmpPath)
+		}
+	}()
+
+	var idxHdr [segIndexHdrSize]byte
+	binary.BigEndian.PutUint32(idxHdr[:], segIndexMagic)
+	binary.BigEndian.PutUint32(idxHdr[4:], segIndexVersion)
+	binary.BigEndian.PutUint64(idxHdr[8:], uint64(len(order)))
+	binary.BigEndian.PutUint64(idxHdr[16:], bloom.NumBytes)
+	binary.BigEndian.PutUint32(idxHdr[24:], uint32(bloom.K))
+	if _, err = out.Write(idxHdr[:]); err != nil {
+		return err
+	}
+	if _, err = out.Write(buff); err != nil {
+		return err
+	}
+	if _, err = out.Write(bloom.Map); err != nil {
+		return err
+	}
+	if err = out.Sync(); err != nil {
+		return err
+	}
+	if err = out.Close(); err != nil {
+		out = nil
+		return err
+	}
+	out = nil
+	if err = os.Rename(tmpPath, indexPath); err != nil {
+		return err
+	}
+	return syncDir(filepath.Dir(indexPath))
+}
+
+// hashAndCount
+// The SHA-256 of a segment file and the record count in its header
+func hashAndCount(path string) (hash string, count uint64, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", 0, err
+	}
+	defer f.Close()
+
+	var header [segDataHdrSize]byte
+	if _, err = f.ReadAt(header[:], 0); err != nil {
+		return "", 0, err
+	}
+	count = binary.BigEndian.Uint64(header[16:])
+
+	if _, err = f.Seek(0, io.SeekStart); err != nil {
+		return "", 0, err
+	}
+	h := sha256.New()
+	if _, err = io.Copy(h, f); err != nil {
+		return "", 0, err
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), count, nil
+}
+
+// copyFileSynced copies src to dst and makes dst durable
+func copyFileSynced(src, dst string) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if out != nil {
+			out.Close()
+			os.Remove(dst)
+		}
+	}()
+	if _, err = io.Copy(out, in); err != nil {
+		return err
+	}
+	if err = out.Sync(); err != nil {
+		return err
+	}
+	if err = out.Close(); err != nil {
+		out = nil
+		return err
+	}
+	out = nil
+	return nil
+}

--- a/database/segstore_bench_test.go
+++ b/database/segstore_bench_test.go
@@ -1,0 +1,209 @@
+package blockchainDB
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSyncCostComparison
+// The central claim of segments-as-storage: syncing a peer is a file
+// copy plus a manifest commit, not a re-insertion of every record.
+//
+// Measured twice, because the difference is structural rather than
+// constant: into an empty node, and into a node that already holds
+// data (the partially synced node the design targets).  Re-inserting
+// records costs a lookup per key against everything already stored;
+// adopting a sealed segment does not.
+func TestSyncCostComparison(t *testing.T) {
+	if testing.Short() {
+		t.Skip("measurement; skipped in -short")
+	}
+	const keys = 200_000
+	const preloaded = 600_000 // Data the syncing node already holds
+
+	base := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(base)
+	defer os.RemoveAll(base)
+
+	// --- v2: SegmentStore, sync by copying sealed files ---
+	srcDir := filepath.Join(base, "v2src")
+	dstDir := filepath.Join(base, "v2dst")
+	src, err := NewSegmentStore(srcDir, false)
+	require.NoError(t, err)
+	kr := NewFastRandom([]byte{111})
+	vr := NewFastRandom([]byte{111, 111})
+	for i := 0; i < keys; i++ {
+		require.NoError(t, src.Put(kr.NextHash(), vr.RandBuff(100, 500)))
+	}
+	_, err = src.Seal(1)
+	require.NoError(t, err)
+	metas, paths := src.SegmentPaths()
+
+	dst, err := NewSegmentStore(dstDir, false)
+	require.NoError(t, err)
+	start := time.Now()
+	for i, meta := range metas {
+		require.NoError(t, dst.ImportSegmentFile(paths[i], meta))
+	}
+	v2Empty := time.Since(start)
+	require.NoError(t, dst.Close())
+
+	// v2 again, into a node that already holds `preloaded` keys
+	dst2Dir := filepath.Join(base, "v2dst2")
+	dst2, err := NewSegmentStore(dst2Dir, false)
+	require.NoError(t, err)
+	pk := NewFastRandom([]byte{121})
+	pv := NewFastRandom([]byte{121, 121})
+	for i := 0; i < preloaded; i++ {
+		require.NoError(t, dst2.Put(pk.NextHash(), pv.RandBuff(100, 500)))
+		if (i+1)%200_000 == 0 {
+			_, err = dst2.Seal(uint64(i/200_000) + 1)
+			require.NoError(t, err)
+		}
+	}
+	start = time.Now()
+	for i, meta := range metas {
+		m := meta
+		m.Height = 100 + uint64(i) // Above the preloaded segments
+		require.NoError(t, dst2.ImportSegmentFile(paths[i], m))
+	}
+	v2Loaded := time.Since(start)
+	require.NoError(t, src.Close())
+	require.NoError(t, dst2.Close())
+
+	// --- v1: KV Perm layer, sync by re-inserting every record ---
+	v1SrcDir := filepath.Join(base, "v1src")
+	v1DstDir := filepath.Join(base, "v1dst")
+	v1Src, err := NewKV(true, v1SrcDir, 1024, 100_000, 50)
+	require.NoError(t, err)
+	kr2 := NewFastRandom([]byte{111})
+	vr2 := NewFastRandom([]byte{111, 111})
+	for i := 0; i < keys; i++ {
+		require.NoError(t, v1Src.Put(kr2.NextHash(), vr2.RandBuff(100, 500)))
+	}
+	segPath := filepath.Join(base, "v1.seg")
+	f, err := os.Create(segPath)
+	require.NoError(t, err)
+	_, _, _, err = v1Src.ExportSegment(f, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	v1Dst, err := NewKV(true, v1DstDir, 1024, 100_000, 50)
+	require.NoError(t, err)
+	in, err := os.Open(segPath)
+	require.NoError(t, err)
+	start = time.Now()
+	n, err := v1Dst.ImportSegment(in)
+	v1Empty := time.Since(start)
+	require.NoError(t, err)
+	require.Equal(t, uint64(keys), n)
+	require.NoError(t, in.Close())
+	require.NoError(t, v1Dst.Close())
+
+	// v1 again, into a node that already holds `preloaded` keys
+	v1Dst2Dir := filepath.Join(base, "v1dst2")
+	v1Dst2, err := NewKV(true, v1Dst2Dir, 1024, 100_000, 50)
+	require.NoError(t, err)
+	pk2 := NewFastRandom([]byte{121})
+	pv2 := NewFastRandom([]byte{121, 121})
+	for i := 0; i < preloaded; i++ {
+		require.NoError(t, v1Dst2.Put(pk2.NextHash(), pv2.RandBuff(100, 500)))
+	}
+	in2, err := os.Open(segPath)
+	require.NoError(t, err)
+	start = time.Now()
+	_, err = v1Dst2.ImportSegment(in2)
+	v1Loaded := time.Since(start)
+	require.NoError(t, err)
+	require.NoError(t, in2.Close())
+	require.NoError(t, v1Src.Close())
+	require.NoError(t, v1Dst2.Close())
+
+	rate := func(d time.Duration) string {
+		return humanize.Comma(int64(float64(keys) / d.Seconds()))
+	}
+	fmt.Printf("syncing %s keys into a node:\n", humanize.Comma(keys))
+	fmt.Printf("  %-34s %8s %14s\n", "", "seconds", "keys/s")
+	fmt.Printf("  %-34s %8.2f %14s\n", "v1 re-insert, empty node", v1Empty.Seconds(), rate(v1Empty))
+	fmt.Printf("  %-34s %8.2f %14s\n", "v2 copy segments, empty node", v2Empty.Seconds(), rate(v2Empty))
+	fmt.Printf("  %-34s %8.2f %14s\n",
+		fmt.Sprintf("v1 re-insert, %s keys held", humanize.Comma(preloaded)), v1Loaded.Seconds(), rate(v1Loaded))
+	fmt.Printf("  %-34s %8.2f %14s\n",
+		fmt.Sprintf("v2 copy segments, %s keys held", humanize.Comma(preloaded)), v2Loaded.Seconds(), rate(v2Loaded))
+	fmt.Printf("  speedup: %.1fx empty, %.1fx partially synced\n",
+		v1Empty.Seconds()/v2Empty.Seconds(), v1Loaded.Seconds()/v2Loaded.Seconds())
+}
+
+// BenchmarkKVGet
+// Full key-to-value lookup through the v1 KV Perm layer, for
+// comparison with BenchmarkSegmentStoreGet (same key count, same
+// value sizes; both read the value, not just the key record).
+func BenchmarkKVGet(b *testing.B) {
+	dir := filepath.Join(os.TempDir(), "BenchKVGet")
+	os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
+
+	kv, err := NewKV(true, dir, 1024, 250_000, 50)
+	if err != nil {
+		b.Fatal(err)
+	}
+	const n = 1_000_000
+	kr := NewFastRandom([]byte{112})
+	vr := NewFastRandom([]byte{112, 112})
+	keys := make([][32]byte, n)
+	for i := 0; i < n; i++ {
+		keys[i] = kr.NextHash()
+		if err := kv.Put(keys[i], vr.RandBuff(100, 500)); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	pick := NewFastRandom([]byte{113})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := kv.Get(keys[int(pick.UintN(n))]); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkSegmentStoreGet measures lookups against sealed segments
+func BenchmarkSegmentStoreGet(b *testing.B) {
+	dir := filepath.Join(os.TempDir(), "BenchSegStoreGet")
+	os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
+
+	store, err := NewSegmentStore(dir, false)
+	if err != nil {
+		b.Fatal(err)
+	}
+	const n = 1_000_000
+	kr := NewFastRandom([]byte{112})
+	vr := NewFastRandom([]byte{112, 112})
+	keys := make([][32]byte, n)
+	for i := 0; i < n; i++ {
+		keys[i] = kr.NextHash()
+		if err := store.Put(keys[i], vr.RandBuff(100, 500)); err != nil {
+			b.Fatal(err)
+		}
+		if (i+1)%250_000 == 0 { // Four sealed segments
+			if _, err := store.Seal(uint64(i/250_000) + 1); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	pick := NewFastRandom([]byte{113})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := store.Get(keys[int(pick.UintN(n))]); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/database/segstore_test.go
+++ b/database/segstore_test.go
@@ -1,0 +1,378 @@
+package blockchainDB
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// storeDir makes a scratch directory for a store test
+func storeDir(t *testing.T, name string) string {
+	t.Helper()
+	dir := filepath.Join(os.TempDir(), t.Name()+"_"+name)
+	os.RemoveAll(dir)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return dir
+}
+
+// TestSegmentStoreBasics
+// Writes are readable before and after sealing, and survive a reopen
+// from both the live tail and the sealed segments.
+func TestSegmentStoreBasics(t *testing.T) {
+	dir := storeDir(t, "s")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{101})
+	vr := NewFastRandom([]byte{101, 101})
+	keys := make([][32]byte, 300)
+	values := make([][]byte, 300)
+	for i := range keys {
+		keys[i] = kr.NextHash()
+		values[i] = vr.RandBuff(20, 200)
+		require.NoError(t, store.Put(keys[i], values[i]))
+	}
+
+	// Readable from the live tail
+	for i := range keys {
+		v, err := store.Get(keys[i])
+		require.NoErrorf(t, err, "live key %d", i)
+		assert.Equal(t, values[i], v)
+	}
+
+	// Seal the first 300, write 200 more, then seal again
+	_, err = store.Seal(1)
+	require.NoError(t, err, "seal 1")
+	for i := 0; i < 200; i++ {
+		key := kr.NextHash()
+		value := vr.RandBuff(20, 200)
+		require.NoError(t, store.Put(key, value))
+		keys = append(keys, key)
+		values = append(values, value)
+	}
+	_, err = store.Seal(2)
+	require.NoError(t, err, "seal 2")
+
+	// Everything readable across two segments
+	for i := range keys {
+		v, err := store.Get(keys[i])
+		require.NoErrorf(t, err, "sealed key %d", i)
+		assert.Equal(t, values[i], v)
+	}
+
+	// Unsealed writes live in the tail
+	tailKey := kr.NextHash()
+	require.NoError(t, store.Put(tailKey, []byte("in the tail")))
+	require.NoError(t, store.Close())
+
+	// Reopen: sealed segments and the unsealed tail both come back
+	store, err = OpenSegmentStore(dir)
+	require.NoError(t, err, "reopen")
+	for i := range keys {
+		v, err := store.Get(keys[i])
+		require.NoErrorf(t, err, "key %d after reopen", i)
+		assert.Equal(t, values[i], v)
+	}
+	v, err := store.Get(tailKey)
+	require.NoError(t, err, "tail key after reopen")
+	assert.Equal(t, []byte("in the tail"), v)
+	require.NoError(t, store.Close())
+}
+
+// TestSegmentStoreImmutability
+// An immutable store treats an identical rewrite as a no-op (replay
+// safety) and rejects a conflicting value, across the tail and sealed
+// segments alike.
+func TestSegmentStoreImmutability(t *testing.T) {
+	dir := storeDir(t, "s")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{102})
+	key := kr.NextHash()
+	require.NoError(t, store.Put(key, []byte("original")))
+
+	require.NoError(t, store.Put(key, []byte("original")), "identical rewrite must be a no-op")
+	require.Error(t, store.Put(key, []byte("different")), "conflicting value must fail")
+
+	_, err = store.Seal(1)
+	require.NoError(t, err)
+
+	require.NoError(t, store.Put(key, []byte("original")), "identical rewrite of a sealed key must be a no-op")
+	require.Error(t, store.Put(key, []byte("different")), "conflicting value with a sealed key must fail")
+
+	v, err := store.Get(key)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("original"), v)
+	require.NoError(t, store.Close())
+}
+
+// TestSegmentStoreMutableShadowing
+// In a mutable store a newer segment shadows an older one, and the
+// live tail shadows every segment.
+func TestSegmentStoreMutableShadowing(t *testing.T) {
+	dir := storeDir(t, "s")
+	store, err := NewSegmentStore(dir, true)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{103})
+	keys := make([][32]byte, 50)
+	for i := range keys {
+		keys[i] = kr.NextHash()
+		require.NoError(t, store.Put(keys[i], []byte(fmt.Sprintf("v1-%d", i))))
+	}
+	_, err = store.Seal(1)
+	require.NoError(t, err)
+
+	// Overwrite half, seal again
+	for i := 0; i < 25; i++ {
+		require.NoError(t, store.Put(keys[i], []byte(fmt.Sprintf("v2-%d", i))))
+	}
+	_, err = store.Seal(2)
+	require.NoError(t, err)
+
+	// Overwrite ten more, leave them in the tail
+	for i := 0; i < 10; i++ {
+		require.NoError(t, store.Put(keys[i], []byte(fmt.Sprintf("v3-%d", i))))
+	}
+
+	check := func(stage string) {
+		for i := range keys {
+			v, err := store.Get(keys[i])
+			require.NoErrorf(t, err, "%s: key %d", stage, i)
+			switch {
+			case i < 10:
+				assert.Equalf(t, fmt.Sprintf("v3-%d", i), string(v), "%s: key %d", stage, i)
+			case i < 25:
+				assert.Equalf(t, fmt.Sprintf("v2-%d", i), string(v), "%s: key %d", stage, i)
+			default:
+				assert.Equalf(t, fmt.Sprintf("v1-%d", i), string(v), "%s: key %d", stage, i)
+			}
+		}
+	}
+	check("before reopen")
+	require.NoError(t, store.Close())
+	store, err = OpenSegmentStore(dir)
+	require.NoError(t, err)
+	check("after reopen")
+	require.NoError(t, store.Close())
+}
+
+// TestSegmentStoreCompact
+// Compaction replaces every segment with one generation holding only
+// live keys: space is reclaimed, values are unchanged, and the commit
+// is a single manifest replacement (issue #19).
+func TestSegmentStoreCompact(t *testing.T) {
+	dir := storeDir(t, "s")
+	store, err := NewSegmentStore(dir, true)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{104})
+	vr := NewFastRandom([]byte{104, 104})
+	keys := make([][32]byte, 200)
+	for i := range keys {
+		keys[i] = kr.NextHash()
+	}
+	// Ten generations of overwrites, sealed one per round: ~90% of the
+	// sealed bytes end up shadowed
+	latest := make([][]byte, 200)
+	for round := 1; round <= 10; round++ {
+		for i := range keys {
+			latest[i] = vr.RandBuff(50, 200)
+			require.NoError(t, store.Put(keys[i], latest[i]))
+		}
+		_, err = store.Seal(uint64(round))
+		require.NoError(t, err)
+	}
+
+	sizeBefore := dirSize(t, dir)
+	require.Len(t, store.segments, 10, "should have ten sealed segments")
+
+	meta, err := store.Compact(11)
+	require.NoError(t, err, "compact")
+	assert.Equal(t, uint64(200), meta.Count, "compacted generation should hold the live keys")
+	require.Len(t, store.segments, 1, "compaction should leave one generation")
+
+	sizeAfter := dirSize(t, dir)
+	assert.Lessf(t, sizeAfter, sizeBefore/5, "space not reclaimed (%d -> %d)", sizeBefore, sizeAfter)
+
+	// Values intact, before and after a reopen
+	for i := range keys {
+		v, err := store.Get(keys[i])
+		require.NoErrorf(t, err, "key %d after compact", i)
+		assert.Equal(t, latest[i], v)
+	}
+	require.NoError(t, store.Close())
+	store, err = OpenSegmentStore(dir)
+	require.NoError(t, err)
+	for i := range keys {
+		v, err := store.Get(keys[i])
+		require.NoErrorf(t, err, "key %d after compact+reopen", i)
+		assert.Equal(t, latest[i], v)
+	}
+	require.NoError(t, store.Close())
+}
+
+// TestSegmentStoreSyncIsFileCopy
+// A peer syncs by copying sealed files and committing a manifest
+// update -- no record is re-inserted.  The imported store must hold
+// byte-identical data, re-imports must be no-ops, and a tampered file
+// must be rejected.
+func TestSegmentStoreSyncIsFileCopy(t *testing.T) {
+	srcDir := storeDir(t, "src")
+	dstDir := storeDir(t, "dst")
+
+	src, err := NewSegmentStore(srcDir, false)
+	require.NoError(t, err)
+	kr := NewFastRandom([]byte{105})
+	vr := NewFastRandom([]byte{105, 105})
+	var keys [][32]byte
+	var values [][]byte
+	for block := uint64(1); block <= 3; block++ {
+		for i := 0; i < 200; i++ {
+			key := kr.NextHash()
+			value := vr.RandBuff(20, 200)
+			require.NoError(t, src.Put(key, value))
+			keys = append(keys, key)
+			values = append(values, value)
+		}
+		_, err = src.Seal(block)
+		require.NoError(t, err)
+	}
+	metas, paths := src.SegmentPaths()
+	require.Len(t, metas, 3)
+
+	// Sync: copy each sealed file, import it (verify + adopt)
+	dst, err := NewSegmentStore(dstDir, false)
+	require.NoError(t, err)
+	for i, meta := range metas {
+		require.NoError(t, dst.ImportSegmentFile(paths[i], meta), "import segment %d", i)
+	}
+	for i := range keys {
+		v, err := dst.Get(keys[i])
+		require.NoErrorf(t, err, "key %d missing on the synced store", i)
+		assert.Equal(t, values[i], v)
+	}
+
+	// The imported files are byte-identical to the source's
+	for i, meta := range metas {
+		want, err := os.ReadFile(paths[i])
+		require.NoError(t, err)
+		got, err := os.ReadFile(filepath.Join(dstDir, meta.File))
+		require.NoError(t, err)
+		assert.Equalf(t, want, got, "segment %d differs after sync", i)
+	}
+
+	// Re-import is a no-op (interrupted syncs resume)
+	require.NoError(t, dst.ImportSegmentFile(paths[2], metas[2]))
+	require.Len(t, dst.segments, 3)
+
+	// A tampered file is rejected
+	tampered := filepath.Join(os.TempDir(), t.Name()+"_tampered.dat")
+	data, err := os.ReadFile(paths[0])
+	require.NoError(t, err)
+	data[len(data)/2] ^= 0xFF
+	require.NoError(t, os.WriteFile(tampered, data, 0644))
+	defer os.Remove(tampered)
+	bad := metas[0]
+	bad.Height = 99 // Above the newest, so only the hash can reject it
+	require.Error(t, dst.ImportSegmentFile(tampered, bad), "tampered segment must be rejected")
+
+	require.NoError(t, src.Close())
+	require.NoError(t, dst.Close())
+}
+
+// TestSegmentStoreRecovery
+// A seal that reached disk but not the manifest is adopted on open;
+// files a committed compaction superseded are swept.
+func TestSegmentStoreRecovery(t *testing.T) {
+	dir := storeDir(t, "s")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+	kr := NewFastRandom([]byte{106})
+	vr := NewFastRandom([]byte{106, 106})
+	keys := make([][32]byte, 100)
+	values := make([][]byte, 100)
+	for i := range keys {
+		keys[i] = kr.NextHash()
+		values[i] = vr.RandBuff(20, 100)
+		require.NoError(t, store.Put(keys[i], values[i]))
+	}
+	_, err = store.Seal(1)
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+
+	// Simulate a crash between the segment rename and the manifest
+	// commit: the data file is on disk, but the manifest predates it
+	// (and its index was never built)
+	m, err := (&SegmentStore{Directory: dir}).readManifest()
+	require.NoError(t, err)
+	require.Len(t, m.Segments, 1)
+	empty := &SegmentStore{Directory: dir, Mutable: m.Mutable}
+	require.NoError(t, empty.writeManifest()) // A manifest naming no segments
+	indexName := strings.TrimSuffix(m.Segments[0].File, segDataSuffix) + segIndexSuffix
+	require.NoError(t, os.Remove(filepath.Join(dir, indexName)))
+
+	// Open must adopt the orphaned segment (and rebuild its index)
+	store, err = OpenSegmentStore(dir)
+	require.NoError(t, err, "open must recover the orphaned segment")
+	require.Len(t, store.segments, 1, "orphaned segment should be adopted")
+	for i := range keys {
+		v, err := store.Get(keys[i])
+		require.NoErrorf(t, err, "key %d lost in recovery", i)
+		assert.Equal(t, values[i], v)
+	}
+	require.NoError(t, store.Close())
+
+	// The adoption was committed to the manifest
+	m2, err := (&SegmentStore{Directory: dir}).readManifest()
+	require.NoError(t, err)
+	require.Len(t, m2.Segments, 1)
+}
+
+// dirSize totals the bytes of files in a directory
+func dirSize(t *testing.T, dir string) (total int64) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		info, err := e.Info()
+		require.NoError(t, err)
+		total += info.Size()
+	}
+	return total
+}
+
+// TestSegmentStoreGenesisHeight
+// Height 0 is a legitimate first height (a genesis block), not a
+// sentinel for "no segments".
+func TestSegmentStoreGenesisHeight(t *testing.T) {
+	dir := storeDir(t, "s")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{107})
+	key := kr.NextHash()
+	require.NoError(t, store.Put(key, []byte("genesis")))
+	meta, err := store.Seal(0)
+	require.NoError(t, err, "sealing at height 0 must work")
+	assert.Equal(t, uint64(0), meta.Height)
+
+	// And a second seal at height 0 must be rejected
+	require.NoError(t, store.Put(kr.NextHash(), []byte("next")))
+	_, err = store.Seal(0)
+	require.Error(t, err, "re-using a height must be rejected")
+
+	require.NoError(t, store.Close())
+	store, err = OpenSegmentStore(dir)
+	require.NoError(t, err)
+	v, err := store.Get(key)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("genesis"), v)
+	require.NoError(t, store.Close())
+}

--- a/docs/design/segment-store.md
+++ b/docs/design/segment-store.md
@@ -1,0 +1,99 @@
+# Sealed Segments as Storage
+
+Status: implemented (`database/segstore.go`), measured 2026-08-24.
+This is the v2 direction sketched in `block-segmentation.md`.
+
+## The change
+
+v1 keeps data in `kfile.dat` + `history.dat` + `values.dat` and treats
+segments as an *export format*: syncing a peer re-inserts every record.
+v2 makes the segment format the *storage* itself.
+
+    live.dat            records accepted since the last seal
+    seg-<height>.dat    a sealed, immutable segment (the transport format)
+    seg-<height>.idx    its index: sorted 48-byte key records + a bloom
+    segments.json       the manifest: segments, counts, hashes
+
+Writes append to the live tail. `Seal(height)` turns the tail into an
+immutable segment; nothing already written is ever moved or rewritten.
+Lookups check the tail, then segments newest to oldest — each segment's
+bloom filter (sized from its own key count) keeps that to about one
+binary search.
+
+An immutable store rejects a conflicting value and treats an identical
+rewrite as a no-op; a mutable store lets newer segments shadow older
+ones, which is what makes state overwrites and compaction work.
+
+## What it buys
+
+**Sync is a file copy.** A sealed `.dat` is byte-identical to what a
+peer sends. `ImportSegmentFile` verifies the hash, copies the file,
+builds the index, and commits one manifest update — no record is
+re-inserted. Measured, 200K keys of 100–500 B:
+
+| | seconds | keys/s |
+|---|---|---|
+| v1 re-insert, empty node | 0.64 | 313,021 |
+| v2 copy segments, empty node | 0.30 | 665,478 |
+| v1 re-insert, node holding 600K keys | 0.90 | 222,859 |
+| v2 copy segments, node holding 600K keys | 0.29 | 679,941 |
+
+2.1× on an empty node, 3.1× on a partially synced one — but the
+multiple is not the point. **v2's cost is flat** (679K vs 665K keys/s
+with 600K keys already stored) because adopting a segment does not
+consult existing data, while v1 must check each incoming key against
+everything the node already holds, so its gap widens with database
+size. Partially synced nodes are exactly the case the original design
+ToDo named.
+
+**Lookups are competitive.** Full key→value reads at 1M keys, four
+sealed segments: **4,927 ns/op vs 5,853 ns/op** for v1's KV — ~16%
+faster, without v1's `history.dat` bin relocation on the write side.
+
+**No move-and-rewrite.** `HistoryFile.UpdateKeySet` relocates a whole
+key bin whenever it outgrows its slot. Sealed segments never move, so
+a write costs what it weighs.
+
+**Compaction is crash-atomic (issue #19).** `Compact(height)` writes a
+new generation holding only live keys, fsyncs it, and commits by
+replacing the manifest — one atomic rename. There is no window where
+keys and values disagree; a crash before the commit leaves the old
+generation in force, and the orphaned file is swept on the next open.
+Measured: ten sealed generations of overwrites compact to one, ~90% of
+bytes reclaimed, values unchanged.
+
+## Crash recovery
+
+The manifest is the commit point for sealing, importing, and
+compaction, and its newest height decides what to do with a data file
+the manifest does not name:
+
+- **above** the newest height — a seal or import that reached disk but
+  not the manifest. It is complete by construction (fsync precedes the
+  rename), so it is adopted, its index rebuilt if missing, and the
+  manifest updated.
+- **at or below** — superseded by a committed compaction; deleted.
+- `*.tmp` — never complete; deleted.
+
+The live tail is replayed record by record on open; a torn trailing
+record from a crash mid-write is dropped.
+
+## Status and integration path
+
+`SegmentStore` is a complete, tested store, not yet wired in as KV2's
+layers. Migration, in order:
+
+1. Use it as the Perm layer behind the existing `KV` interface
+   (`Put`/`Get`/`Close` already match; `Seal` is the added call, at
+   block boundaries).
+2. Use it as the Dyna layer — mutable mode plus `Compact` retires
+   `KV.Compress` and #19 with it.
+3. Retire `kfile.dat`/`history.dat` for Perm data, and with them
+   `PushHistory` and the bin relocation logic.
+4. Wire `ShardWriter.Flush` to `Seal` so a block boundary is one
+   durability, sync, and compaction boundary.
+
+Not yet done here: a per-segment key count cap (segments grow with the
+seal cadence; a size-triggered seal or a tiered merge keeps the
+segment count bounded on long chains), and reading a value with one
+`ReadAt` on the value bytes rather than through the record header.


### PR DESCRIPTION
The v2 direction from `docs/design/block-segmentation.md`, now implemented. Design notes: `docs/design/segment-store.md`.

**The change:** the segment format becomes the *storage* format, not just an export format. A live tail takes writes; `Seal(height)` freezes it into an immutable segment. Nothing already written is ever moved or rewritten.

```
live.dat  seg-<height>.dat  seg-<height>.idx  segments.json
```

## What it delivers

**Sync is a file copy.** `ImportSegmentFile` verifies the hash, copies the file, builds an index, commits one manifest update. No record re-inserted. Measured over 200K keys:

| | keys/s |
|---|---|
| v1 re-insert, empty node | 313,021 |
| **v2 copy segments, empty node** | **665,478** |
| v1 re-insert, node holding 600K keys | 222,859 |
| **v2 copy segments, node holding 600K keys** | **679,941** |

2.1×/3.1× — but the multiple isn't the point: **v2 is flat** (680K vs 665K) because adopting a segment never consults existing data, while v1 checks every incoming key against everything stored, so the gap widens with database size. Partially synced nodes are exactly the case the original ToDo named.

**Compaction is crash-atomic — fixes #19.** `Compact(height)` writes a new generation, fsyncs, then commits by *replacing the manifest*: one rename. No window where keys and values disagree; a crash before the commit leaves the old generation serving, and the orphan is swept on open. Test: 10 generations of overwrites → 1, ~90% of bytes reclaimed, values unchanged.

**Lookups are faster too:** 4,927 ns/op vs 5,853 ns/op for v1's KV at 1M keys (both reading the value, not just the key record) — while also eliminating `history.dat`'s bin relocation on the write side.

**Recovery** is decided by the manifest's newest height: a data file above it is an uncommitted seal → adopted (index rebuilt); at or below → compaction leftovers → swept; `*.tmp` → deleted.

## Scope
`SegmentStore` is complete and tested, **not yet wired in as KV2's layers** — that's a bigger, riskier change and belongs in its own PR. The migration path (Perm first, then Dyna + `Compact` retiring `KV.Compress`, then retiring kfile/history for Perm data, then `ShardWriter.Flush` → `Seal`) is in the design doc, along with two known gaps: no per-segment size cap yet, and values are read through the record header rather than directly.

Tests: basics, immutability, mutable shadowing, compaction, sync-by-copy (byte-identical files + tamper rejection), orphan recovery, genesis height — all under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1MpZq22uwNyJ8w2HWuRyJ