### PR TITLE
Dyna layer runs on mutable segments (1.5x writes, crash-atomic compaction)

### DIFF
--- a/database/dyna_test.go
+++ b/database/dyna_test.go
@@ -1,0 +1,279 @@
+package blockchainDB
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dynaDir is the Dyna layer's directory within a KV2
+func dynaDir(kv2 *KV2) string { return filepath.Join(kv2.Directory, DynaDirName) }
+
+// TestDynaCompressReclaims
+// The Dyna layer accumulates trash as keys are overwritten, and
+// Compress reclaims it -- the property KV.Compress used to provide,
+// now by writing a new sealed generation instead of swapping the
+// values file in place.
+func TestDynaCompressReclaims(t *testing.T) {
+	dir := storeDir(t, "kv2")
+	kv2, err := NewKV2(dir, 16, 500, 5) // SealLimit 500 records
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{201})
+	vr := NewFastRandom([]byte{201, 201})
+	keys := make([][32]byte, 200)
+	for i := range keys {
+		keys[i] = kr.NextHash()
+	}
+
+	// Ten rounds of overwrites: ~90% of what is written is shadowed
+	latest := make([][]byte, len(keys))
+	for round := 0; round < 10; round++ {
+		for i := range keys {
+			latest[i] = vr.RandBuff(50, 200)
+			_, err = kv2.PutDyna(keys[i], latest[i])
+			require.NoError(t, err)
+		}
+	}
+	require.Greater(t, len(kv2.DynaKV.segments), 1, "overwrites should have sealed several generations")
+
+	sizeBefore := dirSize(t, dynaDir(kv2))
+	require.NoError(t, kv2.Compress(), "compress")
+	sizeAfter := dirSize(t, dynaDir(kv2))
+	assert.Lessf(t, sizeAfter, sizeBefore/3, "space not reclaimed (%d -> %d)", sizeBefore, sizeAfter)
+	assert.Len(t, kv2.DynaKV.segments, 1, "compaction should leave one generation")
+
+	for i := range keys {
+		v, err := kv2.Get(keys[i])
+		require.NoErrorf(t, err, "key %d after compress", i)
+		assert.Equalf(t, latest[i], v, "key %d after compress", i)
+	}
+
+	// And across a reopen
+	require.NoError(t, kv2.Close())
+	reopened, err := OpenKV2(dir)
+	require.NoError(t, err)
+	require.NoError(t, reopened.Open())
+	for i := range keys {
+		v, err := reopened.Get(keys[i])
+		require.NoErrorf(t, err, "key %d after compress+reopen", i)
+		assert.Equalf(t, latest[i], v, "key %d after compress+reopen", i)
+	}
+	require.NoError(t, reopened.Close())
+}
+
+// TestDynaCompressIsIdempotent
+// Compress on an already-compacted layer must not rewrite it, and must
+// not lose anything.  KVShard compresses on a write count, so a shard
+// whose keys rarely repeat hits this path often.
+func TestDynaCompressIsIdempotent(t *testing.T) {
+	dir := storeDir(t, "kv2")
+	kv2, err := NewKV2(dir, 16, 1000, 5)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{202})
+	vr := NewFastRandom([]byte{202, 202})
+	keys := make([][32]byte, 50)
+	values := make([][]byte, 50)
+	for i := range keys {
+		keys[i], values[i] = kr.NextHash(), vr.RandBuff(20, 100)
+		_, err = kv2.PutDyna(keys[i], values[i])
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, kv2.Compress())
+	require.Len(t, kv2.DynaKV.segments, 1)
+	first := kv2.DynaKV.segments[0].meta
+
+	require.NoError(t, kv2.Compress(), "second compress")
+	require.Len(t, kv2.DynaKV.segments, 1)
+	assert.Equal(t, first, kv2.DynaKV.segments[0].meta, "nothing to reclaim: the generation should stand as it is")
+
+	for i := range keys {
+		v, err := kv2.Get(keys[i])
+		require.NoErrorf(t, err, "key %d", i)
+		assert.Equal(t, values[i], v)
+	}
+	require.NoError(t, kv2.Close())
+}
+
+// TestDynaLiveTailBounded
+// The Dyna layer seals on physical records, not distinct keys.  A few
+// hot keys rewritten in a loop hold the key count flat, so a key-count
+// trigger would never fire and the live tail -- replayed in full on
+// every open -- would grow without bound.
+func TestDynaLiveTailBounded(t *testing.T) {
+	dir := storeDir(t, "kv2")
+	const sealLimit = 100
+	kv2, err := NewKV2(dir, 16, sealLimit, 5)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{203})
+	vr := NewFastRandom([]byte{203, 203})
+	keys := make([][32]byte, 5) // Five keys, rewritten 400 times each
+	for i := range keys {
+		keys[i] = kr.NextHash()
+	}
+	latest := make([][]byte, len(keys))
+	for round := 0; round < 400; round++ {
+		for i := range keys {
+			latest[i] = vr.RandBuff(20, 60)
+			_, err = kv2.PutDyna(keys[i], latest[i])
+			require.NoError(t, err)
+		}
+		require.LessOrEqualf(t, kv2.DynaKV.LiveRecords(), uint64(sealLimit),
+			"live tail unbounded at round %d", round)
+	}
+
+	for i := range keys {
+		v, err := kv2.Get(keys[i])
+		require.NoErrorf(t, err, "key %d", i)
+		assert.Equal(t, latest[i], v)
+	}
+	require.NoError(t, kv2.Close())
+}
+
+// TestDynaCompressCrashMidway
+// A crash between the compacted generation landing on disk and the
+// manifest naming it must not lose or corrupt a value.  This is what
+// KV.Compress could not promise (issue #19): it swapped the values
+// file and rewrote the key offsets as two steps, and a crash between
+// them left keys pointing into the wrong layout.
+func TestDynaCompressCrashMidway(t *testing.T) {
+	dir := storeDir(t, "kv2")
+	crashed := storeDir(t, "crashed")
+	kv2, err := NewKV2(dir, 16, 200, 5)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{204})
+	vr := NewFastRandom([]byte{204, 204})
+	keys := make([][32]byte, 100)
+	for i := range keys {
+		keys[i] = kr.NextHash()
+	}
+	latest := make([][]byte, len(keys))
+	for round := 0; round < 6; round++ {
+		for i := range keys {
+			latest[i] = vr.RandBuff(20, 100)
+			_, err = kv2.PutDyna(keys[i], latest[i])
+			require.NoError(t, err)
+		}
+	}
+	_, err = kv2.DynaKV.SealNext() // Everything reclaimable is sealed
+	require.NoError(t, err)
+	require.Greater(t, len(kv2.DynaKV.segments), 1)
+
+	// Snapshot the pre-commit state, then compact for real.  Copying
+	// the compacted data file back over the snapshot reproduces
+	// exactly what a crash between the rename and the manifest write
+	// leaves behind: the new generation on disk, the manifest still
+	// naming the old one.
+	copyDir(t, dynaDir(kv2), crashed)
+	meta, err := kv2.DynaKV.CompactNext()
+	require.NoError(t, err)
+	copyFile(t, filepath.Join(dynaDir(kv2), meta.File), filepath.Join(crashed, meta.File))
+	require.NoError(t, kv2.Close())
+
+	store, err := OpenSegmentStore(crashed)
+	require.NoError(t, err, "open after a crash mid-compaction")
+
+	// The compacted segment sits above every height the manifest names,
+	// so recovery adopts it rather than discarding it: it joins the old
+	// generation as the newest segment, and newest wins.  Nothing is
+	// lost either way -- what a crash here costs is the space the old
+	// generation still occupies, until the next compaction.
+	require.Len(t, store.segments, 4, "old generation plus the adopted compaction")
+	assert.Equal(t, meta.Height, store.segments[len(store.segments)-1].meta.Height)
+
+	for i := range keys {
+		v, err := store.Get(keys[i])
+		require.NoErrorf(t, err, "key %d lost by a crash mid-compaction", i)
+		assert.Equalf(t, latest[i], v, "key %d wrong after a crash mid-compaction", i)
+	}
+
+	// And compaction still converges from the recovered state
+	_, err = store.CompactNext()
+	require.NoError(t, err)
+	require.Len(t, store.segments, 1)
+	for i := range keys {
+		v, err := store.Get(keys[i])
+		require.NoErrorf(t, err, "key %d after recompaction", i)
+		assert.Equal(t, latest[i], v)
+	}
+	require.NoError(t, store.Close())
+}
+
+// TestKV2PermOverwriteSurvivesCompress
+// A Perm key overwritten with a different value moves to the Dyna
+// layer.  Compaction of that layer must not resurrect the Perm copy,
+// which is still on disk underneath it.
+func TestKV2PermOverwriteSurvivesCompress(t *testing.T) {
+	dir := storeDir(t, "kv2")
+	kv2, err := NewKV2(dir, 16, 100, 5)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{205})
+	vr := NewFastRandom([]byte{205, 205})
+	keys := make([][32]byte, 40)
+	perm := make([][]byte, len(keys))
+	for i := range keys {
+		keys[i], perm[i] = kr.NextHash(), vr.RandBuff(20, 80)
+		_, err = kv2.Put(keys[i], perm[i]) // Lands in Perm
+		require.NoError(t, err)
+	}
+
+	// Overwrite every other key: those move to Dyna
+	want := make([][]byte, len(keys))
+	copy(want, perm)
+	for i := 0; i < len(keys); i += 2 {
+		want[i] = vr.RandBuff(20, 80)
+		_, err = kv2.Put(keys[i], want[i])
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, kv2.Compress())
+	require.NoError(t, kv2.Close())
+
+	reopened, err := OpenKV2(dir)
+	require.NoError(t, err)
+	require.NoError(t, reopened.Open())
+	for i := range keys {
+		v, err := reopened.Get(keys[i])
+		require.NoErrorf(t, err, "key %d", i)
+		assert.Equalf(t, want[i], v, "key %d resolved to the wrong layer", i)
+	}
+	require.NoError(t, reopened.Close())
+}
+
+// copyDir copies the files of a directory (no recursion needed: a
+// store directory holds only files)
+func copyDir(t *testing.T, src, dst string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dst, os.ModePerm))
+	entries, err := os.ReadDir(src)
+	require.NoError(t, err)
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		copyFile(t, filepath.Join(src, e.Name()), filepath.Join(dst, e.Name()))
+	}
+}
+
+// copyFile copies one file, overwriting the destination
+func copyFile(t *testing.T, src, dst string) {
+	t.Helper()
+	in, err := os.Open(src)
+	require.NoError(t, err)
+	defer in.Close()
+	out, err := os.Create(dst)
+	require.NoError(t, err)
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	require.NoError(t, err)
+	require.NoError(t, out.Sync())
+}

--- a/database/kv.go
+++ b/database/kv.go
@@ -137,10 +137,15 @@ func (k *KV) Open() (err error) {
 // Only meaningful for a mutable (history-disabled) KV: with history
 // enabled values are immutable, so the values file holds no trash.
 //
-// TODO(#5): the swap of the values file and the kfile rewrite are two
-// separate steps; a crash between them leaves the keys and values
-// inconsistent.  Making compaction crash-atomic needs the recovery
-// design tracked in issue #5.
+// No longer on the database's path.  KV2's Dyna layer is a mutable
+// SegmentStore and compacts by writing a new sealed generation and
+// committing it with one manifest rename; this remains for the legacy
+// KV and as the v1 baseline the segment benchmarks measure against.
+//
+// It is not crash-atomic (issue #19): the swap of the values file and
+// the kfile rewrite are two separate steps, and a crash between them
+// leaves keys pointing into the wrong values layout -- reads return
+// wrong bytes with no error.  That is why the Dyna layer moved off it.
 func (k *KV) Compress() (err error) {
 	if k.UseHistory {
 		return nil // Immutable values are never trash; nothing to reclaim

--- a/database/kv_2.go
+++ b/database/kv_2.go
@@ -19,48 +19,53 @@ const DynaDirName = "dyna"
 //    - Typically used for data that doesn't change, like transaction data or blockchain blocks
 //    - Attempting to overwrite a key with a different value will result in the key being moved to DynaKV
 //
-// 2. DynaKV (Dynamic KV): Uses KFile with history disabled
+// 2. DynaKV (Dynamic KV): a SegmentStore in mutable mode
 //    - Values are mutable - keys can be freely associated with different values over time
 //    - Suitable for state storage where keys have an arbitrary relationship to values
 //    - Used for data that changes over time, like account balances or other state information
-//    - We only compress this layer since it's expected to change frequently
+//    - We only compact this layer, since it's the only one that accumulates trash
 //
 // This two-layer design efficiently separates immutable data from mutable data, which is a
 // common pattern in blockchain-style databases where most data is append-only and immutable,
 // but some state needs to be updated.
 //
-// ToDo: Because KV2 can be used as a shard in a sharded database, and because the PermKV values don't
-// change and that database does not benefit from sharding, then KV2 might ought to accept a *KV for the
-// the PermKV. That way, only the DynaKV is really sharded, while all the permanent key/values are kept in
-// one KV database.
+// Both layers are segment stores; what differs is the rule for a repeated key.  The Perm
+// layer rejects a conflicting value, so its sealed segments partition the key space and a
+// peer syncs them by copying files.  The Dyna layer lets the newer write shadow the older,
+// so its sealed segments overlap and Compress reclaims what the shadowing left behind.
 //
-// ToDo furthermore, the PermKV can build databases that are blocked (by major blocks). Those separate KFiles
-// could then be used to rapidly sync partially synced nodes
+// ToDo: Because KV2 can be used as a shard in a sharded database, and because the PermKV values don't
+// change and that database does not benefit from sharding, then KV2 might ought to accept a
+// *SegmentStore for the PermKV. That way, only the DynaKV is really sharded, while all the permanent
+// key/values are kept in one store.
 
 type KV2 struct {
 	Mutex     sync.Mutex    // Serializes access; KV2 methods are safe for concurrent use
 	Directory string        // Directory where the PermKV and DynaKV directories are
 	PermKV    *SegmentStore // The Perm layer: sealed, immutable segments
-	DynaKV    *KV           // the Dyna KV
+	DynaKV    *SegmentStore // The Dyna layer: sealed, mutable segments
 	DWrites   int           // Number of writes to the DynaKV since the last compress
 	PWrites   int           // Number of writes to the PermKV since the last compress
-	SealLimit int           // Seal the Perm layer when the live tail reaches this many keys
+	SealLimit int           // Seal a layer when its live tail reaches this many records
 }
 
 // NewKV2
-// Create a two level KV file with different immutability characteristics:
+// Create a two level KV database with different immutability characteristics:
 //
-// 1. PermKV: Uses KFile with history enabled (immutable values)
-//   - Created with history=true
+// 1. PermKV: an immutable SegmentStore
 //   - Once a key is associated with a value, it cannot be changed
 //   - If a key in PermKV needs to be updated, it's moved to DynaKV
 //
-// 2. DynaKV: Uses KFile with history disabled (mutable values)
-//   - Created with history=false
+// 2. DynaKV: a mutable SegmentStore
 //   - Keys can be freely associated with different values over time
 //
 // This design efficiently separates immutable data (content-addressed storage)
 // from mutable data (state storage) in a blockchain-style database.
+//
+// KeyLimit sets SealLimit, the point at which a layer seals its live tail.
+// offsetsCnt and MaxCachedBlocks configured the KFile both layers used to be
+// built on; neither layer reads them now.  They are kept in the signature so
+// callers need not change ahead of the KFile removal.
 func NewKV2(directory string, offsetsCnt, KeyLimit uint64, MaxCachedBlocks int) (kv2 *KV2, err error) {
 	os.RemoveAll(directory)
 	if err = os.Mkdir(directory, os.ModePerm); err != nil {
@@ -72,10 +77,10 @@ func NewKV2(directory string, offsetsCnt, KeyLimit uint64, MaxCachedBlocks int) 
 	if kv2.PermKV, err = NewSegmentStore(filepath.Join(directory, PermDirName), false); err != nil {
 		return nil, err
 	}
-	kv2.SealLimit = int(KeyLimit)
-	if kv2.DynaKV, err = NewKV(false, filepath.Join(directory, DynaDirName), offsetsCnt, KeyLimit, MaxCachedBlocks); err != nil {
+	if kv2.DynaKV, err = NewSegmentStore(filepath.Join(directory, DynaDirName), true); err != nil {
 		return nil, err
 	}
+	kv2.SealLimit = int(KeyLimit)
 	return kv2, nil
 }
 
@@ -87,7 +92,7 @@ func OpenKV2(directory string) (kv2 *KV2, err error) {
 	if kv2.PermKV, err = OpenSegmentStore(permDirName); err != nil {
 		return nil, err
 	}
-	if kv2.DynaKV, err = OpenKV(dynaDirName); err != nil {
+	if kv2.DynaKV, err = OpenSegmentStore(dynaDirName); err != nil {
 		return nil, err
 	}
 	return kv2, nil
@@ -158,8 +163,10 @@ func (k *KV2) PutDyna(key [32]byte, value []byte) (writes int, err error) {
 	k.Mutex.Lock()
 	defer k.Mutex.Unlock()
 	k.DWrites++
-	err = k.DynaKV.Put(key, value)
-	return k.DWrites, err
+	if err = k.DynaKV.Put(key, value); err != nil {
+		return k.DWrites, err
+	}
+	return k.DWrites, k.sealDynaIfFull()
 }
 
 // PutPerm
@@ -171,18 +178,32 @@ func (k *KV2) PutPerm(key [32]byte, value []byte) (writes int, err error) {
 	if err = k.PermKV.Put(key, value); err != nil {
 		return k.DWrites, err
 	}
-	return k.DWrites, k.sealIfFull()
+	return k.DWrites, k.sealPermIfFull()
 }
 
-// sealIfFull
+// sealPermIfFull
 // Seal the Perm layer once its live tail reaches SealLimit keys, so
 // the unsealed tail (and the memory tracking it) stays bounded between
 // block boundaries.  The caller must hold the Mutex.
-func (k *KV2) sealIfFull() (err error) {
+func (k *KV2) sealPermIfFull() (err error) {
 	if k.SealLimit <= 0 || k.PermKV.LiveCount() < k.SealLimit {
 		return nil
 	}
 	_, err = k.PermKV.SealNext()
+	return err
+}
+
+// sealDynaIfFull
+// Seal the Dyna layer on the same limit, counted in physical records
+// rather than distinct keys.  A mutable layer leaves a record per
+// write, so a handful of hot keys rewritten in a loop would hold the
+// key count flat while the tail grew without bound -- and that tail is
+// replayed in full on every open.  The caller must hold the Mutex.
+func (k *KV2) sealDynaIfFull() (err error) {
+	if k.SealLimit <= 0 || k.DynaKV.LiveRecords() < uint64(k.SealLimit) {
+		return nil
+	}
+	_, err = k.DynaKV.SealNext()
 	return err
 }
 
@@ -206,35 +227,59 @@ func (k *KV2) Put(key [32]byte, value []byte) (writes int, err error) {
 			return k.DWrites, nil //       If the value is not changed, do nothing
 		}
 		k.DWrites++
-		err = k.DynaKV.Put(key, value) // If the value DID change, update
-		return k.DWrites, err
+		if err = k.DynaKV.Put(key, value); err != nil { // If the value DID change, update
+			return k.DWrites, err
+		}
+		return k.DWrites, k.sealDynaIfFull()
 	}
 	if value2, err2 := k.PermKV.Get(key); err2 == nil { // Check. Is it a PermKV
 		if bytes.Equal(value, value2) { // If no change, ignore;
 			return k.PWrites, nil
 		}
 		k.DWrites++
-		err = k.DynaKV.Put(key, value) // If the perm value changed, it is now a DynaKV
-		return k.DWrites, err
+		if err = k.DynaKV.Put(key, value); err != nil { // If the perm value changed, it is now a DynaKV
+			return k.DWrites, err
+		}
+		return k.DWrites, k.sealDynaIfFull()
 	}
 	// If not yet a DynaKV or not in k.PermKV, default to k.PermKV
 	k.PWrites++
 	if err = k.PermKV.Put(key, value); err != nil {
 		return k.DWrites, err
 	}
-	return k.DWrites, k.sealIfFull() // We do not compress the PermKV ... Only report DWrites
+	return k.DWrites, k.sealPermIfFull() // We do not compact the PermKV ... Only report DWrites
 }
 
 // Compress
-// Only DynaKV is compressed, since PermKV doesn't change.  That does mean one
-// bogus DynaKV key will exist in PermKV.
+// Reclaim the space the Dyna layer's overwrites left behind: seal its
+// live tail, then replace every sealed generation with one segment
+// holding only the keys still reachable.  The Perm layer is not
+// compacted -- its values are immutable, so none of them are trash.
+//
+// This is crash-atomic.  The compacted generation is fully durable
+// before the manifest names it, so there is no window in which keys
+// and values disagree (issue #19); a crash before the commit costs
+// only the space the old generation still occupies, which the next
+// compaction reclaims.  The KFile-based Compress this replaced swapped
+// the values file and rewrote the key offsets as two separate steps,
+// and a crash between them left keys pointing into the wrong layout --
+// reads returned wrong bytes with no error.
+//
+// A key written to Dyna keeps a stale copy in Perm, which compaction
+// does not remove; Get resolves the layer order, so the copy is dead
+// weight rather than a wrong answer.
 //
 // TODO: Cleanse PermKV of keys in DynaKV
 func (k *KV2) Compress() error {
 	k.Mutex.Lock()
 	defer k.Mutex.Unlock()
-	err := k.DynaKV.Compress()
+	if _, err := k.DynaKV.SealNext(); err != nil { // Everything to reclaim must be sealed
+		return err
+	}
+	if _, err := k.DynaKV.CompactNext(); err != nil {
+		return err
+	}
 	k.DWrites = 0 // Clear write counts
 	k.PWrites = 0
-	return err
+	return nil
 }

--- a/database/segstore.go
+++ b/database/segstore.go
@@ -1,12 +1,14 @@
 package blockchainDB
 
 import (
+	"bufio"
 	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"os"
 	"path/filepath"
@@ -55,6 +57,8 @@ const (
 	segTmpSuffix    = ".tmp"
 	segCompactName  = "compact"
 
+	segWriteBuffer = 1 << 20 // Buffer for writing a segment's records
+
 	segIndexMagic   = 0x53494458 // "SIDX"
 	segIndexVersion = 1
 	segIndexHdrSize = 32 // magic(4) version(4) count(8) bloomBytes(8) bloomK(4) reserved(4)
@@ -82,11 +86,12 @@ type StoreManifest struct {
 // segment
 // An open sealed segment
 type segment struct {
-	meta  SegmentMeta
-	data  *os.File
-	index *os.File
-	count int64  // Indexed keys
-	bloom *Bloom // Membership filter over this segment's keys
+	meta    SegmentMeta
+	data    *os.File
+	index   *os.File
+	count   int64  // Indexed keys
+	records int64  // Physical records in the data file; > count if any key repeats
+	bloom   *Bloom // Membership filter over this segment's keys
 }
 
 // close releases a segment's file handles
@@ -250,6 +255,12 @@ func (s *SegmentStore) openSegment(meta SegmentMeta) (seg *segment, err error) {
 	if seg.data, err = os.Open(dataPath); err != nil {
 		return nil, err
 	}
+	var dataHdr [segDataHdrSize]byte
+	if _, err = seg.data.ReadAt(dataHdr[:], 0); err != nil {
+		seg.close()
+		return nil, err
+	}
+	seg.records = int64(binary.BigEndian.Uint64(dataHdr[16:]))
 	indexPath := strings.TrimSuffix(dataPath, segDataSuffix) + segIndexSuffix
 	if _, err = os.Stat(indexPath); err != nil { // Rebuild a missing index
 		if err = buildIndexFor(dataPath, indexPath); err != nil {
@@ -366,7 +377,7 @@ func (s *SegmentStore) recoverOrphans() (err error) {
 			os.Remove(strings.TrimSuffix(path, segDataSuffix) + segIndexSuffix)
 			continue
 		}
-		hash, count, err := hashAndCount(path)
+		hash, count, err := s.identify(path)
 		if err != nil {
 			return err
 		}
@@ -524,18 +535,35 @@ func (s *SegmentStore) LiveCount() int {
 	return len(s.live)
 }
 
+// LiveRecords
+// The number of physical records in the live tail.  A mutable store
+// leaves one record per write, so a key rewritten n times leaves n
+// records: this, not LiveCount, is what bounds the tail's size on disk
+// and its replay cost on open.
+func (s *SegmentStore) LiveRecords() uint64 {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+	return s.liveRecords
+}
+
+// nextHeight
+// The height at which a seal or compaction lands above every existing
+// segment.  The caller must hold the Mutex.
+func (s *SegmentStore) nextHeight() uint64 {
+	if newest, ok := s.newestHeight(); ok {
+		return newest + 1
+	}
+	return 0
+}
+
 // SealNext
 // Seal the live tail at the next available height.  Used to bound the
 // live tail when no block boundary has arrived; block boundaries call
 // Seal with the block height instead.
 func (s *SegmentStore) SealNext() (meta SegmentMeta, err error) {
 	s.Mutex.Lock()
-	next := uint64(0)
-	if newest, ok := s.newestHeight(); ok {
-		next = newest + 1
-	}
-	s.Mutex.Unlock()
-	return s.Seal(next)
+	defer s.Mutex.Unlock()
+	return s.seal(s.nextHeight())
 }
 
 // Seal
@@ -548,7 +576,11 @@ func (s *SegmentStore) SealNext() (meta SegmentMeta, err error) {
 func (s *SegmentStore) Seal(height uint64) (meta SegmentMeta, err error) {
 	s.Mutex.Lock()
 	defer s.Mutex.Unlock()
+	return s.seal(height)
+}
 
+// seal is Seal; the caller must hold the Mutex
+func (s *SegmentStore) seal(height uint64) (meta SegmentMeta, err error) {
 	if len(s.live) == 0 {
 		return meta, nil // Nothing to seal
 	}
@@ -559,26 +591,25 @@ func (s *SegmentStore) Seal(height uint64) (meta SegmentMeta, err error) {
 	dataName := segmentFileName(height)
 	dataPath := filepath.Join(s.Directory, dataName)
 
-	var count uint64
-	var hash string
+	var sl sealed
 	if uint64(len(s.live)) == s.liveRecords {
 		// No shadowed records: promote the live file as it stands
-		if hash, count, err = s.promoteLiveFile(dataPath); err != nil {
+		if sl, err = s.promoteLiveFile(dataPath); err != nil {
 			return meta, err
 		}
 	} else {
 		// Shadowed records present (overwrites): write a compacted copy
-		if hash, count, err = s.rewriteLiveFile(dataPath); err != nil {
+		if sl, err = s.rewriteLiveFile(dataPath); err != nil {
 			return meta, err
 		}
 	}
 
 	indexPath := strings.TrimSuffix(dataPath, segDataSuffix) + segIndexSuffix
-	if err = buildIndexFor(dataPath, indexPath); err != nil {
+	if err = writeIndexFile(indexPath, sl.order, sl.entries); err != nil {
 		return meta, err
 	}
 
-	meta = SegmentMeta{Height: height, File: dataName, Count: count, Hash: hash}
+	meta = SegmentMeta{Height: height, File: dataName, Count: uint64(len(sl.order)), Hash: sl.hash}
 	seg, err := s.openSegment(meta)
 	if err != nil {
 		return meta, err
@@ -610,45 +641,67 @@ func (s *SegmentStore) newestHeight() (newest uint64, ok bool) {
 	return newest, ok
 }
 
+// sealed
+// What sealing produced: the segment's hash (empty in a mutable store,
+// which never transports a segment) and the index records for it.
+// Whoever writes the segment already knows where every value landed,
+// so the index is built from these rather than by reading the segment
+// back off disk.
+type sealed struct {
+	hash    string
+	order   [][32]byte
+	entries map[[32]byte]*DBBKey
+}
+
 // promoteLiveFile
 // Finish the live file's header, make it durable, and rename it into
 // place as a sealed segment.  No record is copied.
-func (s *SegmentStore) promoteLiveFile(dataPath string) (hash string, count uint64, err error) {
-	count = s.liveRecords
+func (s *SegmentStore) promoteLiveFile(dataPath string) (sl sealed, err error) {
+	count := s.liveRecords
 	if err = s.liveFile.Flush(); err != nil {
-		return "", 0, err
+		return sl, err
 	}
 	var header [segDataHdrSize]byte
 	binary.BigEndian.PutUint32(header[:], segmentMagic)
 	binary.BigEndian.PutUint32(header[4:], segmentVersion)
 	binary.BigEndian.PutUint64(header[16:], count)
 	if err = s.liveFile.WriteAt(0, header[:]); err != nil {
-		return "", 0, err
+		return sl, err
 	}
 	if err = s.liveFile.File.Sync(); err != nil {
-		return "", 0, err
+		return sl, err
 	}
 	livePath := s.liveFile.Filename
 	if err = s.liveFile.File.Close(); err != nil {
-		return "", 0, err
+		return sl, err
 	}
 	s.liveFile.File = nil
 	if err = os.Rename(livePath, dataPath); err != nil {
-		return "", 0, err
+		return sl, err
 	}
 	if err = syncDir(s.Directory); err != nil {
-		return "", 0, err
+		return sl, err
 	}
-	if hash, _, err = hashAndCount(dataPath); err != nil {
-		return "", 0, err
+
+	// The rename moved no bytes, so the live tail's offsets are the
+	// sealed segment's offsets
+	sl.entries = s.live
+	sl.order = make([][32]byte, 0, len(s.live))
+	for key := range s.live {
+		sl.order = append(sl.order, key)
 	}
-	return hash, count, nil
+	if !s.Mutable { // Immutable segments are transported; a peer verifies this
+		if sl.hash, _, err = hashAndCount(dataPath); err != nil {
+			return sl, err
+		}
+	}
+	return sl, nil
 }
 
 // rewriteLiveFile
 // Write the live tail's newest record per key to a new sealed segment,
 // dropping records shadowed by later writes
-func (s *SegmentStore) rewriteLiveFile(dataPath string) (hash string, count uint64, err error) {
+func (s *SegmentStore) rewriteLiveFile(dataPath string) (sl sealed, err error) {
 	keys := make([][32]byte, 0, len(s.live))
 	for key := range s.live {
 		keys = append(keys, key)
@@ -658,7 +711,7 @@ func (s *SegmentStore) rewriteLiveFile(dataPath string) (hash string, count uint
 	tmpPath := dataPath + segTmpSuffix
 	f, err := os.Create(tmpPath)
 	if err != nil {
-		return "", 0, err
+		return sl, err
 	}
 	defer func() {
 		if f != nil {
@@ -667,15 +720,24 @@ func (s *SegmentStore) rewriteLiveFile(dataPath string) (hash string, count uint
 		}
 	}()
 
-	h := sha256.New()
-	out := io.MultiWriter(f, h)
+	bw := bufio.NewWriterSize(f, segWriteBuffer)
+	var h hash.Hash
+	var out io.Writer = bw
+	if !s.Mutable { // Immutable segments are transported; a peer verifies this
+		h = sha256.New()
+		out = io.MultiWriter(bw, h)
+	}
 	var header [segDataHdrSize]byte
 	binary.BigEndian.PutUint32(header[:], segmentMagic)
 	binary.BigEndian.PutUint32(header[4:], segmentVersion)
 	binary.BigEndian.PutUint64(header[16:], uint64(len(keys)))
 	if _, err = out.Write(header[:]); err != nil {
-		return "", 0, err
+		return sl, err
 	}
+
+	// Record where each value lands, so the index needs no read-back
+	sl.order, sl.entries = keys, make(map[[32]byte]*DBBKey, len(keys))
+	offset := uint64(segDataHdrSize)
 
 	var recHdr [segRecHdrSize]byte
 	value := make([]byte, 0, 1024)
@@ -686,30 +748,35 @@ func (s *SegmentStore) rewriteLiveFile(dataPath string) (hash string, count uint
 		}
 		value = value[:dbb.Length]
 		if err = s.liveFile.ReadAt(dbb.Offset, value); err != nil {
-			return "", 0, err
+			return sl, err
 		}
 		copy(recHdr[:32], key[:])
 		binary.BigEndian.PutUint64(recHdr[32:], dbb.Length)
 		if _, err = out.Write(recHdr[:]); err != nil {
-			return "", 0, err
+			return sl, err
 		}
 		if _, err = out.Write(value); err != nil {
-			return "", 0, err
+			return sl, err
 		}
+		sl.entries[key] = &DBBKey{Offset: offset + segRecHdrSize, Length: dbb.Length}
+		offset += segRecHdrSize + dbb.Length
+	}
+	if err = bw.Flush(); err != nil {
+		return sl, err
 	}
 	if err = f.Sync(); err != nil {
-		return "", 0, err
+		return sl, err
 	}
 	if err = f.Close(); err != nil {
 		f = nil
-		return "", 0, err
+		return sl, err
 	}
 	f = nil
 	if err = os.Rename(tmpPath, dataPath); err != nil {
-		return "", 0, err
+		return sl, err
 	}
 	if err = syncDir(s.Directory); err != nil {
-		return "", 0, err
+		return sl, err
 	}
 
 	// The old live file is superseded by the sealed segment
@@ -718,7 +785,10 @@ func (s *SegmentStore) rewriteLiveFile(dataPath string) (hash string, count uint
 		s.liveFile.File = nil
 	}
 	os.Remove(s.liveFile.Filename)
-	return fmt.Sprintf("%x", h.Sum(nil)), uint64(len(keys)), nil
+	if h != nil {
+		sl.hash = fmt.Sprintf("%x", h.Sum(nil))
+	}
+	return sl, nil
 }
 
 // Compact
@@ -731,7 +801,21 @@ func (s *SegmentStore) rewriteLiveFile(dataPath string) (hash string, count uint
 func (s *SegmentStore) Compact(height uint64) (meta SegmentMeta, err error) {
 	s.Mutex.Lock()
 	defer s.Mutex.Unlock()
+	return s.compact(height)
+}
 
+// CompactNext
+// Compact at the next available height.  The Dyna layer numbers its
+// segments by generation rather than by block height, so it compacts
+// by generation too.
+func (s *SegmentStore) CompactNext() (meta SegmentMeta, err error) {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+	return s.compact(s.nextHeight())
+}
+
+// compact is Compact; the caller must hold the Mutex
+func (s *SegmentStore) compact(height uint64) (meta SegmentMeta, err error) {
 	if len(s.segments) == 0 {
 		return meta, nil
 	}
@@ -763,6 +847,16 @@ func (s *SegmentStore) Compact(height uint64) (meta SegmentMeta, err error) {
 		}
 	}
 
+	// A single generation holding one record per key has nothing to
+	// reclaim: rewriting it would copy every value to produce the same
+	// file.  The Dyna layer compacts on a write count, so it lands here
+	// whenever a compaction has already run since the last seal.  The
+	// meta returned is the standing generation's, at its own height --
+	// not the height asked for, since no segment was written.
+	if len(s.segments) == 1 && int64(len(winners)) == s.segments[0].records {
+		return s.segments[0].meta, nil
+	}
+
 	keys := make([][32]byte, 0, len(winners))
 	for key := range winners {
 		keys = append(keys, key)
@@ -783,8 +877,13 @@ func (s *SegmentStore) Compact(height uint64) (meta SegmentMeta, err error) {
 		}
 	}()
 
-	h := sha256.New()
-	out := io.MultiWriter(f, h)
+	bw := bufio.NewWriterSize(f, segWriteBuffer)
+	var h hash.Hash
+	var out io.Writer = bw
+	if !s.Mutable { // Immutable segments are transported; a peer verifies this
+		h = sha256.New()
+		out = io.MultiWriter(bw, h)
+	}
 	var header [segDataHdrSize]byte
 	binary.BigEndian.PutUint32(header[:], segmentMagic)
 	binary.BigEndian.PutUint32(header[4:], segmentVersion)
@@ -792,6 +891,11 @@ func (s *SegmentStore) Compact(height uint64) (meta SegmentMeta, err error) {
 	if _, err = out.Write(header[:]); err != nil {
 		return meta, err
 	}
+
+	// Record where each value lands, so the index needs no read-back
+	entries := make(map[[32]byte]*DBBKey, len(keys))
+	offset := uint64(segDataHdrSize)
+
 	var recHdr [segRecHdrSize]byte
 	for _, key := range keys {
 		w := winners[key]
@@ -807,6 +911,11 @@ func (s *SegmentStore) Compact(height uint64) (meta SegmentMeta, err error) {
 		if _, err = out.Write(value); err != nil {
 			return meta, err
 		}
+		entries[key] = &DBBKey{Offset: offset + segRecHdrSize, Length: uint64(len(value))}
+		offset += segRecHdrSize + uint64(len(value))
+	}
+	if err = bw.Flush(); err != nil {
+		return meta, err
 	}
 	if err = f.Sync(); err != nil {
 		return meta, err
@@ -823,11 +932,14 @@ func (s *SegmentStore) Compact(height uint64) (meta SegmentMeta, err error) {
 		return meta, err
 	}
 	indexPath := strings.TrimSuffix(dataPath, segDataSuffix) + segIndexSuffix
-	if err = buildIndexFor(dataPath, indexPath); err != nil {
+	if err = writeIndexFile(indexPath, keys, entries); err != nil {
 		return meta, err
 	}
 
-	meta = SegmentMeta{Height: height, File: dataName, Count: uint64(len(keys)), Hash: fmt.Sprintf("%x", h.Sum(nil))}
+	meta = SegmentMeta{Height: height, File: dataName, Count: uint64(len(keys)), Hash: ""}
+	if h != nil {
+		meta.Hash = fmt.Sprintf("%x", h.Sum(nil))
+	}
 	seg, err := s.openSegment(meta)
 	if err != nil {
 		return meta, err
@@ -1015,12 +1127,18 @@ func buildIndexFor(dataPath, indexPath string) (err error) {
 	size := uint64(info.Size())
 
 	// Scan the records.  Later records win, matching lookup order.
+	// The scan is sequential, so it reads through a buffer rather than
+	// issuing a read per record.
+	if _, err = f.Seek(segDataHdrSize, io.SeekStart); err != nil {
+		return err
+	}
+	r := bufio.NewReaderSize(f, segWriteBuffer)
 	entries := make(map[[32]byte]*DBBKey)
 	var order [][32]byte
 	offset := uint64(segDataHdrSize)
 	var recHdr [segRecHdrSize]byte
 	for offset+segRecHdrSize <= size {
-		if _, err = f.ReadAt(recHdr[:], int64(offset)); err != nil {
+		if _, err = io.ReadFull(r, recHdr[:]); err != nil {
 			return err
 		}
 		var key [32]byte
@@ -1030,13 +1148,24 @@ func buildIndexFor(dataPath, indexPath string) (err error) {
 		if valueOffset+length > size {
 			return fmt.Errorf("%s is truncated at offset %d", dataPath, offset)
 		}
+		if _, err = r.Discard(int(length)); err != nil { // The index holds offsets, not values
+			return err
+		}
 		if _, seen := entries[key]; !seen {
 			order = append(order, key)
 		}
 		entries[key] = &DBBKey{Offset: valueOffset, Length: length}
 		offset = valueOffset + length
 	}
+	return writeIndexFile(indexPath, order, entries)
+}
 
+// writeIndexFile
+// Write a segment's index from records already in memory: the keys and
+// where each one's value sits in the data file.  Sealing and
+// compaction both know that as they write, so neither has to read the
+// segment back to index it.
+func writeIndexFile(indexPath string, order [][32]byte, entries map[[32]byte]*DBBKey) (err error) {
 	buff := make([]byte, 0, len(order)*DBKeyFullSize)
 	bloom := NewBloomSizedForKeys(uint64(len(order)), 3)
 	for _, key := range order {
@@ -1084,6 +1213,27 @@ func buildIndexFor(dataPath, indexPath string) (err error) {
 		return err
 	}
 	return syncDir(filepath.Dir(indexPath))
+}
+
+// identify
+// The manifest identity of a segment file on disk.  An immutable
+// store's segments travel to peers, so they carry a SHA-256; a mutable
+// store's never leave the node, and hashing one on every open would be
+// a full read of the store for nothing.
+func (s *SegmentStore) identify(path string) (hash string, count uint64, err error) {
+	if !s.Mutable {
+		return hashAndCount(path)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return "", 0, err
+	}
+	defer f.Close()
+	var header [segDataHdrSize]byte
+	if _, err = f.ReadAt(header[:], 0); err != nil {
+		return "", 0, err
+	}
+	return "", binary.BigEndian.Uint64(header[16:]), nil
 }
 
 // hashAndCount

--- a/database/segstore_bench_test.go
+++ b/database/segstore_bench_test.go
@@ -207,3 +207,114 @@ func BenchmarkSegmentStoreGet(b *testing.B) {
 		}
 	}
 }
+
+// TestDynaCostComparison
+// The Dyna layer's workload is overwrites: a fixed set of state keys
+// rewritten every block.  What that costs is dominated by two things
+// -- what a Put does beyond appending the value, and what reclaiming
+// the overwritten bytes costs.
+//
+// v1 (KFile, history disabled) writes the value, rewrites the key
+// record, and relocates key bins as they fill; Compress copies every
+// live value into a new values file and then rewrites every key offset.
+// v2 (a mutable SegmentStore) appends the value and inserts into a map;
+// Compress writes one new sealed generation and commits it with a
+// single manifest rename.
+func TestDynaCostComparison(t *testing.T) {
+	if testing.Short() {
+		t.Skip("measurement; skipped in -short")
+	}
+	const keyCount = 50_000       // Distinct state keys
+	const rounds = 8              // Times each is rewritten
+	const compressEvery = 100_000 // Writes between compactions
+	const sealLimit = 25_000      // v2 live-tail bound, in records
+
+	base := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(base)
+	require.NoError(t, os.MkdirAll(base, os.ModePerm)) // NewKV creates only its own directory
+	defer os.RemoveAll(base)
+
+	keys := make([][32]byte, keyCount)
+	kr := NewFastRandom([]byte{121})
+	for i := range keys {
+		keys[i] = kr.NextHash()
+	}
+
+	// --- v1: KFile with history disabled, compacted by KV.Compress ---
+	v1Dir := filepath.Join(base, "v1")
+	v1, err := NewKV(false, v1Dir, 1024, 100_000, 50)
+	require.NoError(t, err)
+	vr := NewFastRandom([]byte{121, 121})
+	written := 0
+	start := time.Now()
+	for round := 0; round < rounds; round++ {
+		for i := range keys {
+			require.NoError(t, v1.Put(keys[i], vr.RandBuff(100, 300)))
+			if written++; written%compressEvery == 0 {
+				require.NoError(t, v1.Compress())
+			}
+		}
+	}
+	require.NoError(t, v1.Compress())
+	v1Elapsed := time.Since(start)
+	require.NoError(t, v1.Close())
+	v1Size := dirSize(t, v1Dir)
+
+	// --- v2: mutable SegmentStore, compacted by seal + Compact ---
+	v2Dir := filepath.Join(base, "v2")
+	v2, err := NewSegmentStore(v2Dir, true)
+	require.NoError(t, err)
+	vr = NewFastRandom([]byte{121, 121})
+	written = 0
+	start = time.Now()
+	for round := 0; round < rounds; round++ {
+		for i := range keys {
+			require.NoError(t, v2.Put(keys[i], vr.RandBuff(100, 300)))
+			if v2.LiveRecords() >= sealLimit { // What KV2.sealDynaIfFull does
+				_, err = v2.SealNext()
+				require.NoError(t, err)
+			}
+			if written++; written%compressEvery == 0 {
+				_, err = v2.SealNext()
+				require.NoError(t, err)
+				_, err = v2.CompactNext()
+				require.NoError(t, err)
+			}
+		}
+	}
+	_, err = v2.SealNext()
+	require.NoError(t, err)
+	_, err = v2.CompactNext()
+	require.NoError(t, err)
+	v2Elapsed := time.Since(start)
+	require.NoError(t, v2.Close())
+	v2Size := dirSize(t, v2Dir)
+
+	// Both layers must still answer correctly
+	v1, err = OpenKV(v1Dir)
+	require.NoError(t, err)
+	v2, err = OpenSegmentStore(v2Dir)
+	require.NoError(t, err)
+	for i := range keys {
+		a, err := v1.Get(keys[i])
+		require.NoErrorf(t, err, "v1 key %d", i)
+		b, err := v2.Get(keys[i])
+		require.NoErrorf(t, err, "v2 key %d", i)
+		require.Equalf(t, a, b, "layers disagree on key %d", i)
+	}
+	require.NoError(t, v1.Close())
+	require.NoError(t, v2.Close())
+
+	total := keyCount * rounds
+	rate := func(d time.Duration) string {
+		return humanize.Comma(int64(float64(total) / d.Seconds()))
+	}
+	fmt.Printf("Dyna layer: %s writes over %s keys, compacting every %s\n",
+		humanize.Comma(int64(total)), humanize.Comma(keyCount), humanize.Comma(compressEvery))
+	fmt.Printf("  %-28s %8s %14s %12s\n", "", "seconds", "puts/s", "on disk")
+	fmt.Printf("  %-28s %8.2f %14s %12s\n", "v1 kfile + Compress",
+		v1Elapsed.Seconds(), rate(v1Elapsed), humanize.Bytes(uint64(v1Size)))
+	fmt.Printf("  %-28s %8.2f %14s %12s\n", "v2 segments + Compact",
+		v2Elapsed.Seconds(), rate(v2Elapsed), humanize.Bytes(uint64(v2Size)))
+	fmt.Printf("  speedup: %.1fx\n", v1Elapsed.Seconds()/v2Elapsed.Seconds())
+}

--- a/docs/design/block-segmentation.md
+++ b/docs/design/block-segmentation.md
@@ -60,13 +60,14 @@ sequentially and the import writes it sequentially.
 - **Dyna layer**: state is mutable and belongs to a *snapshot*, not a
   segment chain. A state snapshot export (same file format, whole
   layer) composes with segments: sync = latest snapshot + segments
-  since.
-- **Sealed segments as storage** (v2 direction): today segments are a
-  transport format and the DB re-indexes on import. The deeper design —
-  keeping sealed segments as the storage itself with per-segment key
-  indexes — would make sync a file copy plus manifest update, remove
-  the history file's move-and-rewrite costs, and make Compress
-  crash-atomic (#19) by replacing in-place swaps with new sealed
-  generations.
+  since. The layer is *stored* as segments now (mutable mode, newest
+  shadows oldest, compaction reclaims what the shadowing left) — but
+  its segments stay local: they are not exported by `ExportBlock` and
+  carry no hash, because a peer never receives them one at a time.
+- **Sealed segments as storage**: done, for both layers — see
+  `segment-store.md`. Sync is a file copy plus a manifest update, the
+  history file's move-and-rewrite is off the write path, and
+  compaction is crash-atomic (#19) because a new sealed generation
+  replaces the in-place swap.
 - Transport (fetching manifests/segments from peers) is the
   application's concern; the DB provides the sealed, verifiable units.

--- a/docs/design/durability.md
+++ b/docs/design/durability.md
@@ -54,9 +54,12 @@ committed block. Two mechanics make that safe:
 
 - **`KV.Compress` is not crash-atomic**: the values-file swap and the
   kfile offset rewrite are two steps; a crash between them leaves keys
-  pointing into the wrong values layout. Compress the Dyna layer at
-  quiet moments, or wait for block segmentation, which removes the
-  in-place swap entirely. Tracked separately.
+  pointing into the wrong values layout. **No longer on the database's
+  path** — the Dyna layer is a mutable `SegmentStore` and compacts by
+  writing a new sealed generation and committing it with one manifest
+  rename (issue #19). `KV.Compress` remains only for the legacy `KV`
+  and as the baseline the segment benchmarks measure against; the gap
+  is theirs, not the database's.
 - **Initial creation** (`NewKV`) is not crash-atomic — a crash during
   first-time setup can leave a partial directory. Create once, verify,
   then rely on the contract. Recovery: delete and recreate.

--- a/docs/design/segment-store.md
+++ b/docs/design/segment-store.md
@@ -1,6 +1,7 @@
 # Sealed Segments as Storage
 
-Status: implemented (`database/segstore.go`), measured 2026-08-24.
+Status: implemented (`database/segstore.go`); both KV2 layers are
+segment stores. Measured 2026-08-25.
 This is the v2 direction sketched in `block-segmentation.md`.
 
 ## The change
@@ -50,6 +51,21 @@ ToDo named.
 sealed segments: **4,927 ns/op vs 5,853 ns/op** for v1's KV — ~16%
 faster, without v1's `history.dat` bin relocation on the write side.
 
+**Sealing does not read the segment back.** A seal (or a compaction)
+knows where every value landed as it writes it, so it builds the index
+from those records rather than rescanning the file it just produced.
+That took a 25,000-key seal from ~56 ms to ~49 ms; the scan it replaced
+issued one read per record. `buildIndexFor` still exists for the cases
+that genuinely arrive with only a file — an imported segment, or one
+adopted in recovery — and now scans through a buffer.
+
+**A mutable store does not hash its segments.** The SHA-256 in the
+manifest is what a peer checks against what it was sent. Dyna segments
+are never sent anywhere: they hold state, which a node rebuilds or
+snapshots rather than syncing segment by segment. Hashing them would
+cost a full read of the store on every seal and every open, to verify
+bytes against nothing.
+
 **No move-and-rewrite.** `HistoryFile.UpdateKeySet` relocates a whole
 key bin whenever it outgrows its slot. Sealed segments never move, so
 a write costs what it weighs.
@@ -57,10 +73,17 @@ a write costs what it weighs.
 **Compaction is crash-atomic (issue #19).** `Compact(height)` writes a
 new generation holding only live keys, fsyncs it, and commits by
 replacing the manifest — one atomic rename. There is no window where
-keys and values disagree; a crash before the commit leaves the old
-generation in force, and the orphaned file is swept on the next open.
-Measured: ten sealed generations of overwrites compact to one, ~90% of
-bytes reclaimed, values unchanged.
+keys and values disagree. Measured: ten sealed generations of
+overwrites compact to one, ~90% of bytes reclaimed, values unchanged.
+
+A crash before that commit is safe but not free. The compacted file
+sits above every height the manifest names, so the recovery rule below
+adopts it as the newest segment rather than deleting it — correct,
+since newest wins and it holds every live key, but the old generation
+it was meant to replace is still on disk. What the crash costs is that
+space, until the next compaction. (An earlier draft of this document
+said the orphan was swept; it is adopted. `TestDynaCompressCrashMidway`
+pins the behaviour.)
 
 ## Crash recovery
 
@@ -98,10 +121,32 @@ record from a crash mid-write is dropped.
    The Perm write path is now an append plus a map insert: no history
    push, no kfile rewrite, no bin relocation, and no `Stat` per put.
 
-2. Next — use it as the Dyna layer; mutable mode plus `Compact`
-   retires `KV.Compress` and #19 with it.
-3. Then — delete the now-unused Perm paths in `KFile`/`HistoryFile`
-   (`PushHistory` and the bin relocation logic).
+2. **Done** — `SegmentStore` is KV2's Dyna layer too, in mutable mode.
+   `KV2.Compress` is now a seal plus a `Compact`, so the layer's
+   compaction is crash-atomic and `KV.Compress` is off the database's
+   path (#19). The Dyna layer seals on **physical records**, not
+   distinct keys: a mutable layer leaves one record per write, so a
+   handful of hot state keys rewritten every block would hold the key
+   count flat while the tail — replayed in full on every open — grew
+   without bound.
+
+   Measured on the layer's own workload (`TestDynaCostComparison`:
+   400,000 writes over 50,000 keys, compacting every 100,000):
+
+   | | puts/s | on disk |
+   |---|---|---|
+   | v1 kfile + `KV.Compress` | 136,000–171,000 | 12 MB |
+   | v2 segments + `Compact` | 223,000–248,000 | 14 MB |
+
+   ~1.5×, and the write path no longer has a two-file swap to crash in
+   the middle of. The extra ~2 MB is the 40-byte record header each
+   value carries in a segment; v1 stores values bare and keeps its keys
+   in a separate file.
+
+3. Next — delete the now-unused Perm paths in `KFile`/`HistoryFile`
+   (`PushHistory` and the bin relocation logic), and drop `offsetsCnt`
+   and `MaxCachedBlocks` from `NewKV2`/`NewKVShard`, which no longer
+   reach anything.
 4. Then — wire `ShardWriter.Flush` to `Seal` so a block boundary is one
    durability, sync, and compaction boundary.
 
@@ -109,6 +154,14 @@ Not yet done here: a per-segment key count cap (segments grow with the
 seal cadence; a size-triggered seal or a tiered merge keeps the
 segment count bounded on long chains), and reading a value with one
 `ReadAt` on the value bytes rather than through the record header.
+
+Sealing is also still where the Perm layer's time goes — about 60% of
+it at a 25,000-key block, of which the largest remaining piece is the
+SHA-256 read-back of the segment just written. It cannot be folded
+into the write, because the record count in the header is not known
+until the seal and the hash covers the header. Hashing the body alone
+would let the write stream it, at the cost of a transport format that
+no longer authenticates its own header.
 
 ### Divergence detection on import
 


### PR DESCRIPTION
Step 2 of the segment migration. `KV2`'s Dyna layer was a `KFile` with history disabled plus a values file, compacted by `KV.Compress`. It is now a `SegmentStore` in mutable mode, compacted by a seal plus a `Compact`.

Both `KV2` layers are segment stores now. What differs is the rule for a repeated key: Perm rejects a conflicting value, so its sealed segments partition the key space and a peer syncs them by copying files; Dyna lets the newer write shadow the older, so its segments overlap and `Compress` reclaims what the shadowing left behind.

## Why

Issue #19. `KV.Compress` swapped the values file into place and *then* rewrote every key offset — two steps, and a crash between them left keys pointing into the wrong values layout, so reads returned wrong bytes with no error. Compaction on segments writes a new sealed generation, fsyncs it, and commits by replacing the manifest: one atomic rename.

`KV.Compress` is now off the database's path. It stays for the legacy `KV` and as the v1 baseline the segment benchmarks measure against.

## Measured

`TestDynaCostComparison` — 400,000 writes over 50,000 keys, compacting every 100,000, three consecutive runs:

| | puts/s | on disk |
|---|---|---|
| v1 kfile + `KV.Compress` | 136,000–171,000 | 12 MB |
| v2 segments + `Compact` | 223,000–248,000 | 14 MB |

The extra ~2 MB is the 40-byte record header each value carries in a segment; v1 stores values bare with its keys in a separate file.

**The first cut of this was not faster** — it measured at 0.9×. Sealing was the cost: every seal read back the segment it had just written, one `pread` per record, to build the index. That is fixed below, and I A/B'd the fix against a worktree at `main` so it isn't credited with more than it earned (on this workload it is within noise; the 1.5× is the migration itself).

## Seals on records, not keys

The Dyna layer seals when its live tail reaches `SealLimit` **physical records**, where Perm counts distinct keys. A mutable layer leaves one record per write, so a handful of hot state keys rewritten every block would hold the key count flat while the tail — replayed in full on every open — grew without bound. `TestDynaLiveTailBounded` is the regression test.

## Seal-path changes (both layers)

- **A seal no longer reads the segment back.** It knows where every value landed as it writes it, so it builds the index from those records. A 25,000-key seal went from ~56 ms to ~49 ms. `buildIndexFor` stays for the cases that genuinely arrive with only a file — an imported segment, one adopted in recovery — and now scans through a buffer instead of issuing a read per record.
- **A mutable store does not hash its segments.** The SHA-256 in the manifest is what a peer checks against what it was sent; Dyna segments are never sent anywhere. Hashing them would cost a full read of the store on every seal and every open to verify bytes against nothing.
- **Compacting a single generation that already holds one record per key is a no-op** rather than a rewrite producing the same file. `KVShard` compacts on a write count, so it lands here often.
- `SealNext`/`CompactNext` pick their height under the same lock they seal under. `SealNext` previously read the height, dropped the lock, and re-took it.

## A correction to the last PR's docs

`docs/design/segment-store.md` said a crash between a compaction's rename and its manifest commit leaves the orphan to be swept. It does not — the compacted file sits above every height the manifest names, which is the same rule that recovers an interrupted seal, so it is **adopted** as the newest segment. Reads stay correct (newest wins, and it holds every live key); what the crash costs is the space the old generation still occupies until the next compaction. `TestDynaCompressCrashMidway` pins the behaviour and the doc now says so.

## Tests

New in `database/dyna_test.go`: `TestDynaCompressReclaims`, `TestDynaCompressIsIdempotent`, `TestDynaLiveTailBounded`, `TestDynaCompressCrashMidway`, `TestKV2PermOverwriteSurvivesCompress`. New benchmark `TestDynaCostComparison`.

Suite green under `-race` (761s), skipping four unguarded load tests — `TestBuildBig` (200M keys), `TestBuildBig2` (20M), `TestKVShard_2` (10M), `TestBuildBigFor3Minutes`. None of them call `t.Skip` or check `testing.Short()`, so a plain `go test ./...` runs all four; `TestBuildBig` alone wrote 26 GB before I stopped it. Guarding them is a one-line-each change I have not made here.

## Not in scope

`offsetsCnt` and `MaxCachedBlocks` on `NewKV2`/`NewKVShard` no longer reach anything, but removing them touches ~20 call sites plus `NewShardDBViews`'s public signature. Queued with step 3 (deleting the dead `KFile`/`HistoryFile` Perm paths) and noted in the design doc's integration path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtJ86J2ge2Y2sW69Qeb737
