### PR TITLE
Load tests are opt-in behind -load

### DIFF
--- a/database/kv_shard_test.go
+++ b/database/kv_shard_test.go
@@ -68,6 +68,7 @@ func TestKVShard(t *testing.T) {
 }
 
 func TestKVShard_2(t *testing.T) {
+	skipUnlessLoad(t)
 	dir := filepath.Join(os.TempDir(), "BigDB")
 
 	//dir, rm := MakeDir()
@@ -185,6 +186,7 @@ func TestKVShard_2(t *testing.T) {
 }
 
 func TestBuildBig(t *testing.T) {
+	skipUnlessLoad(t)
 	dir := filepath.Join(os.TempDir(), "BigDB")
 
 	const numPermKeys = 200_000_000
@@ -240,6 +242,7 @@ func TestBuildBig(t *testing.T) {
 }
 
 func TestBuildBig2(t *testing.T) {
+	skipUnlessLoad(t)
 	dir := filepath.Join(os.TempDir(), "BigDB")
 
 	const numPermKeys = 20_000_000

--- a/database/loadtest_test.go
+++ b/database/loadtest_test.go
@@ -1,0 +1,28 @@
+package blockchainDB
+
+import (
+	"flag"
+	"testing"
+)
+
+// The load tests in this package build databases measured in tens of
+// gigabytes and run for tens of minutes to hours: TestBuildBig alone
+// writes 200 million keys.  They are opt-in, so that `go test ./...`
+// stays a suite someone can actually wait for.
+//
+// A flag rather than an environment variable or a config file, because
+// a misspelled flag is a hard error before any test runs -- `go test
+// -lod ./database/` exits 2 -- while a misspelled variable or config
+// key silently does not opt in, and the run looks like a pass of tests
+// that never executed.
+var runLoadTests = flag.Bool("load", false, "run the multi-GB load tests (hours; tens of GB in TMPDIR)")
+
+// skipUnlessLoad
+// Skip a load test unless -load was passed.  The skip message names
+// the flag, so the suite's own output says how to run what it skipped.
+func skipUnlessLoad(t *testing.T) {
+	t.Helper()
+	if !*runLoadTests {
+		t.Skip("load test; pass -load to run (hours; tens of GB in TMPDIR)")
+	}
+}

--- a/database/profile_test.go
+++ b/database/profile_test.go
@@ -10,6 +10,7 @@ import (
 
 // TestBuildBigFor3Minutes runs a modified version of TestBuildBig that only runs for 3 minutes
 func TestBuildBigFor3Minutes(t *testing.T) {
+	skipUnlessLoad(t)
 	// Create memory profile file
 	f, err := os.Create("memprofile.out")
 	if err != nil {


### PR DESCRIPTION
`TestBuildBig` writes 200 million keys. `TestBuildBig2` writes 20 million, `TestKVShard_2` ten million, and `TestBuildBigFor3Minutes` runs for three minutes by design. None of them checked anything before running, so a plain `go test ./...` ran all four — 31 minutes and 26 GB in `TMPDIR` before I stopped it, with no sign it was close to done. The package's real suite is 338 seconds.

They now skip unless `-load` is passed.

## Why a flag

Not an environment variable and not a config file: a misspelled flag is a hard error *before any test runs*, while a misspelled variable or config key silently fails to opt in, and the run then looks like a pass of tests that never executed.

| | result |
|---|---|
| `go test ./database/` | four skips, 338s |
| `go test -load ./database/` | runs them |
| `go test -lod ./database/` | `exit 2`, `FAIL`, before any test |

The skip message names the flag — `--- SKIP: TestBuildBig (load test; pass -load to run)` — so the suite's own output says how to run what it skipped, with nothing to look up.

## Note

Three of the four are not really tests. `TestBuildBigFor3Minutes` has no assertions; `TestBuildBig` and `TestBuildBig2` have one each, the constructor error check. They print throughput. The flag makes them harmless where they are, but `cmd/dbbench` is where they belong. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtJ86J2ge2Y2sW69Qeb737