### PR TITLE
Fix three silent data losses in SegmentStore crash recovery

### DIFF
--- a/database/kv_shard.go
+++ b/database/kv_shard.go
@@ -70,7 +70,9 @@ func NewKVShard(directory string, offsetsCnt, keyLimit uint64, MaxCachedBlocks i
 // Find the right shard, and put the key/value in the DynaKV in the shard
 func (k *KVShard) PutDyna(key [32]byte, value []byte) (err error) {
 	index := ShardIndex(key[:])
-	k.Shards[index].Open()
+	if err = k.Shards[index].Open(); err != nil { // A failed load leaves the
+		return // shard empty, so a dropped error reads as "not found"
+	}
 	if writes, err := k.Shards[index].PutDyna(key, value); err != nil {
 		return err
 	} else if writes > 5000 {
@@ -83,7 +85,9 @@ func (k *KVShard) PutDyna(key [32]byte, value []byte) (err error) {
 // Find the right shard, and put the key/value in the PermKV in the shard
 func (k *KVShard) PutPerm(key [32]byte, value []byte) (err error) {
 	index := ShardIndex(key[:])
-	k.Shards[index].Open()
+	if err = k.Shards[index].Open(); err != nil { // A failed load leaves the
+		return // shard empty, so a dropped error reads as "not found"
+	}
 	if writes, err := k.Shards[index].PutPerm(key, value); err != nil {
 		return err
 	} else if writes > 5000 {
@@ -96,7 +100,9 @@ func (k *KVShard) PutPerm(key [32]byte, value []byte) (err error) {
 // Find the right shard, and put the key/value in said shard
 func (k *KVShard) Put(key [32]byte, value []byte) (err error) {
 	index := ShardIndex(key[:])
-	k.Shards[index].Open()
+	if err = k.Shards[index].Open(); err != nil { // A failed load leaves the
+		return // shard empty, so a dropped error reads as "not found"
+	}
 	if writes, err := k.Shards[index].Put(key, value); err != nil {
 		return err
 	} else if writes > 5000 {
@@ -109,7 +115,9 @@ func (k *KVShard) Put(key [32]byte, value []byte) (err error) {
 // Find the right shard, and extract the value from the DynaKV in the shard
 func (k *KVShard) GetDyna(key [32]byte) (value []byte, err error) {
 	index := ShardIndex(key[:])
-	k.Shards[index].Open()
+	if err = k.Shards[index].Open(); err != nil { // A failed load leaves the
+		return // shard empty, so a dropped error reads as "not found"
+	}
 	if value, err = k.Shards[index].GetDyna(key); err != nil {
 		return nil, err
 	}
@@ -120,7 +128,9 @@ func (k *KVShard) GetDyna(key [32]byte) (value []byte, err error) {
 // Find the right shard, and extract the value from the PermKV in the shard
 func (k *KVShard) GetPerm(key [32]byte) (value []byte, err error) {
 	index := ShardIndex(key[:])
-	k.Shards[index].Open()
+	if err = k.Shards[index].Open(); err != nil { // A failed load leaves the
+		return // shard empty, so a dropped error reads as "not found"
+	}
 	if value, err = k.Shards[index].GetPerm(key); err != nil {
 		return nil, err
 	}
@@ -131,7 +141,9 @@ func (k *KVShard) GetPerm(key [32]byte) (value []byte, err error) {
 // Find the right shard, and extract the value from said shard
 func (k *KVShard) Get(key [32]byte) (value []byte, err error) {
 	index := ShardIndex(key[:])
-	k.Shards[index].Open()
+	if err = k.Shards[index].Open(); err != nil { // A failed load leaves the
+		return // shard empty, so a dropped error reads as "not found"
+	}
 	if value, err = k.Shards[index].Get(key); err != nil {
 		return nil, err
 	}
@@ -144,6 +156,9 @@ func (k *KVShard) Get(key [32]byte) (value []byte, err error) {
 // ExportBlock calls it as its first step.
 func (k *KVShard) SealBlock(height uint64) (err error) {
 	for i, shard := range k.Shards {
+		if err = shard.Open(); err != nil {
+			return fmt.Errorf("shard %d: %w", i, err)
+		}
 		if _, err = shard.Seal(height); err != nil {
 			return fmt.Errorf("shard %d: %w", i, err)
 		}
@@ -154,9 +169,12 @@ func (k *KVShard) SealBlock(height uint64) (err error) {
 // Compress
 // Compress all the shards
 func (k *KVShard) Compress() (err error) {
-	for _, kvs := range k.Shards {
+	for i, kvs := range k.Shards {
+		if err = kvs.Open(); err != nil {
+			return fmt.Errorf("shard %d: %w", i, err)
+		}
 		if err = kvs.Compress(); err != nil {
-			return err
+			return fmt.Errorf("shard %d: %w", i, err)
 		}
 	}
 	return nil

--- a/database/segstore.go
+++ b/database/segstore.go
@@ -309,8 +309,19 @@ func (s *SegmentStore) openSegment(meta SegmentMeta) (seg *segment, err error) {
 // lookups use.
 func (s *SegmentStore) openLive() (err error) {
 	path := filepath.Join(s.Directory, segLiveName)
-	if _, err = os.Stat(path); err != nil {
+	fi, err := os.Stat(path)
+	if err != nil {
 		return s.newLiveFile() // No live tail (e.g. crash right after a seal)
+	}
+	if fi.Size() < segDataHdrSize {
+		// seal() creates the new live file and leaves its header in the
+		// BFile buffer, so a crash before the first flush leaves the
+		// file existing at 0 bytes.  Such a file holds no records, so
+		// rewriting it loses nothing -- while keeping it would put the
+		// next record at offset 0 and shift the whole tail under the
+		// header, where replay reads a key fragment as a record header
+		// and silently discards the tail.
+		return s.newLiveFile()
 	}
 	if s.liveFile, err = OpenBFile(path); err != nil {
 		return err
@@ -332,6 +343,23 @@ func (s *SegmentStore) openLive() (err error) {
 		s.live[key] = &DBBKey{Offset: valueOffset, Length: length}
 		s.liveRecords++
 		offset = valueOffset + length
+	}
+
+	// Drop whatever follows the last complete record: a torn record
+	// from a crash mid-write, or bytes too few to form a header.
+	// Truncating is what makes the drop real -- leaving the bytes puts
+	// the next append after them, so every later open reads that
+	// record's key as a header and mis-parses the whole tail from
+	// there.  The bytes being discarded were never replayable, so no
+	// durable record is lost.
+	if offset < s.liveFile.EOD {
+		if err = s.liveFile.File.Truncate(int64(offset)); err != nil {
+			return err
+		}
+		if err = s.liveFile.File.Sync(); err != nil {
+			return err
+		}
+		s.liveFile.EOD = offset
 	}
 	return nil
 }
@@ -459,6 +487,25 @@ func (s *SegmentStore) writeManifest() (err error) {
 	return syncDir(s.Directory)
 }
 
+// errStoreClosed is returned by every operation that would read or
+// mutate a store whose files are shut.  Close() drops the sealed
+// segment list but leaves the live map populated, so without this an
+// operation on a closed store runs against half a store: a Seal or
+// Compact would commit a manifest built from no segments at all and
+// silently drop every sealed segment on the next open, and a Get would
+// answer "not found" for keys that are simply not loaded.  Callers
+// reopen with Open, which is cheap and safe on an already-open store.
+var errStoreClosed = errors.New("segment store is closed")
+
+// checkOpen reports whether the store can be operated on.  The caller
+// must hold the Mutex.
+func (s *SegmentStore) checkOpen() error {
+	if s.closed {
+		return errStoreClosed
+	}
+	return nil
+}
+
 // Get
 // Return the value for a key.  Checks the live tail, then the sealed
 // segments newest to oldest.
@@ -470,6 +517,9 @@ func (s *SegmentStore) Get(key [32]byte) (value []byte, err error) {
 
 // get is Get; the caller must hold the Mutex
 func (s *SegmentStore) get(key [32]byte) (value []byte, err error) {
+	if err = s.checkOpen(); err != nil {
+		return nil, err
+	}
 	if dbb, ok := s.live[key]; ok {
 		value = make([]byte, dbb.Length)
 		if err = s.liveFile.ReadAt(dbb.Offset, value); err != nil {
@@ -503,6 +553,9 @@ func (s *SegmentStore) Put(key [32]byte, value []byte) (err error) {
 
 // put is Put; the caller must hold the Mutex
 func (s *SegmentStore) put(key [32]byte, value []byte) (err error) {
+	if err = s.checkOpen(); err != nil {
+		return err
+	}
 	if !s.Mutable {
 		if existing, err := s.get(key); err == nil {
 			if bytes.Equal(existing, value) {
@@ -581,6 +634,9 @@ func (s *SegmentStore) Seal(height uint64) (meta SegmentMeta, err error) {
 
 // seal is Seal; the caller must hold the Mutex
 func (s *SegmentStore) seal(height uint64) (meta SegmentMeta, err error) {
+	if err = s.checkOpen(); err != nil {
+		return meta, err
+	}
 	if len(s.live) == 0 {
 		return meta, nil // Nothing to seal
 	}
@@ -816,6 +872,9 @@ func (s *SegmentStore) CompactNext() (meta SegmentMeta, err error) {
 
 // compact is Compact; the caller must hold the Mutex
 func (s *SegmentStore) compact(height uint64) (meta SegmentMeta, err error) {
+	if err = s.checkOpen(); err != nil {
+		return meta, err
+	}
 	if len(s.segments) == 0 {
 		return meta, nil
 	}
@@ -989,6 +1048,10 @@ func (s *SegmentStore) SegmentPaths() (metas []SegmentMeta, paths []string) {
 func (s *SegmentStore) ImportSegmentFile(path string, meta SegmentMeta) (err error) {
 	s.Mutex.Lock()
 	defer s.Mutex.Unlock()
+
+	if err = s.checkOpen(); err != nil {
+		return err
+	}
 
 	for _, seg := range s.segments {
 		if seg.meta.Height == meta.Height && seg.meta.Hash == meta.Hash {

--- a/database/segstore_test.go
+++ b/database/segstore_test.go
@@ -1,6 +1,7 @@
 package blockchainDB
 
 import (
+	"encoding/binary"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -375,4 +376,162 @@ func TestSegmentStoreGenesisHeight(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []byte("genesis"), v)
 	require.NoError(t, store.Close())
+}
+
+// TestSegmentStoreLiveTailAfterInterruptedSeal
+// Regression test: a crash between seal()'s os.Create of the new live
+// file and its first flush leaves live.dat existing at 0 bytes.
+//
+// seal() renames live.dat to seg-N.dat and calls newLiveFile(), which
+// os.Create()s a fresh live.dat (0 bytes on disk) and writes the
+// 24-byte header into the BFile *buffer*.  A crash in that window
+// leaves live.dat existing at 0 bytes.
+//
+// Abandoning the store without Close reproduces exactly that on-disk
+// state, so this needs no SIGKILL.
+func TestSegmentStoreLiveTailAfterInterruptedSeal(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
+
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+	k1, v1 := [32]byte{1}, []byte("first")
+	require.NoError(t, store.Put(k1, v1))
+	_, err = store.Seal(1)
+	require.NoError(t, err)
+
+	// The crash window: live.dat exists, header still only in memory
+	fi, err := os.Stat(filepath.Join(dir, segLiveName))
+	require.NoError(t, err, "live.dat must exist after a seal")
+	require.Equal(t, int64(0), fi.Size(), "live.dat is 0 bytes: header is buffered, not written")
+
+	// Crash here: `store` is abandoned, never closed.
+
+	s2, err := OpenSegmentStore(dir)
+	require.NoError(t, err, "reopen must succeed")
+	k2, v2 := [32]byte{2}, []byte("written after the crash, then durably closed")
+	require.NoError(t, s2.Put(k2, v2))
+	require.NoError(t, s2.Close(), "Close is the durability point")
+
+	// k2 was written and Close returned.  The contract says it survives.
+	s3, err := OpenSegmentStore(dir)
+	require.NoError(t, err)
+	got, err := s3.Get(k2)
+	require.NoError(t, err, "key lost after a completed Close")
+	require.Equal(t, v2, got)
+
+	// k1 was sealed before the crash and must also survive
+	got1, err := s3.Get(k1)
+	require.NoError(t, err, "sealed key lost")
+	require.Equal(t, v1, got1)
+	require.NoError(t, s3.Close())
+}
+
+// TestSegmentStoreClosedRejectsOperations
+// Regression test: Close() drops the sealed segment list but leaves
+// the live map populated.  Without a closed guard, a Seal or Compact
+// after Close commits a manifest built from no segments at all, and
+// the next open deletes every segment that manifest no longer names.
+func TestSegmentStoreClosedRejectsOperations(t *testing.T) {
+	dir := storeDir(t, "closed")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{57})
+	keys := make([][32]byte, 250)
+	for i := range keys {
+		keys[i] = kr.NextHash()
+		require.NoError(t, store.Put(keys[i], []byte("v")))
+		if (i+1)%50 == 0 {
+			_, err = store.SealNext()
+			require.NoError(t, err)
+		}
+	}
+	sealed := len(store.segments)
+	require.Equal(t, 5, sealed, "expected five sealed segments")
+	require.NoError(t, store.Close())
+
+	// Every operation must refuse rather than run against half a store
+	_, err = store.Get(keys[0])
+	require.ErrorIs(t, err, errStoreClosed, "Get on a closed store")
+	require.ErrorIs(t, store.Put(kr.NextHash(), []byte("v")), errStoreClosed, "Put on a closed store")
+	_, err = store.Seal(99)
+	require.ErrorIs(t, err, errStoreClosed, "Seal on a closed store")
+	_, err = store.SealNext()
+	require.ErrorIs(t, err, errStoreClosed, "SealNext on a closed store")
+	_, err = store.Compact(99)
+	require.ErrorIs(t, err, errStoreClosed, "Compact on a closed store")
+	_, err = store.CompactNext()
+	require.ErrorIs(t, err, errStoreClosed, "CompactNext on a closed store")
+
+	// and nothing they did may have reached the manifest
+	reopened, err := OpenSegmentStore(dir)
+	require.NoError(t, err)
+	require.Len(t, reopened.segments, sealed, "sealed segments lost")
+	for i, key := range keys {
+		got, err := reopened.Get(key)
+		require.NoErrorf(t, err, "key %d lost", i)
+		require.Equal(t, []byte("v"), got)
+	}
+	require.NoError(t, reopened.Close())
+}
+
+// TestSegmentStoreTornTailIsTruncated
+// Regression test: openLive stops replaying at a torn record, but the
+// bytes stay on disk unless it also truncates.  Left in place, the
+// next append lands after them, so the following open reads the torn
+// record's key as a record header and mis-parses everything written
+// since -- losing records that a completed Close made durable.
+func TestSegmentStoreTornTailIsTruncated(t *testing.T) {
+	dir := storeDir(t, "torn")
+	store, err := NewSegmentStore(dir, true) // Mutable, as the Dyna layer is
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{7})
+	before := make([][32]byte, 5)
+	for i := range before {
+		before[i] = kr.NextHash()
+		require.NoError(t, store.Put(before[i], []byte("value-before")))
+	}
+	require.NoError(t, store.Close())
+
+	// The crash: a record header reached disk, its value bytes did not
+	livePath := filepath.Join(dir, segLiveName)
+	f, err := os.OpenFile(livePath, os.O_RDWR|os.O_APPEND, 0644)
+	require.NoError(t, err)
+	var hdr [segRecHdrSize]byte
+	tornKey := kr.NextHash()
+	copy(hdr[:32], tornKey[:])
+	binary.BigEndian.PutUint64(hdr[32:], 500) // Claims 500 value bytes that never arrived
+	_, err = f.Write(hdr[:])
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// Reopen, write more, and close durably
+	s2, err := OpenSegmentStore(dir)
+	require.NoError(t, err)
+	after := make([][32]byte, 5)
+	for i := range after {
+		after[i] = kr.NextHash()
+		require.NoError(t, s2.Put(after[i], []byte("value-after")))
+	}
+	require.NoError(t, s2.Close())
+
+	// Everything durable must read back
+	s3, err := OpenSegmentStore(dir)
+	require.NoError(t, err)
+	for i, key := range before {
+		got, err := s3.Get(key)
+		require.NoErrorf(t, err, "pre-crash key %d lost", i)
+		require.Equal(t, []byte("value-before"), got)
+	}
+	for i, key := range after {
+		got, err := s3.Get(key)
+		require.NoErrorf(t, err, "post-crash key %d lost", i)
+		require.Equal(t, []byte("value-after"), got)
+	}
+	_, err = s3.Get(tornKey)
+	require.Error(t, err, "the torn record must not resolve")
+	require.NoError(t, s3.Close())
 }


### PR DESCRIPTION
Three defects in `SegmentStore`, each of which lost keys that a completed `Close` had made durable — no error, no corruption signal, just missing keys on the next open.

Found by putting compaction under a SIGKILL. `TestCrashRecovery` never called `Compress`, and `KV2` does not compact on its own (`sealPermIfFull`/`sealDynaIfFull` seal and stop there), so the compaction path had never been under a kill. Adding it produced 5 failures in 25 runs, always the same key, which led to a deterministic reproducer that needs no kill at all.

## 1. Headerless live tail

`seal()` creates the new `live.dat` with `os.Create` and only *buffers* its 24-byte header, so a crash before the first flush leaves the file at 0 bytes. `openLive` treated an existing `live.dat` as already carrying that header: it set `EOD` from the file size (0) and began replay at offset 24, so the next `Put` wrote a record at file offset **0**. Every later open then parsed 24 bytes into that record's key, read the remainder as a length, called the tail torn, and dropped every record since the seal.

The evidence, from the failing crash test:

```
expected key 200 = 1e84f1fb…092a1625 32c7d174ea2e553a
live.dat header  = 1e84f1fb…092a1625          <- first 24 bytes of the key
live rec 0 @24 key=32c7d174ea2e553a len=5526380644490373729 (fits=false)
```

Open now rewrites the header when the file is shorter than one.

## 2. No closed-store guard

No path checked `s.closed`. `Close` nils the sealed segment list but leaves the live map populated, so a `Seal` or `Compress` after `Close` committed a manifest built from **no segments at all** — and the next open deleted every segment that manifest no longer named. Measured at **500 of 550 keys lost, returning a nil error**. `Compress` after `Close`: 100 of 550.

Reads had the same split: they answered "not found" for keys that were merely unloaded. `Get`, `Put`, `Seal`, `Compact`, and `ImportSegmentFile` now refuse with `errStoreClosed`.

## 3. Torn tail not truncated

Replay stopped at a torn record but left its bytes on disk, so the next append landed after them and the following open mis-parsed everything written since. Open now truncates to the last complete record. The discarded bytes were never replayable, so no durable record is lost.

## Follow-on: reopen consistency

Guarding on `closed` made a pre-existing inconsistency load-bearing. The six `KVShard` Get/Put forwarders lazily reopen a shard; `SealBlock`, `Compress`, `ExportBlock`, and `ImportBlock` never did. Before the guard they ran against a half-closed store and silently produced wrong results; after it they would hard-fail where the rest of the layer recovers. `SealBlock` and `Compress` now reopen, naming the shard that failed.

The forwarders also discarded `Open`'s error. `load()` clears `live`, `segments`, and `liveRecords` before the first step that can fail, so a failed reopen leaves the shard empty with `closed` still set — and a dropped error turns that into "not found" for keys sitting on disk. All six now return it.

## Verification

Three regression tests: `TestSegmentStoreLiveTailAfterInterruptedSeal`, `TestSegmentStoreClosedRejectsOperations`, `TestSegmentStoreTornTailIsTruncated`. Each was confirmed to fail against the unfixed code by disabling the fixes one at a time:

```
--- FAIL: TestSegmentStoreLiveTailAfterInterruptedSeal   key lost after a completed Close
--- FAIL: TestSegmentStoreClosedRejectsOperations        Get on a closed store
--- FAIL: TestSegmentStoreTornTailIsTruncated            post-crash key 0 lost
```

Full suite green: `ok github.com/AccumulateNetwork/BlockchainDB/database 1257.230s`. `TestCrashRecovery` with compaction under the kill: 25/25 (was 5 failures in 25).

## Not fixed here

Higher-severity defects in the same subsystem, out of scope for this PR and worth their own:

- **Auto-seal heights collide with block heights.** `sealPermIfFull` seals via `SealNext` (`newest+1`), the same namespace block boundaries use, so once a shard's tail fills more often than the block number, `SealBlock`/`ExportBlock` fail permanently. Verified: 500 `PutPerm` at `sealLimit` 60 gives newest height 7, and `Seal(1)` returns `seal height 1 is not above the newest segment height 7`. Block export and peer sync die as soon as a live tail fills.
- **A failed seal leaves no live file.** `promoteLiveFile` renames `live.dat` away, then `writeIndexFile`, `openSegment`, and `writeManifest` each return on error before `newLiveFile()` runs. The store then keeps accepting writes — `BFile.Write` returns success without touching a file for anything under `BufferSize`, and `Close` skips the flush because `liveFile.File` is nil — so a transient I/O error becomes permanent silent data loss. Observed in this repo's own suite under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsJvBSuTPPVbbxiMKG6u7D