### PR TITLE
Perm layer runs on sealed segments (1.9x single-thread, 3.1x parallel writes)

### DIFF
--- a/database/kv_2.go
+++ b/database/kv_2.go
@@ -13,7 +13,7 @@ const DynaDirName = "dyna"
 // KV2
 // Maintains 2 layers of key value pairs with different immutability characteristics:
 //
-// 1. PermKV (Permanent KV): Uses KFile with history enabled
+// 1. PermKV (Permanent KV): a SegmentStore in immutable mode
 //    - Values are immutable - once a key is associated with a value, it cannot be changed
 //    - Suitable for content-addressed storage where keys are derived from values (e.g., hash of value)
 //    - Typically used for data that doesn't change, like transaction data or blockchain blocks
@@ -38,12 +38,13 @@ const DynaDirName = "dyna"
 // could then be used to rapidly sync partially synced nodes
 
 type KV2 struct {
-	Mutex     sync.Mutex // Serializes access; KV2 methods are safe for concurrent use
-	Directory string     // Directory where the PermKV and DynaKV directories are
-	PermKV    *KV        // The Perm KV
-	DynaKV    *KV        // the Dyna KV
-	DWrites   int        // Number of writes to the DynaKV since the last compress
-	PWrites   int        // Number of writes to the PermKV since the last compress
+	Mutex     sync.Mutex    // Serializes access; KV2 methods are safe for concurrent use
+	Directory string        // Directory where the PermKV and DynaKV directories are
+	PermKV    *SegmentStore // The Perm layer: sealed, immutable segments
+	DynaKV    *KV           // the Dyna KV
+	DWrites   int           // Number of writes to the DynaKV since the last compress
+	PWrites   int           // Number of writes to the PermKV since the last compress
+	SealLimit int           // Seal the Perm layer when the live tail reaches this many keys
 }
 
 // NewKV2
@@ -68,9 +69,10 @@ func NewKV2(directory string, offsetsCnt, KeyLimit uint64, MaxCachedBlocks int) 
 
 	kv2 = new(KV2)
 	kv2.Directory = directory
-	if kv2.PermKV, err = NewKV(true, filepath.Join(directory, PermDirName), offsetsCnt, KeyLimit, MaxCachedBlocks); err != nil {
+	if kv2.PermKV, err = NewSegmentStore(filepath.Join(directory, PermDirName), false); err != nil {
 		return nil, err
 	}
+	kv2.SealLimit = int(KeyLimit)
 	if kv2.DynaKV, err = NewKV(false, filepath.Join(directory, DynaDirName), offsetsCnt, KeyLimit, MaxCachedBlocks); err != nil {
 		return nil, err
 	}
@@ -82,7 +84,7 @@ func OpenKV2(directory string) (kv2 *KV2, err error) {
 	kv2.Directory = directory
 	permDirName := filepath.Join(directory, PermDirName) // Add directory names
 	dynaDirName := filepath.Join(directory, DynaDirName) // Add directory names
-	if kv2.PermKV, err = OpenKV(permDirName); err != nil {
+	if kv2.PermKV, err = OpenSegmentStore(permDirName); err != nil {
 		return nil, err
 	}
 	if kv2.DynaKV, err = OpenKV(dynaDirName); err != nil {
@@ -96,6 +98,9 @@ func (k *KV2) Open() error {
 	defer k.Mutex.Unlock()
 	if err := k.PermKV.Open(); err != nil {
 		return err
+	}
+	if k.SealLimit == 0 {
+		k.SealLimit = int(DefaultBloomCapacity) // Reopened stores: a sane default
 	}
 	return k.DynaKV.Open()
 }
@@ -158,13 +163,36 @@ func (k *KV2) PutDyna(key [32]byte, value []byte) (writes int, err error) {
 }
 
 // PutPerm
-// Use when the k/v is known to be a dynamic k/v
+// Use when the k/v is known to be a permanent (immutable) k/v
 func (k *KV2) PutPerm(key [32]byte, value []byte) (writes int, err error) {
 	k.Mutex.Lock()
 	defer k.Mutex.Unlock()
 	k.PWrites++
-	err = k.PermKV.Put(key, value)
-	return k.DWrites, err
+	if err = k.PermKV.Put(key, value); err != nil {
+		return k.DWrites, err
+	}
+	return k.DWrites, k.sealIfFull()
+}
+
+// sealIfFull
+// Seal the Perm layer once its live tail reaches SealLimit keys, so
+// the unsealed tail (and the memory tracking it) stays bounded between
+// block boundaries.  The caller must hold the Mutex.
+func (k *KV2) sealIfFull() (err error) {
+	if k.SealLimit <= 0 || k.PermKV.LiveCount() < k.SealLimit {
+		return nil
+	}
+	_, err = k.PermKV.SealNext()
+	return err
+}
+
+// Seal
+// Seal the Perm layer at a block height.  Sealing is the Perm layer's
+// durability point and the unit a peer syncs.
+func (k *KV2) Seal(height uint64) (meta SegmentMeta, err error) {
+	k.Mutex.Lock()
+	defer k.Mutex.Unlock()
+	return k.PermKV.Seal(height)
 }
 
 // Put
@@ -191,8 +219,10 @@ func (k *KV2) Put(key [32]byte, value []byte) (writes int, err error) {
 	}
 	// If not yet a DynaKV or not in k.PermKV, default to k.PermKV
 	k.PWrites++
-	err = k.PermKV.Put(key, value)
-	return k.DWrites, err // We do not compress the PermKV ... Only report DWrites
+	if err = k.PermKV.Put(key, value); err != nil {
+		return k.DWrites, err
+	}
+	return k.DWrites, k.sealIfFull() // We do not compress the PermKV ... Only report DWrites
 }
 
 // Compress

--- a/database/kv_shard.go
+++ b/database/kv_shard.go
@@ -138,6 +138,19 @@ func (k *KVShard) Get(key [32]byte) (value []byte, err error) {
 	return value, nil
 }
 
+// SealBlock
+// Seal every shard's Perm layer at a block height.  This is the
+// durability point for permanent data and the boundary a peer syncs;
+// ExportBlock calls it as its first step.
+func (k *KVShard) SealBlock(height uint64) (err error) {
+	for i, shard := range k.Shards {
+		if _, err = shard.Seal(height); err != nil {
+			return fmt.Errorf("shard %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
 // Compress
 // Compress all the shards
 func (k *KVShard) Compress() (err error) {

--- a/database/segment.go
+++ b/database/segment.go
@@ -44,13 +44,13 @@ const (
 )
 
 // SegmentInfo
-// One shard's segment within a block export
+// One sealed segment within a block export
 type SegmentInfo struct {
-	Shard     int    `json:"shard"`
-	File      string `json:"file"`      // Segment file name within the block directory
-	Count     uint64 `json:"count"`     // Number of key/value records
-	EndOffset uint64 `json:"endOffset"` // values.dat offset the segment reaches
-	Hash      string `json:"hash"`      // SHA-256 of the segment file, hex
+	Shard  int    `json:"shard"`
+	Height uint64 `json:"height"` // The segment's own seal height within its shard
+	File   string `json:"file"`   // Segment file name within the block directory
+	Count  uint64 `json:"count"`  // Number of keys in the segment
+	Hash   string `json:"hash"`   // SHA-256 of the segment file, hex
 }
 
 // Manifest
@@ -244,49 +244,52 @@ func VerifySegmentFile(path string, wantHex string) error {
 }
 
 // ExportBlock
-// Seal a block: export every shard's Perm data written since the
-// previous block into <exportDir>/block-<height>/ and write a manifest
-// with the record counts, end offsets, and SHA-256 of each segment.
-// prev is the previous block's manifest (nil for the first block); it
-// supplies the offsets to export from.
+// Seal a block and export it: every shard seals its live tail at the
+// block height, and every segment sealed since the previous block is
+// copied into <exportDir>/block-<height>/ with a manifest recording
+// its shard, seal height, key count, and SHA-256.
+//
+// Copying sealed files is the whole export: the segments are already
+// the storage format, so nothing is re-encoded.  prev is the previous
+// block's manifest (nil for the first block); it says which segments
+// a peer already has.  A shard that sealed more than once since the
+// previous block (an auto-seal when its live tail filled) contributes
+// each of those segments.
 func (k *KVShard) ExportBlock(exportDir string, height uint64, prev *Manifest) (m *Manifest, err error) {
 	blockDir := filepath.Join(exportDir, fmt.Sprintf("block-%08d", height))
 	if err = os.MkdirAll(blockDir, os.ModePerm); err != nil {
 		return nil, err
 	}
 
-	since := make([]uint64, NumShards)
+	// The newest seal height a peer already has, per shard
+	exported := make(map[int]uint64)
 	if prev != nil {
 		for _, s := range prev.Segments {
-			if s.Shard >= 0 && s.Shard < NumShards {
-				since[s.Shard] = s.EndOffset
+			if h, ok := exported[s.Shard]; !ok || s.Height > h {
+				exported[s.Shard] = s.Height
 			}
 		}
 	}
 
 	m = &Manifest{Height: height}
 	for i, shard := range k.Shards {
-		name := fmt.Sprintf("shard-%04d.seg", i)
-		f, err := os.Create(filepath.Join(blockDir, name))
-		if err != nil {
-			return nil, err
-		}
-		end, count, hash, err := shard.ExportPermSegment(f, since[i])
-		if err != nil {
-			f.Close()
+		if _, err = shard.Seal(height); err != nil {
 			return nil, fmt.Errorf("shard %d: %w", i, err)
 		}
-		if err = f.Sync(); err != nil {
-			f.Close()
-			return nil, err
+		metas, paths := shard.PermKV.SegmentPaths()
+		for j, meta := range metas {
+			if last, ok := exported[i]; ok && meta.Height <= last {
+				continue // The peer already has this one
+			}
+			name := fmt.Sprintf("shard-%04d-%08d.seg", i, meta.Height)
+			if err = copyFileSynced(paths[j], filepath.Join(blockDir, name)); err != nil {
+				return nil, fmt.Errorf("shard %d: %w", i, err)
+			}
+			m.Segments = append(m.Segments, SegmentInfo{
+				Shard: i, Height: meta.Height, File: name,
+				Count: meta.Count, Hash: meta.Hash,
+			})
 		}
-		if err = f.Close(); err != nil {
-			return nil, err
-		}
-		m.Segments = append(m.Segments, SegmentInfo{
-			Shard: i, File: name, Count: count, EndOffset: end,
-			Hash: fmt.Sprintf("%x", hash),
-		})
 	}
 
 	// Write the manifest last: its presence marks a complete export
@@ -304,22 +307,13 @@ func (k *KVShard) ExportBlock(exportDir string, height uint64, prev *Manifest) (
 	return m, syncDir(blockDir)
 }
 
-// ExportPermSegment
-// KV2-level export of the Perm layer, serialized with the shard's
-// other operations by the KV2 mutex
-func (k *KV2) ExportPermSegment(w io.Writer, sinceOffset uint64) (endOffset uint64, count uint64, hash [32]byte, err error) {
-	k.Mutex.Lock()
-	defer k.Mutex.Unlock()
-	return k.PermKV.ExportSegment(w, sinceOffset)
-}
-
 // ImportPermSegment
-// KV2-level import into the Perm layer, serialized with the shard's
-// other operations by the KV2 mutex
-func (k *KV2) ImportPermSegment(r io.Reader) (count uint64, err error) {
+// KV2-level adoption of a sealed segment file into the Perm layer,
+// serialized with the shard's other operations by the KV2 mutex
+func (k *KV2) ImportPermSegment(path string, meta SegmentMeta) (err error) {
 	k.Mutex.Lock()
 	defer k.Mutex.Unlock()
-	return k.PermKV.ImportSegment(r)
+	return k.PermKV.ImportSegmentFile(path, meta)
 }
 
 // LoadManifest
@@ -337,39 +331,38 @@ func LoadManifest(blockDir string) (m *Manifest, err error) {
 }
 
 // ImportBlock
-// Verify and import one exported block directory into this KVShard.
-// Every segment is checked against its manifest hash before any record
-// is imported.  Idempotent: re-importing a block is a no-op.
+// Verify and import one exported block directory.  Every segment is
+// checked against its manifest hash before any of them is adopted,
+// and adopting one is a file copy plus a manifest commit -- no record
+// is re-inserted.
+//
+// Idempotent: a segment the store already has is skipped, so an
+// interrupted sync resumes by re-running.
 func (k *KVShard) ImportBlock(blockDir string) (count uint64, err error) {
 	m, err := LoadManifest(blockDir)
 	if err != nil {
 		return 0, err
 	}
 
-	// Verify everything before importing anything
+	// Verify everything before adopting anything
 	for _, s := range m.Segments {
+		if s.Shard < 0 || s.Shard >= NumShards {
+			return 0, fmt.Errorf("manifest references invalid shard %d", s.Shard)
+		}
 		if err = VerifySegmentFile(filepath.Join(blockDir, s.File), s.Hash); err != nil {
 			return 0, err
 		}
 	}
 
-	for _, s := range m.Segments {
-		if s.Shard < 0 || s.Shard >= NumShards {
-			return count, fmt.Errorf("manifest references invalid shard %d", s.Shard)
-		}
-		f, err := os.Open(filepath.Join(blockDir, s.File))
-		if err != nil {
-			return count, err
-		}
-		n, err := k.Shards[s.Shard].ImportPermSegment(f)
-		f.Close()
-		count += n
-		if err != nil {
+	// Adopt in seal order so heights stay ascending within each shard
+	segments := append([]SegmentInfo(nil), m.Segments...)
+	sort.Slice(segments, func(i, j int) bool { return segments[i].Height < segments[j].Height })
+	for _, s := range segments {
+		meta := SegmentMeta{Height: s.Height, Count: s.Count, Hash: s.Hash}
+		if err = k.Shards[s.Shard].ImportPermSegment(filepath.Join(blockDir, s.File), meta); err != nil {
 			return count, fmt.Errorf("shard %d: %w", s.Shard, err)
 		}
-		if n != s.Count {
-			return count, fmt.Errorf("shard %d: imported %d records, manifest says %d", s.Shard, n, s.Count)
-		}
+		count += s.Count
 	}
 	return count, nil
 }

--- a/database/segment_test.go
+++ b/database/segment_test.go
@@ -49,8 +49,8 @@ func TestSegmentRoundTrip(t *testing.T) {
 	m2, err := nodeA.ExportBlock(exportDir, 2, m1)
 	require.NoError(t, err, "export block 2")
 
-	// The two blocks must partition the data: block 2 exports only what
-	// came after block 1
+	// The two blocks must partition the data: block 2 exports only the
+	// segments sealed after block 1
 	var c1, c2 uint64
 	for _, s := range m1.Segments {
 		c1 += s.Count

--- a/database/segstore.go
+++ b/database/segstore.go
@@ -152,6 +152,7 @@ type SegmentStore struct {
 	live        map[[32]byte]*DBBKey // Keys written since the last seal
 	liveFile    *BFile               // Their records
 	liveRecords uint64               // Physical records in liveFile (>= len(live) if keys repeat)
+	closed      bool                 // Set by Close; cleared by Open
 }
 
 // NewSegmentStore
@@ -192,29 +193,54 @@ func (s *SegmentStore) newLiveFile() (err error) {
 // an interrupted seal, and replay the live tail.
 func OpenSegmentStore(directory string) (store *SegmentStore, err error) {
 	store = &SegmentStore{Directory: directory}
-	store.live = make(map[[32]byte]*DBBKey)
-
-	m, err := store.readManifest()
-	if err != nil {
-		return nil, err
-	}
-	store.Mutable = m.Mutable
-
-	for _, meta := range m.Segments {
-		seg, err := store.openSegment(meta)
-		if err != nil {
-			return nil, err
-		}
-		store.segments = append(store.segments, seg)
-	}
-
-	if err = store.recoverOrphans(); err != nil {
-		return nil, err
-	}
-	if err = store.openLive(); err != nil {
+	if err = store.load(); err != nil {
 		return nil, err
 	}
 	return store, nil
+}
+
+// Open
+// Reopen a closed store.  Cheap and safe to call on an open store,
+// which callers on the hot path rely on.
+func (s *SegmentStore) Open() (err error) {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+	if !s.closed {
+		return nil
+	}
+	return s.load()
+}
+
+// load
+// Read the store off disk.  The caller must hold the Mutex (or hold
+// the only reference, as the constructors do).
+func (s *SegmentStore) load() (err error) {
+	s.live = make(map[[32]byte]*DBBKey)
+	s.segments = nil
+	s.liveRecords = 0
+
+	m, err := s.readManifest()
+	if err != nil {
+		return err
+	}
+	s.Mutable = m.Mutable
+
+	for _, meta := range m.Segments {
+		seg, err := s.openSegment(meta)
+		if err != nil {
+			return err
+		}
+		s.segments = append(s.segments, seg)
+	}
+
+	if err = s.recoverOrphans(); err != nil {
+		return err
+	}
+	if err = s.openLive(); err != nil {
+		return err
+	}
+	s.closed = false
+	return nil
 }
 
 // openSegment opens a sealed segment's data and index files
@@ -488,6 +514,28 @@ func (s *SegmentStore) put(key [32]byte, value []byte) (err error) {
 	s.live[key] = &DBBKey{Offset: offset + segRecHdrSize, Length: uint64(len(value))}
 	s.liveRecords++
 	return nil
+}
+
+// LiveCount
+// The number of keys in the live tail (not yet sealed)
+func (s *SegmentStore) LiveCount() int {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+	return len(s.live)
+}
+
+// SealNext
+// Seal the live tail at the next available height.  Used to bound the
+// live tail when no block boundary has arrived; block boundaries call
+// Seal with the block height instead.
+func (s *SegmentStore) SealNext() (meta SegmentMeta, err error) {
+	s.Mutex.Lock()
+	next := uint64(0)
+	if newest, ok := s.newestHeight(); ok {
+		next = newest + 1
+	}
+	s.Mutex.Unlock()
+	return s.Seal(next)
 }
 
 // Seal
@@ -866,8 +914,60 @@ func (s *SegmentStore) ImportSegmentFile(path string, meta SegmentMeta) (err err
 	}
 	meta.Count = uint64(seg.count)
 	seg.meta = meta
+
+	// An immutable store must not silently shadow a value it already
+	// holds: that is a divergence, not an update.  Checking is cheap
+	// because the keys a syncing node receives are almost all new --
+	// the existing segments' bloom filters reject them from memory, and
+	// only a bloom hit costs a real lookup.
+	if !s.Mutable {
+		if err = s.checkNoConflicts(seg); err != nil {
+			seg.close()
+			os.Remove(dataPath)
+			os.Remove(indexPath)
+			return err
+		}
+	}
+
 	s.segments = append(s.segments, seg)
 	return s.writeManifest() // Commit
+}
+
+// checkNoConflicts
+// Verify that no key in an incoming segment already has a different
+// value in this store.  The caller must hold the Mutex, and seg must
+// not yet be in s.segments.
+func (s *SegmentStore) checkNoConflicts(seg *segment) (err error) {
+	const batch = 4096 // Index records read per pass
+	buff := make([]byte, batch*DBKeyFullSize)
+	for i := int64(0); i < seg.count; i += batch {
+		n := seg.count - i
+		if n > batch {
+			n = batch
+		}
+		chunk := buff[:n*DBKeyFullSize]
+		if _, err = seg.index.ReadAt(chunk, segIndexHdrSize+i*DBKeyFullSize); err != nil {
+			return err
+		}
+		for pos := 0; pos+DBKeyFullSize <= len(chunk); pos += DBKeyFullSize {
+			key, dbb, err := GetDBBKey(chunk[pos : pos+DBKeyFullSize])
+			if err != nil {
+				return err
+			}
+			existing, err := s.get(key) // Bloom-gated; no disk I/O unless a filter hits
+			if err != nil {
+				continue // Not held locally: the common case
+			}
+			incoming, err := seg.value(dbb)
+			if err != nil {
+				return err
+			}
+			if !bytes.Equal(existing, incoming) {
+				return fmt.Errorf("segment conflicts with the value already stored for key %x", key)
+			}
+		}
+	}
+	return nil
 }
 
 // Close
@@ -885,6 +985,7 @@ func (s *SegmentStore) Close() (err error) {
 		seg.close()
 	}
 	s.segments = nil
+	s.closed = true
 	return nil
 }
 

--- a/docs/design/block-segmentation.md
+++ b/docs/design/block-segmentation.md
@@ -1,6 +1,9 @@
 # Block Segmentation & Node Sync
 
-Status: v1 implemented (`database/segment.go`), 2026-08-24.
+Status: implemented (`database/segment.go`). Superseded in part by
+`segment-store.md`: the Perm layer now *stores* sealed segments, so a
+block export is seal-then-copy rather than a re-encode, and an import
+adopts files rather than re-inserting records.
 
 ## Why
 

--- a/docs/design/multicore-ingest.md
+++ b/docs/design/multicore-ingest.md
@@ -57,23 +57,27 @@ return it. After `Close`, calls return `ErrWriterClosed`.
 values 100–500 B, 512 shards, warmed Bloom filters, buffered writes
 (no per-op fsync):
 
-| configuration                | puts/sec  | vs single |
-|------------------------------|-----------|-----------|
-| sync, 1 goroutine            |   232,000 |      1.0× |
-| sync, 4 goroutines           |   440,000 |      1.9× |
-| sync, 8 goroutines           | 2,103,000 |      9.1× |
-| sync, 16 goroutines          | 3,668,000 |     15.8× |
-| async, 1 producer, 8 workers | 1,999,000 |      8.6× |
+| configuration                | puts/sec   | vs single |
+|------------------------------|------------|-----------|
+| sync, 1 goroutine            |  1,299,000 |      1.0× |
+| sync, 4 goroutines           |  4,474,000 |      3.4× |
+| sync, 8 goroutines           |  7,521,000 |      5.8× |
+| sync, 16 goroutines          | 11,328,000 |      8.7× |
+| async, 1 producer, 8 workers |  2,624,000 |      2.0× |
+
+(Perm writes, measured after the Perm layer moved to sealed segments;
+the same run against the kfile+history layer peaked at 3.67M/s.)
 
 Notes:
 
 - Sync scaling is roughly linear per core at 8–16 workers. The low
   4-worker result is repeatable and consistent with hybrid P/E-core
   scheduling; treat low-worker numbers as noisy.
-- The async path is **producer-bound** at ~2M puts/s: a single
+- The async path is **producer-bound** at ~2.6M puts/s: a single
   goroutine generating and queuing writes is the ceiling, independent
-  of worker count. That ceiling is far above current chain throughput
-  needs; if it ever matters, batch the queue sends.
+  of worker count. Now that the apply side is much faster, this is the
+  binding constraint for single-producer ingest; batching the queue
+  sends is the fix if it ever matters.
 - Cold-start caveat (resolved by #12): fixed 10 MB Bloom filters made
   first-touch page faults dominate a cold `KVShard`. Filters are now
   layered and sized from the key count (~300 KB initial per KFile),

--- a/docs/design/segment-store.md
+++ b/docs/design/segment-store.md
@@ -80,20 +80,44 @@ record from a crash mid-write is dropped.
 
 ## Status and integration path
 
-`SegmentStore` is a complete, tested store, not yet wired in as KV2's
-layers. Migration, in order:
+1. **Done** — `SegmentStore` is KV2's Perm layer. `KV2.Seal(height)` /
+   `KVShard.SealBlock(height)` seal at block boundaries, and the layer
+   auto-seals when its live tail reaches `SealLimit` keys (carried over
+   from `KeyLimit`) so unsealed state stays bounded between blocks.
+   Block export is now seal-then-copy: `ExportBlock` copies the sealed
+   files, and `ImportBlock` adopts them.
 
-1. Use it as the Perm layer behind the existing `KV` interface
-   (`Put`/`Get`/`Close` already match; `Seal` is the added call, at
-   block boundaries).
-2. Use it as the Dyna layer — mutable mode plus `Compact` retires
-   `KV.Compress` and #19 with it.
-3. Retire `kfile.dat`/`history.dat` for Perm data, and with them
-   `PushHistory` and the bin relocation logic.
-4. Wire `ShardWriter.Flush` to `Seal` so a block boundary is one
+   Measured effect on the running database (`TestMultiCoreScaling`,
+   Perm writes, same seal cadence as the old history-push cadence):
+
+   | | before (kfile+history) | after (segments) |
+   |---|---|---|
+   | 1 goroutine | 683,000 puts/s | **1,299,000** |
+   | 16 goroutines | 3,668,000 puts/s | **11,328,000** |
+
+   The Perm write path is now an append plus a map insert: no history
+   push, no kfile rewrite, no bin relocation, and no `Stat` per put.
+
+2. Next — use it as the Dyna layer; mutable mode plus `Compact`
+   retires `KV.Compress` and #19 with it.
+3. Then — delete the now-unused Perm paths in `KFile`/`HistoryFile`
+   (`PushHistory` and the bin relocation logic).
+4. Then — wire `ShardWriter.Flush` to `Seal` so a block boundary is one
    durability, sync, and compaction boundary.
 
 Not yet done here: a per-segment key count cap (segments grow with the
 seal cadence; a size-triggered seal or a tiered merge keeps the
 segment count bounded on long chains), and reading a value with one
 `ReadAt` on the value bytes rather than through the record header.
+
+### Divergence detection on import
+
+Adopting a segment file skips the per-key immutability check that
+re-inserting records performed, so an immutable store verifies the
+incoming keys against what it already holds before committing the
+adoption. That check is bloom-gated: a syncing node's incoming keys
+are almost all new, so the existing segments' filters reject them from
+memory and only a filter hit costs a real lookup. Measured cost is
+within noise of an unchecked import (724K keys/s into a node holding
+600K keys), and a conflicting value fails the import instead of being
+silently shadowed.


### PR DESCRIPTION
Migration step 1 from `docs/design/segment-store.md`: KV2's Perm layer is now a `SegmentStore` rather than a `KFile` + history file.

## Write throughput (TestMultiCoreScaling, same seal cadence as the old history-push cadence)
| | before (kfile+history) | after (segments) |
|---|---|---|
| 1 goroutine | 683,000 puts/s | **1,299,000** |
| 16 goroutines | 3,668,000 puts/s | **11,328,000** |

The Perm write path is now an append plus a map insert — no history push, no kfile rewrite, no bin relocation, and no `Stat` syscall per put.

## What changed
- `KV2.PermKV` is a `*SegmentStore` (immutable mode). `KV2.Seal(height)` / `KVShard.SealBlock(height)` seal at block boundaries; the layer **auto-seals** when its live tail hits `SealLimit` (carried over from `KeyLimit`), so unsealed state stays bounded between blocks.
- `SegmentStore` gains `Open` (cheap when already open — `KVShard` calls it per operation), `LiveCount`, `SealNext`.
- **Block export is seal-then-copy.** `ExportBlock` seals each shard and copies the sealed files; nothing is re-encoded. Chaining is by seal height instead of value-file offsets, which also handles a shard that auto-sealed more than once inside one block. `ImportBlock` verifies every hash, then adopts files in seal order.

## One regression this caught (and fixes)
Adopting a segment *file* skips the per-key immutability check that re-inserting records performed — so on the first cut of this change, a divergent peer's conflicting value was silently shadowed instead of rejected. `TestSegmentImmutableConflict` failed and caught it.

The fix keeps the speed: an immutable store verifies incoming keys against what it already holds before committing the adoption, **bloom-gated** — a syncing node's keys are almost all new, so existing segment filters reject them from memory and only a filter hit costs a real lookup. Import stays flat at ~724K keys/s into a node already holding 600K keys.

## Scope
`KFile`/`HistoryFile` stay in place for the Dyna layer and the legacy `KV` (still exercised by the reopen, history, crash-recovery, and v1-sync tests). Deleting their Perm-only paths is step 3; step 2 is the Dyna layer, which retires `KV.Compress` and closes #19.

Full suite passes under `-race` (278s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1MpZq22uwNyJ8w2HWuRyJ