### PR TITLE
Correct auto-seal block heights, block export, and both layers' durability

### DIFF
--- a/database/crash_test.go
+++ b/database/crash_test.go
@@ -44,6 +44,22 @@ import (
 const crashChildEnv = "BDB_CRASH_CHILD_DIR"
 const crashChildStartEnv = "BDB_CRASH_CHILD_START"
 
+// crashChildModeEnv selects which durability point the child reaches at
+// each checkpoint.  Both are part of the contract and they fail
+// differently:
+//
+//	close -- Close() flushes and fsyncs both layers and shuts the files.
+//	seal  -- Seal(height) closes a block on a running store.  This is
+//	         what a node actually does per block; it does not Close, so
+//	         it is the only one that catches a layer whose writes are
+//	         still sitting in a buffer (issue #29).
+const crashChildModeEnv = "BDB_CRASH_CHILD_MODE"
+
+const (
+	crashModeClose = "close"
+	crashModeSeal  = "seal"
+)
+
 // crashSealLimit is deliberately small so that the few hundred keys a
 // round gets through before the kill still seal many times.  Seals,
 // and the compactions they enable, are the crash windows this test
@@ -98,6 +114,10 @@ func TestCrashChildProcess(t *testing.T) {
 	start, err := strconv.Atoi(startEnv)
 	require.NoErrorf(t, err, "child: %s must be an integer, got %q", crashChildStartEnv, startEnv)
 
+	mode := os.Getenv(crashChildModeEnv)
+	require.Containsf(t, []string{crashModeClose, crashModeSeal}, mode,
+		"child: %s must be %q or %q, got %q", crashChildModeEnv, crashModeClose, crashModeSeal, mode)
+
 	kv, err := OpenKV2(dir)
 	require.NoError(t, err, "child: open")
 	require.NoError(t, kv.Open(), "child: open files")
@@ -109,21 +129,53 @@ func TestCrashChildProcess(t *testing.T) {
 		if (i+1)%crashCompressEvery == 0 {
 			require.NoError(t, kv.Compress(), "child: compress")
 		}
-		if (i+1)%batch == 0 {
+		if (i+1)%batch != 0 {
+			continue
+		}
+		switch mode {
+		case crashModeClose:
 			require.NoError(t, kv.Close(), "child: close")
 			fmt.Printf("CHECKPOINT %d\n", i+1) // Durability point reached
 			require.NoError(t, kv.Open(), "child: reopen")
+		case crashModeSeal:
+			// Seal the block being accumulated rather than a counted
+			// one: a kill between a seal and its CHECKPOINT rolls the
+			// parent's start back to before that seal, and re-sealing
+			// a block the store has already closed is an error.
+			_, err := kv.Seal(kv.PermKV.BlockHeight())
+			require.NoError(t, err, "child: seal")
+			fmt.Printf("CHECKPOINT %d\n", i+1)
 		}
 	}
 }
 
 // TestCrashRecovery
-// Kill the child at random moments; verify the durability contract
+// Kill the child at random moments; verify that Close is a durability
+// point.
 func TestCrashRecovery(t *testing.T) {
+	runCrashRounds(t, crashModeClose)
+}
+
+// TestCrashRecoverySeal
+// The same contract with Seal as the durability point and no Close:
+// what a node does at a block boundary.
+//
+// This is the case issue #29 broke.  Seal made the Perm layer durable
+// and left the Dyna layer's newest writes in a 32 KB buffer, so a
+// SIGKILL here came back with permanent records -- the even-numbered
+// keys -- present and the dynamic records interleaved with them gone.
+// Close hid it, because Close flushes and fsyncs both layers.
+func TestCrashRecoverySeal(t *testing.T) {
+	runCrashRounds(t, crashModeSeal)
+}
+
+// runCrashRounds is the crash-injection loop: run the child, kill it at
+// a random moment, and verify every key it reported durable
+func runCrashRounds(t *testing.T, mode string) {
 	if os.Getenv(crashChildEnv) != "" {
 		t.Skip("running as child")
 	}
-	dir := filepath.Join(os.TempDir(), "CrashRecovery")
+	dir := filepath.Join(os.TempDir(), "CrashRecovery_"+mode)
 	os.RemoveAll(dir)
 	defer os.RemoveAll(dir)
 
@@ -143,6 +195,7 @@ func TestCrashRecovery(t *testing.T) {
 		cmd := exec.Command(os.Args[0], "-test.run", "TestCrashChildProcess$")
 		cmd.Env = append(os.Environ(),
 			crashChildEnv+"="+dir,
+			crashChildModeEnv+"="+mode,
 			crashChildStartEnv+"="+strconv.Itoa(durable))
 		stdout, err := cmd.StdoutPipe()
 		require.NoError(t, err)

--- a/database/degradation_test.go
+++ b/database/degradation_test.go
@@ -1,0 +1,392 @@
+package blockchainDB
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDegradationOverTime answers one question: does a KV2 database get
+// slower as it grows, and if so, where does the time go?
+//
+// The shape of the answer is predictable from the code, which is why it
+// is worth measuring rather than asserting.  A Get that misses walks
+// every sealed segment newest to oldest, testing each segment's bloom
+// filter and paying a binary search over any that returns a false
+// positive.  KV2.Put misses on purpose: a new key is looked up in Dyna,
+// then in Perm, and then SegmentStore.put looks it up in Perm a second
+// time to enforce immutability.  So a put costs three full misses, and a
+// miss costs O(sealed segments).  The Perm layer never compacts -- its
+// segments are the unit a peer syncs -- so its segment count only ever
+// rises.  Dyna's does not: Compress collapses every sealed generation
+// into one.
+//
+// The test therefore reports, per bucket of puts: the put rate, the
+// latency of a hit and of a miss, the segment count of each layer, and
+// what sealing and compaction cost.  Degradation that tracks the Perm
+// segment count is the structural cost above; degradation that does not
+// is something else, and the columns are there to tell them apart.
+//
+// Flags, because a mistyped flag is a hard error and a mistyped
+// environment variable is a silent default:
+//
+//	go test ./database/ -run TestDegradationOverTime -load -degrade-for=2h -degrade-csv=/tmp/degrade.csv -v
+var (
+	degradeFor = flag.Duration("degrade-for", 30*time.Minute,
+		"how long TestDegradationOverTime writes for")
+	degradeCSV = flag.String("degrade-csv", "",
+		"write TestDegradationOverTime's per-bucket samples to this CSV file")
+	degradeDir = flag.String("degrade-dir", "",
+		"directory for TestDegradationOverTime's database (default: a temp dir, removed at the end)")
+	degradeMaxGB = flag.Int64("degrade-max-gb", 200,
+		"stop TestDegradationOverTime when its database reaches this many GB")
+)
+
+const (
+	degSealLimit     = 100_000 // Records in a live tail before it auto-seals
+	degPutsPerBlock  = 20_000  // Puts between block boundaries (a Perm seal)
+	degCompressEvery = 25      // Blocks between Dyna compactions
+	degStateKeys     = 200_000 // The mutable working set, rewritten forever
+	degStatePct      = 30      // Percent of puts that rewrite a state key
+	degBucketPuts    = 500_000 // Puts between samples
+	degSampleGets    = 5_000   // Gets timed per sample, per kind
+
+	degNSPerm  = 1 // Namespaces, so the three key kinds cannot collide
+	degNSState = 2
+	degNSMiss  = 3
+)
+
+// degKey derives a key from its namespace and index, so the test can
+// name any key it has ever written without holding a map of them.  A
+// map of a hundred million keys would be the largest thing in the
+// process, and this test is trying to measure the database's memory.
+func degKey(ns byte, i uint64) (key [32]byte) {
+	var b [9]byte
+	b[0] = ns
+	binary.BigEndian.PutUint64(b[1:], i)
+	return sha256.Sum256(b[:])
+}
+
+// degValue derives a value from its key's identity and version.  Values
+// vary in length the way real ones do, and a state key's value changes
+// every time it is rewritten, which is what moves it into the Dyna
+// layer and what leaves trash behind for Compress to reclaim.
+func degValue(ns byte, i, version uint64) []byte {
+	var b [17]byte
+	b[0] = ns
+	binary.BigEndian.PutUint64(b[1:], i)
+	binary.BigEndian.PutUint64(b[9:], version)
+	h := sha256.Sum256(b[:])
+	value := make([]byte, 100+int(h[0])) // 100..355 bytes
+	x := binary.BigEndian.Uint64(h[:8]) | 1
+	for n := 0; n < len(value); n += 8 {
+		x ^= x << 13
+		x ^= x >> 7
+		x ^= x << 17
+		var word [8]byte
+		binary.BigEndian.PutUint64(word[:], x)
+		copy(value[n:], word[:])
+	}
+	return value
+}
+
+// degSample is one row of the report
+type degSample struct {
+	elapsed    time.Duration
+	blocks     int
+	permKeys   uint64
+	stateWrite uint64
+	putRate    float64
+	hitUS      float64
+	missUS     float64
+	permSegs   int
+	dynaSegs   int
+	sealMS     float64
+	compactMS  float64
+	disk       int64
+	heapMB     float64
+	rssMB      float64
+}
+
+func TestDegradationOverTime(t *testing.T) {
+	skipUnlessLoad(t)
+
+	dir := *degradeDir
+	if dir == "" {
+		dir = filepath.Join(os.TempDir(), "DegradationOverTime")
+		defer os.RemoveAll(dir)
+	}
+	os.RemoveAll(dir)
+
+	kv, err := NewKV2(dir, degSealLimit)
+	require.NoError(t, err)
+
+	fmt.Printf("TestDegradationOverTime: writing for %v into %s\n", *degradeFor, dir)
+	fmt.Printf("  seal limit %s records, %s puts per block, Compress every %d blocks,\n",
+		humanize.Comma(degSealLimit), humanize.Comma(degPutsPerBlock), degCompressEvery)
+	fmt.Printf("  %s state keys rewritten at %d%% of puts, sample every %s puts\n\n",
+		humanize.Comma(degStateKeys), degStatePct, humanize.Comma(degBucketPuts))
+
+	// Every state key is written once up front, so that from the first
+	// sample onward a state read is a read of a key that exists.  These
+	// first writes land in Perm; the second, differing write of each is
+	// what moves it to Dyna.
+	stateVersion := make([]uint64, degStateKeys)
+	for i := uint64(0); i < degStateKeys; i++ {
+		_, err = kv.Put(degKey(degNSState, i), degValue(degNSState, i, 0))
+		require.NoError(t, err)
+	}
+
+	var (
+		pick       = NewFastRandom([]byte{7, 7, 7})
+		samples    []degSample
+		permNext   uint64 // Next unused Perm key index
+		stateWrite uint64 // State rewrites so far
+		missNext   uint64 // Next unused never-written key
+		height     uint64 = 1
+		blocks     int
+		bucketPuts int
+		putNanos   int64
+		sealNanos  int64
+		compNanos  int64
+		start      = time.Now()
+		deadline   = start.Add(*degradeFor)
+		maxBytes   = *degradeMaxGB << 30
+	)
+
+	fmt.Printf("%8s %7s %12s %11s %9s %9s %7s %7s %9s %10s %9s %8s\n",
+		"elapsed", "blocks", "perm keys", "puts/s", "hit us", "miss us",
+		"pSegs", "dSegs", "seal ms", "compact ms", "on disk", "heap MB")
+
+	for time.Now().Before(deadline) {
+		// One block
+		blockStart := time.Now()
+		for j := 0; j < degPutsPerBlock; j++ {
+			if pick.UintN(100) < degStatePct {
+				i := uint64(pick.UintN(degStateKeys))
+				stateVersion[i]++
+				_, err = kv.Put(degKey(degNSState, i), degValue(degNSState, i, stateVersion[i]))
+				stateWrite++
+			} else {
+				_, err = kv.Put(degKey(degNSPerm, permNext), degValue(degNSPerm, permNext, 0))
+				permNext++
+			}
+			require.NoError(t, err)
+		}
+		putNanos += time.Since(blockStart).Nanoseconds()
+		bucketPuts += degPutsPerBlock
+
+		sealStart := time.Now()
+		_, err = kv.Seal(height)
+		require.NoError(t, err)
+		sealNanos += time.Since(sealStart).Nanoseconds()
+		height++
+		blocks++
+
+		if blocks%degCompressEvery == 0 {
+			compStart := time.Now()
+			require.NoError(t, kv.Compress())
+			compNanos += time.Since(compStart).Nanoseconds()
+		}
+
+		if bucketPuts < degBucketPuts {
+			continue
+		}
+
+		// Sample.  Timed separately, and its time is not charged to the
+		// put rate: what a sample costs is the point of two of these
+		// columns, not noise to fold into a third.
+		s := degSample{
+			elapsed:    time.Since(start),
+			blocks:     blocks,
+			permKeys:   permNext,
+			stateWrite: stateWrite,
+			putRate:    float64(bucketPuts) / (float64(putNanos) / 1e9),
+			permSegs:   degSegCount(kv.PermKV),
+			dynaSegs:   degSegCount(kv.DynaKV),
+			sealMS:     float64(sealNanos) / 1e6,
+			compactMS:  float64(compNanos) / 1e6,
+			disk:       degDirSize(t, dir),
+		}
+
+		// Hits: existing keys, verified.  A database that degrades into
+		// wrong answers is not a performance result.
+		got := make([][]byte, degSampleGets)
+		idx := make([]uint64, degSampleGets)
+		kinds := make([]byte, degSampleGets)
+		hitStart := time.Now()
+		for n := 0; n < degSampleGets; n++ {
+			if n%2 == 0 && permNext > 0 {
+				idx[n], kinds[n] = uint64(pick.UintN(uint(permNext))), degNSPerm
+			} else {
+				idx[n], kinds[n] = uint64(pick.UintN(degStateKeys)), degNSState
+			}
+			got[n], err = kv.Get(degKey(kinds[n], idx[n]))
+			require.NoError(t, err)
+		}
+		s.hitUS = float64(time.Since(hitStart).Microseconds()) / degSampleGets
+		for n := 0; n < degSampleGets; n++ {
+			version := uint64(0)
+			if kinds[n] == degNSState {
+				version = stateVersion[idx[n]]
+			}
+			want := degValue(kinds[n], idx[n], version)
+			require.Truef(t, bytes.Equal(want, got[n]),
+				"wrong value for ns %d key %d version %d after %s puts",
+				kinds[n], idx[n], version, humanize.Comma(int64(permNext+stateWrite)))
+		}
+
+		// Misses: keys never written, which is the path a put takes
+		missStart := time.Now()
+		for n := 0; n < degSampleGets; n++ {
+			_, err = kv.Get(degKey(degNSMiss, missNext))
+			missNext++
+			require.Error(t, err, "a key that was never written was found")
+		}
+		s.missUS = float64(time.Since(missStart).Microseconds()) / degSampleGets
+
+		var ms runtime.MemStats
+		runtime.ReadMemStats(&ms)
+		s.heapMB = float64(ms.HeapAlloc) / (1 << 20)
+		s.rssMB = degRSSMB()
+
+		samples = append(samples, s)
+		fmt.Printf("%8s %7d %12s %11s %9.1f %9.1f %7d %7d %9.1f %10.1f %9s %8.0f\n",
+			s.elapsed.Round(time.Second), s.blocks, humanize.Comma(int64(s.permKeys)),
+			humanize.Comma(int64(s.putRate)), s.hitUS, s.missUS, s.permSegs, s.dynaSegs,
+			s.sealMS, s.compactMS, humanize.Bytes(uint64(s.disk)), s.heapMB)
+
+		bucketPuts, putNanos, sealNanos, compNanos = 0, 0, 0, 0
+
+		if s.disk >= maxBytes {
+			fmt.Printf("\nstopping: the database reached %s (-degrade-max-gb=%d)\n",
+				humanize.Bytes(uint64(s.disk)), *degradeMaxGB)
+			break
+		}
+	}
+
+	require.NoError(t, kv.Close())
+	require.NotEmpty(t, samples, "the run was too short to produce a single sample")
+
+	degReport(t, samples)
+	if *degradeCSV != "" {
+		degWriteCSV(t, *degradeCSV, samples)
+		fmt.Printf("\nper-bucket samples written to %s\n", *degradeCSV)
+	}
+}
+
+// degReport states what the samples say, rather than leaving a wall of
+// numbers to be eyeballed
+func degReport(t *testing.T, samples []degSample) {
+	t.Helper()
+	first, last := samples[0], samples[len(samples)-1]
+	fmt.Printf("\n%s\n", strings.Repeat("-", 78))
+	fmt.Printf("over %v: %s Perm keys, %s state rewrites, %s on disk\n",
+		last.elapsed.Round(time.Second), humanize.Comma(int64(last.permKeys)),
+		humanize.Comma(int64(last.stateWrite)), humanize.Bytes(uint64(last.disk)))
+	ratio := func(a, b float64) string {
+		if a == 0 {
+			return "n/a"
+		}
+		return fmt.Sprintf("%.2fx", b/a)
+	}
+	fmt.Printf("  %-24s %14s %14s %10s\n", "", "first bucket", "last bucket", "change")
+	fmt.Printf("  %-24s %14s %14s %10s\n", "puts/s",
+		humanize.Comma(int64(first.putRate)), humanize.Comma(int64(last.putRate)),
+		ratio(first.putRate, last.putRate))
+	fmt.Printf("  %-24s %14.1f %14.1f %10s\n", "get hit, us",
+		first.hitUS, last.hitUS, ratio(first.hitUS, last.hitUS))
+	fmt.Printf("  %-24s %14.1f %14.1f %10s\n", "get miss, us",
+		first.missUS, last.missUS, ratio(first.missUS, last.missUS))
+	fmt.Printf("  %-24s %14d %14d %10s\n", "Perm segments",
+		first.permSegs, last.permSegs, ratio(float64(first.permSegs), float64(last.permSegs)))
+	fmt.Printf("  %-24s %14d %14d %10s\n", "Dyna segments",
+		first.dynaSegs, last.dynaSegs, ratio(float64(first.dynaSegs), float64(last.dynaSegs)))
+	fmt.Printf("  %-24s %14.1f %14.1f %10s\n", "seal, ms/bucket",
+		first.sealMS, last.sealMS, ratio(first.sealMS, last.sealMS))
+	fmt.Printf("  %-24s %14.1f %14.1f %10s\n", "compact, ms/bucket",
+		first.compactMS, last.compactMS, ratio(first.compactMS, last.compactMS))
+	fmt.Printf("  %-24s %14.0f %14.0f %10s\n", "heap, MB",
+		first.heapMB, last.heapMB, ratio(first.heapMB, last.heapMB))
+	fmt.Printf("  %-24s %14.0f %14.0f %10s\n", "RSS, MB",
+		first.rssMB, last.rssMB, ratio(first.rssMB, last.rssMB))
+
+	// Cost per sealed Perm segment, if the miss latency tracks the
+	// segment count.  This is the number that says whether the walk over
+	// segments is what is being paid for.
+	if last.permSegs > first.permSegs {
+		perSeg := (last.missUS - first.missUS) / float64(last.permSegs-first.permSegs)
+		fmt.Printf("\n  miss latency per added Perm segment: %.3f us\n", perSeg)
+	}
+	fmt.Printf("%s\n", strings.Repeat("-", 78))
+}
+
+func degWriteCSV(t *testing.T, path string, samples []degSample) {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString("elapsed_s,blocks,perm_keys,state_writes,puts_per_s,hit_us,miss_us," +
+		"perm_segments,dyna_segments,seal_ms,compact_ms,disk_bytes,heap_mb,rss_mb\n")
+	for _, s := range samples {
+		fmt.Fprintf(&b, "%.1f,%d,%d,%d,%.1f,%.3f,%.3f,%d,%d,%.1f,%.1f,%d,%.1f,%.1f\n",
+			s.elapsed.Seconds(), s.blocks, s.permKeys, s.stateWrite, s.putRate,
+			s.hitUS, s.missUS, s.permSegs, s.dynaSegs, s.sealMS, s.compactMS,
+			s.disk, s.heapMB, s.rssMB)
+	}
+	require.NoError(t, os.WriteFile(path, []byte(b.String()), 0644))
+}
+
+// degSegCount is the number of sealed segments in a layer
+func degSegCount(s *SegmentStore) int {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+	return len(s.segments)
+}
+
+// degDirSize totals a directory tree, since a KV2 has a directory per layer
+func degDirSize(t *testing.T, dir string) (total int64) {
+	t.Helper()
+	err := filepath.WalkDir(dir, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		total += info.Size()
+		return nil
+	})
+	require.NoError(t, err)
+	return total
+}
+
+// degRSSMB is the process's resident size, which counts what the heap
+// does not: the index and data files the kernel is holding for us
+func degRSSMB() float64 {
+	buf, err := os.ReadFile("/proc/self/statm")
+	if err != nil {
+		return 0
+	}
+	fields := strings.Fields(string(buf))
+	if len(fields) < 2 {
+		return 0
+	}
+	var pages float64
+	fmt.Sscanf(fields[1], "%f", &pages)
+	return pages * float64(os.Getpagesize()) / (1 << 20)
+}

--- a/database/iterate.go
+++ b/database/iterate.go
@@ -1,0 +1,131 @@
+package blockchainDB
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// Iteration over a store's keys.
+//
+// This exists for the things that have to see everything -- a
+// snapshot, an export, a consistency check -- rather than for the
+// lookup path, and it is written for that: correctness and a simple
+// contract over speed.
+//
+// A sealed segment's index is already a sorted list of keys, so
+// iterating one is a sequential read rather than a traversal.  What
+// costs something is shadowing: in a mutable store a key may appear in
+// several segments and only the newest counts, so iteration walks
+// newest to oldest and remembers what it has already emitted.  That
+// set is proportional to the number of distinct keys, which is why
+// this is not something to call on the hot path of a large store.
+//
+// (A k-way merge across the segments' sorted indexes would emit keys
+// in order with no such set.  It is the better implementation and the
+// obvious next step if iteration ever moves off the cold path.)
+
+// ForEach
+// Call fn for every key the store holds, with its current value.
+// Iteration stops and returns the error if fn returns one.
+//
+// The order is unspecified.  A store must not be written to while
+// ForEach runs: it holds the store's lock for the duration.
+func (s *SegmentStore) ForEach(fn func(key [32]byte, value []byte) error) (err error) {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+	if err = s.checkOpen(); err != nil {
+		return err
+	}
+
+	seen := make(map[[32]byte]struct{}, len(s.live))
+
+	// The live tail first: it is the newest thing in the store, so
+	// anything it holds shadows every sealed copy
+	for key, dbb := range s.live {
+		value := make([]byte, dbb.Length)
+		if err = s.liveFile.ReadAt(dbb.Offset, value); err != nil {
+			return err
+		}
+		seen[key] = struct{}{}
+		if err = fn(key, value); err != nil {
+			return err
+		}
+	}
+
+	const batch = 4096
+	buff := make([]byte, batch*DBKeyFullSize)
+	for i := len(s.segments) - 1; i >= 0; i-- { // Newest segment wins
+		seg := s.segments[i]
+		for at := int64(0); at < seg.count; {
+			n := seg.count - at
+			if n > batch {
+				n = batch
+			}
+			b := buff[:n*DBKeyFullSize]
+			if _, err = seg.index.ReadAt(b, segIndexHdrSize+at*DBKeyFullSize); err != nil {
+				return err
+			}
+			for j := int64(0); j < n; j++ {
+				rec := b[j*DBKeyFullSize:]
+				var key [32]byte
+				copy(key[:], rec[:32])
+				if _, ok := seen[key]; ok {
+					continue // A newer copy was already emitted
+				}
+				seen[key] = struct{}{}
+				dbb := &DBBKey{
+					Offset: binary.BigEndian.Uint64(rec[32:]),
+					Length: binary.BigEndian.Uint64(rec[40:]),
+				}
+				value, err := seg.value(dbb)
+				if err != nil {
+					return err
+				}
+				if err = fn(key, value); err != nil {
+					return err
+				}
+			}
+			at += n
+		}
+	}
+	return nil
+}
+
+// ForEach
+// Call fn for every key the database holds.  The Dyna layer is walked
+// first, and a key it holds is not emitted again from Perm: a key that
+// moved to Dyna leaves its original behind in Perm, and the Dyna copy
+// is the one Get answers with.
+func (k *KV2) ForEach(fn func(key [32]byte, value []byte) error) error {
+	k.Mutex.Lock()
+	defer k.Mutex.Unlock()
+
+	dyna := make(map[[32]byte]struct{})
+	err := k.DynaKV.ForEach(func(key [32]byte, value []byte) error {
+		dyna[key] = struct{}{}
+		return fn(key, value)
+	})
+	if err != nil {
+		return err
+	}
+	return k.PermKV.ForEach(func(key [32]byte, value []byte) error {
+		if _, ok := dyna[key]; ok {
+			return nil // Shadowed by the dynamic copy
+		}
+		return fn(key, value)
+	})
+}
+
+// ForEach
+// Call fn for every key in the sharded database, shard by shard.
+func (k *KVShard) ForEach(fn func(key [32]byte, value []byte) error) error {
+	for i, shard := range k.Shards {
+		if shard == nil {
+			continue
+		}
+		if err := shard.ForEach(fn); err != nil {
+			return fmt.Errorf("shard %d: %w", i, err)
+		}
+	}
+	return nil
+}

--- a/database/iterate_test.go
+++ b/database/iterate_test.go
@@ -1,0 +1,138 @@
+package blockchainDB
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestForEachSeesEveryCurrentValue
+// Iteration has to see each key exactly once, with the value a Get
+// would return -- which in a mutable store means the newest of several
+// copies, not the first one found.
+func TestForEachSeesEveryCurrentValue(t *testing.T) {
+	for _, mutable := range []bool{false, true} {
+		name := "immutable"
+		if mutable {
+			name = "mutable"
+		}
+		t.Run(name, func(t *testing.T) {
+			dir := storeDir(t, name)
+			store, err := NewSegmentStore(dir, mutable)
+			require.NoError(t, err)
+
+			kr := NewFastRandom([]byte{41})
+			keys := make([][32]byte, 300)
+			want := make(map[[32]byte]string, len(keys))
+			for i := range keys {
+				keys[i] = kr.NextHash()
+			}
+
+			// Spread the keys over several sealed segments and a tail
+			for i, key := range keys {
+				v := fmt.Sprintf("v%d", i)
+				require.NoError(t, store.Put(key, []byte(v)))
+				want[key] = v
+				if (i+1)%70 == 0 {
+					_, err = store.Seal(uint64(i / 70))
+					require.NoError(t, err)
+				}
+			}
+			if mutable {
+				// Rewrite some keys so older segments hold stale copies
+				for i := 0; i < len(keys); i += 3 {
+					v := fmt.Sprintf("rewritten%d", i)
+					require.NoError(t, store.Put(keys[i], []byte(v)))
+					want[keys[i]] = v
+				}
+				_, err = store.SealNext()
+				require.NoError(t, err)
+			}
+
+			got := map[[32]byte]string{}
+			require.NoError(t, store.ForEach(func(key [32]byte, value []byte) error {
+				_, dup := got[key]
+				require.False(t, dup, "key emitted twice")
+				got[key] = string(value)
+				return nil
+			}))
+			require.Equal(t, len(want), len(got), "wrong number of keys")
+			for key, v := range want {
+				require.Equal(t, v, got[key], "iteration returned a stale value")
+			}
+			require.NoError(t, store.Close())
+		})
+	}
+}
+
+// TestKV2ForEachPrefersTheDynamicCopy
+// A key that was rewritten lives in both layers: the original in Perm
+// and the current value in Dyna.  Iteration must report it once, with
+// the value Get answers with.
+func TestKV2ForEachPrefersTheDynamicCopy(t *testing.T) {
+	dir := storeDir(t, "kv2")
+	kv, err := NewKV2(dir, 50)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{42})
+	keys := make([][32]byte, 100)
+	for i := range keys {
+		keys[i] = kr.NextHash()
+		_, err = kv.Put(keys[i], []byte(fmt.Sprintf("orig%d", i)))
+		require.NoError(t, err)
+	}
+	// Rewrite half: these move to the Dyna layer, leaving Perm's copy
+	for i := 0; i < len(keys); i += 2 {
+		_, err = kv.Put(keys[i], []byte(fmt.Sprintf("new%d", i)))
+		require.NoError(t, err)
+	}
+
+	got := map[[32]byte]string{}
+	require.NoError(t, kv.ForEach(func(key [32]byte, value []byte) error {
+		_, dup := got[key]
+		require.False(t, dup, "key emitted twice across the two layers")
+		got[key] = string(value)
+		return nil
+	}))
+	require.Len(t, got, len(keys))
+	for i, key := range keys {
+		want := fmt.Sprintf("orig%d", i)
+		if i%2 == 0 {
+			want = fmt.Sprintf("new%d", i)
+		}
+		require.Equalf(t, want, got[key], "key %d", i)
+		// And iteration agrees with what a lookup answers
+		v, err := kv.Get(key)
+		require.NoError(t, err)
+		require.Equal(t, want, string(v), "iteration and Get disagree on key %d", i)
+	}
+	require.NoError(t, kv.Close())
+}
+
+// TestForEachStopsOnError
+// A caller that gives up mid-iteration gets its error back, rather
+// than the walk running to completion and swallowing it.
+func TestForEachStopsOnError(t *testing.T) {
+	dir := storeDir(t, "s")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+	kr := NewFastRandom([]byte{43})
+	for i := 0; i < 100; i++ {
+		require.NoError(t, store.Put(kr.NextHash(), []byte("v")))
+	}
+	_, err = store.Seal(1)
+	require.NoError(t, err)
+
+	stop := fmt.Errorf("enough")
+	seen := 0
+	err = store.ForEach(func([32]byte, []byte) error {
+		if seen++; seen == 10 {
+			return stop
+		}
+		return nil
+	})
+	require.ErrorIs(t, err, stop)
+	require.Equal(t, 10, seen, "iteration continued past the error")
+	require.NoError(t, store.Close())
+}

--- a/database/keyfilter_test.go
+++ b/database/keyfilter_test.go
@@ -1,0 +1,281 @@
+package blockchainDB
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The store-level key filter answers "is this key absent?" without
+// walking the sealed segments.  Its two failure modes are not
+// symmetric: a filter that claims a key it does not have costs a
+// pointless walk, while a filter that DENIES a key the store holds
+// turns a Get into a wrong answer -- "not found" for a key sitting in
+// a segment, with nothing downstream to catch it.
+//
+// These tests are about that second mode.  Every stage that changes
+// what the store holds -- a write, a seal, a compaction, an import, a
+// reopen, a reopen after a crash -- must leave every key still
+// findable.
+
+// TestKeyFilterNeverMissesAKey
+// Walk a store through every stage that moves keys around, checking
+// after each one that nothing has become invisible.
+func TestKeyFilterNeverMissesAKey(t *testing.T) {
+	dir := storeDir(t, "s")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+	require.NoError(t, store.SetSealLimit(64))
+
+	kr := NewFastRandom([]byte{31})
+	vr := NewFastRandom([]byte{31, 31})
+	keys := make([][32]byte, 0, 600)
+	values := make([][]byte, 0, 600)
+
+	mustFindAll := func(s *SegmentStore, stage string) {
+		t.Helper()
+		for i, key := range keys {
+			got, err := s.Get(key)
+			require.NoErrorf(t, err, "%s: key %d went missing", stage, i)
+			require.Equalf(t, values[i], got, "%s: key %d wrong", stage, i)
+		}
+	}
+	write := func(n int) {
+		t.Helper()
+		for i := 0; i < n; i++ {
+			key, value := kr.NextHash(), vr.RandBuff(20, 60)
+			require.NoError(t, store.Put(key, value))
+			keys = append(keys, key)
+			values = append(values, value)
+		}
+	}
+
+	// Keys in the live tail
+	write(50)
+	mustFindAll(store, "live tail")
+
+	// Keys spread over several sealed segments
+	for block := uint64(1); block <= 5; block++ {
+		write(50)
+		_, err = store.Seal(block)
+		require.NoError(t, err)
+		mustFindAll(store, "after seal")
+	}
+	require.Greater(t, len(store.segments), 1, "the walk being skipped must be worth skipping")
+
+	// A tail on top of the sealed segments
+	write(20)
+	mustFindAll(store, "sealed plus tail")
+
+	// Reopened cleanly: the filter is loaded from disk
+	require.NoError(t, store.Close())
+	store, err = OpenSegmentStore(dir)
+	require.NoError(t, err)
+	mustFindAll(store, "clean reopen")
+
+	// Reopened after a seal that the saved filter predates, which is
+	// what a crash leaves behind: the filter must be rebuilt, not
+	// trusted
+	write(30)
+	_, err = store.Seal(6)
+	require.NoError(t, err)
+	store2, err := OpenSegmentStore(dir) // Without closing: no save
+	require.NoError(t, err)
+	mustFindAll(store2, "reopen with a stale saved filter")
+	require.NoError(t, store2.Close())
+	require.NoError(t, store.Close())
+}
+
+// TestKeyFilterRebuildsFromADamagedFile
+// A saved filter that cannot be read is a reason to rebuild, not a
+// reason to fail the open or to serve lookups from a half-read filter.
+func TestKeyFilterRebuildsFromADamagedFile(t *testing.T) {
+	dir := storeDir(t, "s")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{32})
+	var keys [][32]byte
+	for i := 0; i < 200; i++ {
+		key := kr.NextHash()
+		require.NoError(t, store.Put(key, []byte("v")))
+		keys = append(keys, key)
+	}
+	_, err = store.Seal(1)
+	require.NoError(t, err)
+	require.NoError(t, store.Close()) // Saves bloom.dat and claims coverage
+
+	path := filepath.Join(dir, bloomFilename)
+	require.FileExists(t, path, "Close must persist the filter")
+	require.NoError(t, os.WriteFile(path, []byte("not a bloom filter"), 0644))
+
+	store, err = OpenSegmentStore(dir)
+	require.NoError(t, err, "a damaged filter must not fail the open")
+	for i, key := range keys {
+		_, err := store.Get(key)
+		require.NoErrorf(t, err, "key %d went missing after a damaged filter was rebuilt", i)
+	}
+	require.NoError(t, store.Close())
+}
+
+// TestKeyFilterSurvivesCompaction
+// Compaction rewrites the whole key set of a mutable store.  What
+// survives must still be findable; what it reclaimed may linger in the
+// filter, which costs a walk and nothing else.
+func TestKeyFilterSurvivesCompaction(t *testing.T) {
+	dir := storeDir(t, "s")
+	store, err := NewSegmentStore(dir, true)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{33})
+	keys := make([][32]byte, 100)
+	for i := range keys {
+		keys[i] = kr.NextHash()
+	}
+	for round := 0; round < 4; round++ {
+		for i, key := range keys {
+			require.NoError(t, store.Put(key, []byte{byte(round), byte(i)}))
+		}
+		_, err = store.SealNext()
+		require.NoError(t, err)
+	}
+	_, err = store.CompactNext()
+	require.NoError(t, err)
+
+	for i, key := range keys {
+		got, err := store.Get(key)
+		require.NoErrorf(t, err, "key %d went missing in compaction", i)
+		require.Equal(t, []byte{3, byte(i)}, got, "key %d is stale", i)
+	}
+
+	// And a key written after the compaction
+	fresh := kr.NextHash()
+	require.NoError(t, store.Put(fresh, []byte("after")))
+	got, err := store.Get(fresh)
+	require.NoError(t, err, "a key written after compaction went missing")
+	require.Equal(t, []byte("after"), got)
+	require.NoError(t, store.Close())
+}
+
+// TestKeyFilterSurvivesImport
+// An adopted segment's keys are keys the store now holds, so the
+// filter has to learn them at adoption -- a syncing node's whole
+// database arrives this way, never through Put.
+func TestKeyFilterSurvivesImport(t *testing.T) {
+	srcDir, dstDir := storeDir(t, "src"), storeDir(t, "dst")
+	src, err := NewSegmentStore(srcDir, false)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{34})
+	var keys [][32]byte
+	for i := 0; i < 150; i++ {
+		key := kr.NextHash()
+		require.NoError(t, src.Put(key, []byte("v")))
+		keys = append(keys, key)
+	}
+	_, err = src.Seal(1)
+	require.NoError(t, err)
+	metas, paths := src.SegmentPaths()
+
+	dst, err := NewSegmentStore(dstDir, false)
+	require.NoError(t, err)
+	for i, meta := range metas {
+		require.NoError(t, dst.ImportSegmentFile(paths[i], meta))
+	}
+	for i, key := range keys {
+		_, err := dst.Get(key)
+		require.NoErrorf(t, err, "imported key %d is invisible", i)
+	}
+	require.NoError(t, src.Close())
+	require.NoError(t, dst.Close())
+}
+
+// TestPutIfAbsent
+// The three answers the layered lookup above it needs, from one pass:
+// absent (and now written), present with the same value, present with
+// a different one.
+func TestPutIfAbsent(t *testing.T) {
+	dir := storeDir(t, "s")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{35})
+	key := kr.NextHash()
+
+	existing, existed, err := store.PutIfAbsent(key, []byte("first"))
+	require.NoError(t, err)
+	require.False(t, existed, "a key never written must report absent")
+	require.Nil(t, existing)
+	got, err := store.Get(key)
+	require.NoError(t, err, "an absent key must have been written")
+	require.Equal(t, []byte("first"), got)
+
+	existing, existed, err = store.PutIfAbsent(key, []byte("first"))
+	require.NoError(t, err)
+	require.True(t, existed)
+	require.Equal(t, []byte("first"), existing)
+
+	// A conflicting value is reported, not written and not an error:
+	// deciding what a conflict means belongs to the caller, which is
+	// the layer that can move the key somewhere mutable
+	existing, existed, err = store.PutIfAbsent(key, []byte("second"))
+	require.NoError(t, err)
+	require.True(t, existed)
+	require.Equal(t, []byte("first"), existing, "the stored value must be reported")
+	got, err = store.Get(key)
+	require.NoError(t, err)
+	require.Equal(t, []byte("first"), got, "PutIfAbsent must not overwrite")
+
+	// The same across a seal, where the key is no longer in the tail
+	_, err = store.Seal(1)
+	require.NoError(t, err)
+	existing, existed, err = store.PutIfAbsent(key, []byte("third"))
+	require.NoError(t, err)
+	require.True(t, existed, "a sealed key is still present")
+	require.Equal(t, []byte("first"), existing)
+	require.NoError(t, store.Close())
+}
+
+// TestStoreStatsCountWhatHappened
+// The counters exist to answer "are duplicate permanent writes common
+// enough to be worth checking for?", so they have to distinguish the
+// three outcomes of a write and the two ways a lookup can be settled.
+func TestStoreStatsCountWhatHappened(t *testing.T) {
+	dir := storeDir(t, "s")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{36})
+	keys := make([][32]byte, 10)
+	for i := range keys {
+		keys[i] = kr.NextHash()
+		require.NoError(t, store.Put(keys[i], []byte("v")))
+	}
+	_, err = store.Seal(1) // Push them out of the live tail
+	require.NoError(t, err)
+
+	for _, key := range keys[:4] { // Identical rewrites: avoidable writes
+		require.NoError(t, store.Put(key, []byte("v")))
+	}
+	require.Error(t, store.Put(keys[0], []byte("different"))) // A conflict
+	for i := 0; i < 20; i++ {                                 // Keys never written
+		_, err = store.Get(kr.NextHash())
+		require.Error(t, err)
+	}
+
+	s := store.Stats()
+	require.Equal(t, uint64(15), s.PutTotal, "10 new, 4 duplicates, 1 conflict")
+	require.Equal(t, uint64(10), s.PutNew)
+	require.Equal(t, uint64(4), s.PutDuplicate)
+	require.Equal(t, uint64(1), s.PutConflict)
+
+	// The 20 absent keys must have been settled by the filter, not by
+	// walking: that is the whole point of it
+	require.GreaterOrEqual(t, s.FilterAbsent, uint64(19),
+		"absent keys should be settled without touching a segment")
+	require.Equal(t, s.FilterMisled, s.FilterWalked-uint64(5),
+		"the only walks that found something were the 4 duplicates and the conflict")
+	require.NoError(t, store.Close())
+}

--- a/database/kv_2.go
+++ b/database/kv_2.go
@@ -234,12 +234,34 @@ func (k *KV2) sealDynaIfFull() (err error) {
 }
 
 // Seal
-// Seal the Perm layer at a block height.  Sealing is the Perm layer's
-// durability point and the unit a peer syncs.
+// Close a block: seal the Perm layer at the block height, and make the
+// Dyna layer's live tail durable.
+//
+// Both halves matter, and the second one used to be missing.  Sealing
+// is the Perm layer's durability point and the unit a peer syncs, so
+// permanent records were durable the moment Seal returned.  Dynamic
+// writes were not: they sat in a 32 KB buffer until the tail filled,
+// was compacted, or the store was closed.  A node killed after a
+// commit therefore came back with permanent records -- chain elements
+// -- newer than the mutable state that indexes them, and the two
+// layers disagreed about where the block ended (issue #29).
+//
+// The Dyna layer is synced rather than sealed: its segments are local
+// (a peer never receives one), so there is nothing to gain from
+// cutting one per block and a full seal per block per shard to pay
+// for.  A sync on a tail that took no writes is free.
+//
+// Both layers are advanced before either error is returned, so a
+// failure to sync Dyna does not leave Perm unsealed and the block
+// unrepeatable.
 func (k *KV2) Seal(height uint64) (meta SegmentMeta, err error) {
 	k.Mutex.Lock()
 	defer k.Mutex.Unlock()
-	return k.PermKV.Seal(height)
+	meta, err = k.PermKV.Seal(height)
+	if syncErr := k.DynaKV.Sync(); err == nil {
+		err = syncErr
+	}
+	return meta, err
 }
 
 // Put

--- a/database/kv_2.go
+++ b/database/kv_2.go
@@ -258,22 +258,28 @@ func (k *KV2) Put(key [32]byte, value []byte) (writes int, err error) {
 		}
 		return k.DWrites, k.sealDynaIfFull()
 	}
-	if value2, err2 := k.PermKV.Get(key); err2 == nil { // Check. Is it a PermKV
-		if bytes.Equal(value, value2) { // If no change, ignore;
-			return k.PWrites, nil
-		}
-		k.DWrites++
-		if err = k.DynaKV.Put(key, value); err != nil { // If the perm value changed, it is now a DynaKV
-			return k.DWrites, err
-		}
-		return k.DWrites, k.sealDynaIfFull()
-	}
-	// If not yet a DynaKV or not in k.PermKV, default to k.PermKV
-	k.PWrites++
-	if err = k.PermKV.Put(key, value); err != nil {
+	// One lookup settles all three Perm cases: absent (in which case the
+	// write has already happened), present and identical (nothing to
+	// do), present and different (the key becomes dynamic).  Asking
+	// whether the key was there and then calling Put, which asked again
+	// to enforce immutability, made a new key -- the common case, and a
+	// miss by definition -- pay for the answer twice.
+	existing, existed, err := k.PermKV.PutIfAbsent(key, value)
+	if err != nil {
 		return k.DWrites, err
 	}
-	return k.DWrites, k.sealPermIfFull() // We do not compact the PermKV ... Only report DWrites
+	if !existed { // It is a new permanent key, and it is now written
+		k.PWrites++
+		return k.DWrites, k.sealPermIfFull() // PermKV is never compacted; report DWrites
+	}
+	if bytes.Equal(existing, value) { // If no change, ignore;
+		return k.PWrites, nil
+	}
+	k.DWrites++
+	if err = k.DynaKV.Put(key, value); err != nil { // If the perm value changed, it is now a DynaKV
+		return k.DWrites, err
+	}
+	return k.DWrites, k.sealDynaIfFull()
 }
 
 // Compress

--- a/database/kv_2_test.go
+++ b/database/kv_2_test.go
@@ -190,3 +190,42 @@ func TestKV2BlockSealAfterAutoSeals(t *testing.T) {
 	}
 	require.NoError(t, kv.Close())
 }
+
+// TestPutPermImmutableSentinel
+// A caller classifying its own records into the two layers has to tell
+// "I put this in the wrong layer" from "the store failed", and the
+// first is survivable: the record belongs in the dynamic layer.  Both
+// used to arrive as a bare error, so the only way to separate them was
+// to match the message (issue #28).  PutPerm returns the Perm layer's
+// error unwrapped, at both the KV2 and the sharded layer, so errors.Is
+// has to reach ErrImmutable through either.
+func TestPutPermImmutableSentinel(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
+	// NewKV2 creates its own directory with Mkdir, not MkdirAll, so the
+	// parent this test puts the two databases under has to exist first
+	require.NoError(t, os.MkdirAll(dir, os.ModePerm))
+
+	kv, err := NewKV2(filepath.Join(dir, "kv2"), 1000)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{43})
+	key := kr.NextHash()
+	_, err = kv.PutPerm(key, []byte("original"))
+	require.NoError(t, err)
+
+	_, err = kv.PutPerm(key, []byte("original"))
+	require.NoError(t, err, "an identical rewrite is a replay, not a refusal")
+
+	_, err = kv.PutPerm(key, []byte("different"))
+	require.ErrorIs(t, err, ErrImmutable)
+	require.NoError(t, kv.Close())
+
+	// And through the shard router, which is what a node writes to
+	kvs, err := NewKVShard(filepath.Join(dir, "shard"), 1000)
+	require.NoError(t, err)
+	require.NoError(t, kvs.PutPerm(key, []byte("original")))
+	require.ErrorIs(t, kvs.PutPerm(key, []byte("different")), ErrImmutable)
+	require.NoError(t, kvs.Close())
+}

--- a/database/kv_2_test.go
+++ b/database/kv_2_test.go
@@ -3,10 +3,13 @@ package blockchainDB
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestKV2(t *testing.T) {
@@ -143,4 +146,47 @@ func TestKV2_2(t *testing.T) {
 
 	fmt.Printf("Writes per second %10.3f Reads per second %10.3f\n", wps, rps)
 	fmt.Printf("Writes %s Reads %s\n", ComputeTimePerOp(wps), ComputeTimePerOp(rps))
+}
+
+// TestKV2BlockSealAfterAutoSeals
+// The reproduction from issue #27, at the layer a node actually uses:
+// a live tail that fills eight times before the first block boundary
+// used to make Seal(1) -- and so every later block -- fail forever.
+func TestKV2BlockSealAfterAutoSeals(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	defer os.RemoveAll(dir)
+
+	kv, err := NewKV2(dir, 60) // sealLimit 60
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{41})
+	keys := make([][32]byte, 500)
+	for i := range keys {
+		keys[i] = kr.NextHash()
+		_, err = kv.PutPerm(keys[i], []byte("v"))
+		require.NoError(t, err)
+	}
+	require.Greater(t, len(kv.PermKV.segments), 1, "the tail must have auto-sealed for this to test anything")
+
+	_, err = kv.Seal(1)
+	require.NoError(t, err, "the first block boundary must be sealable after auto-seals")
+
+	// Keep going: more writes, more auto-seals, more blocks
+	for b := uint64(2); b <= 4; b++ {
+		for i := 0; i < 200; i++ {
+			k := kr.NextHash()
+			keys = append(keys, k)
+			_, err = kv.PutPerm(k, []byte("v"))
+			require.NoError(t, err)
+		}
+		_, err = kv.Seal(b)
+		require.NoErrorf(t, err, "block %d must be sealable", b)
+	}
+
+	for i, k := range keys {
+		v, err := kv.Get(k)
+		require.NoErrorf(t, err, "key %d lost across blocks", i)
+		require.Equal(t, []byte("v"), v)
+	}
+	require.NoError(t, kv.Close())
 }

--- a/database/segment.go
+++ b/database/segment.go
@@ -95,33 +95,38 @@ func (k *KVShard) ExportBlock(exportDir string, height uint64, prev *Manifest) (
 		return nil, err
 	}
 
-	// The newest segment a peer already has, per shard
-	exported := make(map[int]SegmentMeta)
+	// The last block a peer already has.  The boundary is the block
+	// number, not a per-shard high-water mark taken from prev.Segments:
+	// a shard that took no writes during the previous block sealed
+	// nothing and so appears nowhere in prev, and a per-shard map has no
+	// entry to skip it by -- every segment it holds would be copied
+	// again, into every block until it next seals.
+	//
+	// The block number works because sealing at a boundary advances the
+	// block each shard accumulates into, so a segment sealed after the
+	// export of block N -- auto-seal or boundary -- carries a height
+	// above N, and one sealed before it does not.
+	//
+	// exportedOK distinguishes "no previous export" from one at block 0,
+	// which a genesis block is.
+	exported, exportedOK := uint64(0), false
 	if prev != nil {
-		for _, s := range prev.Segments {
-			cur, ok := exported[s.Shard]
-			m := SegmentMeta{Height: s.Height, Seq: s.Seq}
-			if !ok || m.after(cur) {
-				exported[s.Shard] = m
-			}
-		}
+		exported, exportedOK = prev.Height, true
 	}
 
 	// Seal every shard before copying anything.  Sealing is durable and
 	// cannot be rolled back, so a failure partway through the copy
 	// phase would otherwise leave a block half-built on disk with some
 	// shards already closed at this height.
-	for i, shard := range k.Shards {
-		if _, err = shard.Seal(height); err != nil {
-			return nil, fmt.Errorf("shard %d: %w", i, err)
-		}
+	if err = k.SealBlock(height); err != nil {
+		return nil, err
 	}
 
 	m = &Manifest{Height: height}
 	for i, shard := range k.Shards {
 		metas, paths := shard.PermKV.SegmentPaths()
 		for j, meta := range metas {
-			if last, ok := exported[i]; ok && !meta.after(last) {
+			if exportedOK && meta.Height <= exported {
 				continue // The peer already has this one
 			}
 			name := fmt.Sprintf("shard-%04d-%08d-%04d.seg", i, meta.Height, meta.Seq)

--- a/database/segment.go
+++ b/database/segment.go
@@ -44,7 +44,8 @@ const (
 // One sealed segment within a block export
 type SegmentInfo struct {
 	Shard  int    `json:"shard"`
-	Height uint64 `json:"height"` // The segment's own seal height within its shard
+	Height uint64 `json:"height"` // The block the segment belongs to
+	Seq    uint64 `json:"seq"`    // Its order within that block
 	File   string `json:"file"`   // Segment file name within the block directory
 	Count  uint64 `json:"count"`  // Number of keys in the segment
 	Hash   string `json:"hash"`   // SHA-256 of the segment file, hex
@@ -94,32 +95,41 @@ func (k *KVShard) ExportBlock(exportDir string, height uint64, prev *Manifest) (
 		return nil, err
 	}
 
-	// The newest seal height a peer already has, per shard
-	exported := make(map[int]uint64)
+	// The newest segment a peer already has, per shard
+	exported := make(map[int]SegmentMeta)
 	if prev != nil {
 		for _, s := range prev.Segments {
-			if h, ok := exported[s.Shard]; !ok || s.Height > h {
-				exported[s.Shard] = s.Height
+			cur, ok := exported[s.Shard]
+			m := SegmentMeta{Height: s.Height, Seq: s.Seq}
+			if !ok || m.after(cur) {
+				exported[s.Shard] = m
 			}
+		}
+	}
+
+	// Seal every shard before copying anything.  Sealing is durable and
+	// cannot be rolled back, so a failure partway through the copy
+	// phase would otherwise leave a block half-built on disk with some
+	// shards already closed at this height.
+	for i, shard := range k.Shards {
+		if _, err = shard.Seal(height); err != nil {
+			return nil, fmt.Errorf("shard %d: %w", i, err)
 		}
 	}
 
 	m = &Manifest{Height: height}
 	for i, shard := range k.Shards {
-		if _, err = shard.Seal(height); err != nil {
-			return nil, fmt.Errorf("shard %d: %w", i, err)
-		}
 		metas, paths := shard.PermKV.SegmentPaths()
 		for j, meta := range metas {
-			if last, ok := exported[i]; ok && meta.Height <= last {
+			if last, ok := exported[i]; ok && !meta.after(last) {
 				continue // The peer already has this one
 			}
-			name := fmt.Sprintf("shard-%04d-%08d.seg", i, meta.Height)
+			name := fmt.Sprintf("shard-%04d-%08d-%04d.seg", i, meta.Height, meta.Seq)
 			if err = copyFileSynced(paths[j], filepath.Join(blockDir, name)); err != nil {
 				return nil, fmt.Errorf("shard %d: %w", i, err)
 			}
 			m.Segments = append(m.Segments, SegmentInfo{
-				Shard: i, Height: meta.Height, File: name,
+				Shard: i, Height: meta.Height, Seq: meta.Seq, File: name,
 				Count: meta.Count, Hash: meta.Hash,
 			})
 		}
@@ -187,11 +197,15 @@ func (k *KVShard) ImportBlock(blockDir string) (count uint64, err error) {
 		}
 	}
 
-	// Adopt in seal order so heights stay ascending within each shard
+	// Adopt in seal order so (block, seq) stays ascending within each shard
 	segments := append([]SegmentInfo(nil), m.Segments...)
-	sort.Slice(segments, func(i, j int) bool { return segments[i].Height < segments[j].Height })
+	sort.Slice(segments, func(i, j int) bool {
+		a := SegmentMeta{Height: segments[i].Height, Seq: segments[i].Seq}
+		b := SegmentMeta{Height: segments[j].Height, Seq: segments[j].Seq}
+		return b.after(a)
+	})
 	for _, s := range segments {
-		meta := SegmentMeta{Height: s.Height, Count: s.Count, Hash: s.Hash}
+		meta := SegmentMeta{Height: s.Height, Seq: s.Seq, Count: s.Count, Hash: s.Hash}
 		if err = k.Shards[s.Shard].ImportPermSegment(filepath.Join(blockDir, s.File), meta); err != nil {
 			return count, fmt.Errorf("shard %d: %w", s.Shard, err)
 		}

--- a/database/segment_test.go
+++ b/database/segment_test.go
@@ -22,9 +22,13 @@ func TestSegmentRoundTrip(t *testing.T) {
 		defer os.RemoveAll(d)
 	}
 
-	// Node A: two "blocks" of writes.  A seal limit of 50 forces
-	// auto-seals, so a block exports more than one segment per shard.
-	nodeA, err := NewKVShard(dirA, 50)
+	// Node A: two "blocks" of writes.  The seal limit is deliberately
+	// tiny relative to the keys per shard, so tails fill mid-block and
+	// auto-seal -- the case ExportBlock claims to support and issue #27
+	// showed it did not.  At 512 shards this needs thousands of keys to
+	// reach even a handful per shard; the previous 400 never auto-sealed
+	// once, so the test certified a path it never entered.
+	nodeA, err := NewKVShard(dirA, 2)
 	require.NoError(t, err)
 
 	kr := NewFastRandom([]byte{91})
@@ -41,11 +45,21 @@ func TestSegmentRoundTrip(t *testing.T) {
 		}
 	}
 
-	writeBlock(400)
+	writeBlock(4000)
+
+	// Confirm the premise: some shard really did auto-seal
+	autoSealed := 0
+	for _, sh := range nodeA.Shards {
+		if len(sh.PermKV.segments) > 0 {
+			autoSealed += len(sh.PermKV.segments)
+		}
+	}
+	require.Greater(t, autoSealed, 0, "no shard auto-sealed; the test would not exercise issue #27")
+
 	m1, err := nodeA.ExportBlock(exportDir, 1, nil)
 	require.NoError(t, err, "export block 1")
 
-	writeBlock(300)
+	writeBlock(3000)
 	m2, err := nodeA.ExportBlock(exportDir, 2, m1)
 	require.NoError(t, err, "export block 2")
 
@@ -58,18 +72,18 @@ func TestSegmentRoundTrip(t *testing.T) {
 	for _, s := range m2.Segments {
 		c2 += s.Count
 	}
-	assert.Equal(t, uint64(400), c1, "block 1 record count")
-	assert.Equal(t, uint64(300), c2, "block 2 record count")
+	assert.Equal(t, uint64(4000), c1, "block 1 record count")
+	assert.Equal(t, uint64(3000), c2, "block 2 record count")
 
 	// Node B: verify + import in height order
-	nodeB, err := NewKVShard(dirB, 50)
+	nodeB, err := NewKVShard(dirB, 2)
 	require.NoError(t, err)
 	n1, err := nodeB.ImportBlock(filepath.Join(exportDir, "block-00000001"))
 	require.NoError(t, err, "import block 1")
-	assert.Equal(t, uint64(400), n1)
+	assert.Equal(t, uint64(4000), n1)
 	n2, err := nodeB.ImportBlock(filepath.Join(exportDir, "block-00000002"))
 	require.NoError(t, err, "import block 2")
-	assert.Equal(t, uint64(300), n2)
+	assert.Equal(t, uint64(3000), n2)
 
 	// Node B must now hold every key with the correct value
 	for i, key := range keys {

--- a/database/segment_test.go
+++ b/database/segment_test.go
@@ -1,6 +1,7 @@
 package blockchainDB
 
 import (
+	"encoding/binary"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -103,6 +104,66 @@ func TestSegmentRoundTrip(t *testing.T) {
 
 	require.NoError(t, nodeA.Close())
 	require.NoError(t, nodeB.Close())
+}
+
+// keyForShard
+// A key that routes to the given shard, so a test can decide which
+// shards take writes in a block rather than relying on the spread of
+// random keys across 512 of them.
+func keyForShard(kr *FastRandom, shard int) [32]byte {
+	key := kr.NextHash()
+	binary.BigEndian.PutUint32(key[indexShards:], uint32(shard))
+	return key
+}
+
+// TestExportBlockQuietShardNotReexported
+// A shard that takes no writes during a block seals nothing, so it
+// appears nowhere in that block's manifest.  The next export must still
+// know the peer already has its older segments.
+//
+// prev carries only the previous block's segments, so a per-shard
+// high-water map built from it has no entry for a shard that was quiet
+// -- and every segment that shard holds is copied again, into every
+// block until it next seals.  Three blocks is the shortest sequence
+// that shows it: shard A seals in block 1 and is quiet thereafter, so
+// block 3 is where its segment reappears.
+func TestExportBlockQuietShardNotReexported(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	exportDir := filepath.Join(os.TempDir(), t.Name()+"_export")
+	for _, d := range []string{dir, exportDir} {
+		os.RemoveAll(d)
+		defer os.RemoveAll(d)
+	}
+
+	const shardA, shardB = 3, 7
+	node, err := NewKVShard(dir, 1000)
+	require.NoError(t, err)
+	defer node.Close()
+
+	kr := NewFastRandom([]byte{94})
+	vr := NewFastRandom([]byte{94, 94})
+
+	require.NoError(t, node.PutPerm(keyForShard(kr, shardA), vr.RandBuff(20, 100)))
+	m1, err := node.ExportBlock(exportDir, 1, nil)
+	require.NoError(t, err)
+	require.Len(t, m1.Segments, 1, "block 1 seals shard A only")
+	require.Equal(t, shardA, m1.Segments[0].Shard)
+
+	// Shard A is quiet from here on
+	require.NoError(t, node.PutPerm(keyForShard(kr, shardB), vr.RandBuff(20, 100)))
+	m2, err := node.ExportBlock(exportDir, 2, m1)
+	require.NoError(t, err)
+	require.Len(t, m2.Segments, 1, "block 2 seals shard B only")
+	require.Equal(t, shardB, m2.Segments[0].Shard)
+
+	require.NoError(t, node.PutPerm(keyForShard(kr, shardB), vr.RandBuff(20, 100)))
+	m3, err := node.ExportBlock(exportDir, 3, m2)
+	require.NoError(t, err)
+	for _, s := range m3.Segments {
+		assert.NotEqualf(t, shardA, s.Shard,
+			"shard %d sealed in block 1 and was quiet since; block 3 must not re-export it", s.Shard)
+	}
+	assert.Len(t, m3.Segments, 1, "block 3 seals shard B only")
 }
 
 // TestSegmentTamperDetection

--- a/database/segstore.go
+++ b/database/segstore.go
@@ -198,6 +198,70 @@ type SegmentStore struct {
 	liveFile    *BFile               // Their records
 	liveRecords uint64               // Physical records in liveFile (>= len(live) if keys repeat)
 	closed      bool                 // Set by Close; cleared by Open
+
+	// keys is a membership filter over everything the store holds --
+	// every sealed segment and the live tail.  It exists to make
+	// proving a key ABSENT cheap.
+	//
+	// Without it, "not here" costs a bloom probe against every sealed
+	// segment plus a binary search per false positive, so the answer
+	// gets steadily more expensive as the store seals: a store that has
+	// sealed 2,600 times pays 2,600 probes for it.  That is the
+	// question a write asks -- a new key is absent by definition -- so
+	// the write path decayed with the segment count.  One probe per
+	// BloomSet layer replaces it, and the layer count grows with the
+	// logarithm of the key count rather than with the seal count.
+	//
+	// A false positive costs no more than the walk it replaced, so a
+	// stale filter is slow, never wrong.  A false NEGATIVE would be
+	// silent data loss -- "not found" for a key that is right there --
+	// so the filter is used only where its coverage is proven, and nil
+	// (falling back to the walk) wherever it is not: see loadKeyFilter.
+	keys *BloomSet
+
+	// bloomValid/bloomAt are the coverage claim writeManifest records.
+	// It is a one-shot: only the manifest written immediately after a
+	// save carries it.
+	bloomValid bool
+	bloomAt    SegmentMeta
+
+	stats StoreStats // Counted under the Mutex, like everything else here
+}
+
+// StoreStats
+// What the store has been asked to do, and what it did about it.
+//
+// These exist to settle a design question with measurement rather than
+// intuition: an immutable store pays for a lookup on every write, and
+// the only thing that lookup can discover is that the key is already
+// there.  If that essentially never happens on a real workload, the
+// lookup is a tax on every write to catch a case that does not occur,
+// and a write could be a pure append with duplicates reconciled later.
+// If it happens often, the check is earning its keep.  PutDuplicate
+// over PutTotal is that ratio.
+//
+// The filter counters answer the companion question -- what the
+// store-level filter is actually buying -- including its false
+// positive rate in situ rather than at its design point.
+type StoreStats struct {
+	PutTotal     uint64 // Writes attempted
+	PutNew       uint64 // Key was absent: a record was appended
+	PutDuplicate uint64 // Key was present with the same value: write avoided
+	PutConflict  uint64 // Key was present with a different value
+
+	LookupTotal  uint64 // Lookups that reached the sealed segments logic
+	FilterAbsent uint64 // Settled by the filter alone: no segment touched
+	FilterWalked uint64 // Filter said "maybe" (or was absent): segments walked
+	FilterMisled uint64 // Walked on the filter's say-so and found nothing
+	LiveHit      uint64 // Answered from the live tail, before any filter
+}
+
+// Stats
+// A snapshot of the store's counters.
+func (s *SegmentStore) Stats() StoreStats {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+	return s.stats
 }
 
 // NewSegmentStore
@@ -209,6 +273,7 @@ func NewSegmentStore(directory string, mutable bool) (store *SegmentStore, err e
 	}
 	store = &SegmentStore{Directory: directory, Mutable: mutable}
 	store.live = make(map[[32]byte]*DBBKey)
+	store.keys = store.newKeyFilter(0)
 	if err = store.newLiveFile(); err != nil {
 		return nil, err
 	}
@@ -254,7 +319,30 @@ func (s *SegmentStore) SetSealLimit(limit uint64) (err error) {
 		return err
 	}
 	s.SealLimit = limit
+	// Resize the key filter's first layer to the scale the caller just
+	// declared, while it is still empty and resizing is free.  A store
+	// is created before its limit is known, so without this every store
+	// starts at the same size regardless of what it is for -- and a
+	// 512-shard database creates 1,024 of them.
+	if s.keys != nil && s.keys.Count() == 0 {
+		s.keys = s.newKeyFilter(0)
+	}
 	return s.writeManifest()
+}
+
+// newKeyFilter
+// A key filter sized for what this store is expected to hold: the
+// caller's estimate if it has one, and otherwise the seal limit, which
+// is the only scale the store is told about.  Both are a starting
+// point rather than a cap -- a BloomSet adds layers as it fills -- but
+// starting near the right size keeps the layer count, and so the cost
+// of a lookup, low.  newBloomSized floors tiny filters, so a store
+// configured to seal every two records gets 4KB rather than nothing.
+func (s *SegmentStore) newKeyFilter(expected uint64) *BloomSet {
+	if expected < s.SealLimit {
+		expected = s.SealLimit
+	}
+	return NewBloomSet(expected, 3)
 }
 
 // Open
@@ -296,10 +384,94 @@ func (s *SegmentStore) load() (err error) {
 	if err = s.recoverOrphans(); err != nil {
 		return err
 	}
+	// After recoverOrphans, because an adopted segment changes what the
+	// filter has to cover; before openLive, which adds the live keys as
+	// it replays them.
+	if err = s.loadKeyFilter(m); err != nil {
+		return err
+	}
 	if err = s.openLive(); err != nil {
 		return err
 	}
 	s.closed = false
+	return nil
+}
+
+// loadKeyFilter
+// Restore the store-level key filter: load the persisted one when the
+// manifest proves it covers exactly the sealed segments now open, and
+// rebuild it from those segments' own indexes otherwise.
+//
+// Coverage is proven rather than assumed because the two failure modes
+// are not symmetric.  A filter holding keys the store no longer has
+// costs a wasted walk.  A filter MISSING a key the store does hold
+// turns a Get into a wrong answer -- "not found" for a key sitting in
+// a segment -- and nothing downstream would catch it.  A crash, an
+// interrupted save, and a seal after the last save all leave the file
+// behind the segment list, so each of them rebuilds.
+func (s *SegmentStore) loadKeyFilter(m *StoreManifest) (err error) {
+	newest, ok := s.newestMeta()
+	covered := m.BloomValid &&
+		((ok && newest.Height == m.BloomHeight && newest.Seq == m.BloomSeq) ||
+			(!ok && len(s.segments) == 0)) // An empty filter covers no segments
+	if covered {
+		if s.keys, err = LoadBloomSet(s.Directory); err == nil {
+			return nil
+		}
+		s.keys = nil // Unreadable or truncated; rebuild instead
+	}
+	return s.rebuildKeyFilter()
+}
+
+// rebuildKeyFilter
+// Build the key filter from what the store actually holds.  Layer 0 is
+// sized for the current key count, so a store reopened at 30 million
+// keys starts with one layer covering all of them rather than growing
+// a stack of layers to reach them.
+//
+// A rebuild that fails leaves the filter nil, which is the safe
+// direction: lookups fall back to walking the segments, which is what
+// they did before the filter existed.
+func (s *SegmentStore) rebuildKeyFilter() (err error) {
+	var total uint64
+	for _, seg := range s.segments {
+		total += uint64(seg.count)
+	}
+	s.keys = s.newKeyFilter(total)
+	for _, seg := range s.segments {
+		if err = s.addSegmentKeys(seg); err != nil {
+			s.keys = nil
+			return err
+		}
+	}
+	for key := range s.live { // The tail is part of what the store holds
+		s.keys.Set(key)
+	}
+	return nil
+}
+
+// addSegmentKeys
+// Add every key in a sealed segment to the filter, read from the
+// segment's index: the keys are already there, sorted, 48 bytes apart.
+func (s *SegmentStore) addSegmentKeys(seg *segment) (err error) {
+	const batch = 4096 // Index records per read
+	buff := make([]byte, batch*DBKeyFullSize)
+	for i := int64(0); i < seg.count; {
+		n := seg.count - i
+		if n > batch {
+			n = batch
+		}
+		b := buff[:n*DBKeyFullSize]
+		if _, err = seg.index.ReadAt(b, segIndexHdrSize+i*DBKeyFullSize); err != nil {
+			return err
+		}
+		for j := int64(0); j < n; j++ {
+			var key [32]byte
+			copy(key[:], b[j*DBKeyFullSize:])
+			s.keys.Set(key)
+		}
+		i += n
+	}
 	return nil
 }
 
@@ -397,6 +569,9 @@ func (s *SegmentStore) openLive() (err error) {
 		}
 		s.live[key] = &DBBKey{Offset: valueOffset, Length: length}
 		s.liveRecords++
+		if s.keys != nil {
+			s.keys.Set(key)
+		}
 		offset = valueOffset + length
 	}
 
@@ -523,7 +698,14 @@ func (s *SegmentStore) readManifest() (m *StoreManifest, err error) {
 // Replace the manifest atomically.  This is the commit point for
 // sealing, importing, and compaction.
 func (s *SegmentStore) writeManifest() (err error) {
-	m := StoreManifest{Mutable: s.Mutable, SealLimit: s.SealLimit, BlockHeight: s.blockHeight}
+	// The coverage claim is true only of the manifest written directly
+	// after the filter was saved.  Everything else that writes a
+	// manifest -- a seal, a compaction, an import -- has changed the
+	// segment set, so clearing it here means no path can forget to.
+	defer func() { s.bloomValid = false }()
+
+	m := StoreManifest{Mutable: s.Mutable, SealLimit: s.SealLimit, BlockHeight: s.blockHeight,
+		BloomValid: s.bloomValid, BloomHeight: s.bloomAt.Height, BloomSeq: s.bloomAt.Seq}
 	for _, seg := range s.segments {
 		m.Segments = append(m.Segments, seg.meta)
 	}
@@ -592,13 +774,23 @@ func (s *SegmentStore) get(key [32]byte) (value []byte, err error) {
 	if err = s.checkOpen(); err != nil {
 		return nil, err
 	}
+	s.stats.LookupTotal++
 	if dbb, ok := s.live[key]; ok {
 		value = make([]byte, dbb.Length)
 		if err = s.liveFile.ReadAt(dbb.Offset, value); err != nil {
 			return nil, err
 		}
+		s.stats.LiveHit++
 		return value, nil
 	}
+	// One probe settles the common case.  The filter covers every key
+	// in the store, so a "no" here is definitive and the walk below --
+	// which is what grows with the seal count -- is skipped entirely.
+	if s.keys != nil && !s.keys.Test(key) {
+		s.stats.FilterAbsent++
+		return nil, errNotFound
+	}
+	s.stats.FilterWalked++
 	for i := len(s.segments) - 1; i >= 0; i-- { // Newest segment wins
 		dbb, found, err := s.segments[i].lookup(key)
 		if err != nil {
@@ -607,6 +799,9 @@ func (s *SegmentStore) get(key [32]byte) (value []byte, err error) {
 		if found {
 			return s.segments[i].value(dbb)
 		}
+	}
+	if s.keys != nil {
+		s.stats.FilterMisled++ // The walk was the filter's fault
 	}
 	return nil, errNotFound
 }
@@ -628,14 +823,26 @@ func (s *SegmentStore) put(key [32]byte, value []byte) (err error) {
 	if err = s.checkOpen(); err != nil {
 		return err
 	}
+	s.stats.PutTotal++
 	if !s.Mutable {
 		if existing, err := s.get(key); err == nil {
 			if bytes.Equal(existing, value) {
+				s.stats.PutDuplicate++
 				return nil // Same value: no-op
 			}
+			s.stats.PutConflict++
 			return errors.New("cannot overwrite immutable value")
 		}
 	}
+	s.stats.PutNew++
+	return s.writeRecord(key, value)
+}
+
+// writeRecord
+// Append a key/value to the live tail.  The caller must hold the Mutex
+// and must already have settled whether the write is allowed:
+// writeRecord enforces nothing, it just writes.
+func (s *SegmentStore) writeRecord(key [32]byte, value []byte) (err error) {
 	offset := s.liveFile.EOD + s.liveFile.EOB
 	var recHdr [segRecHdrSize]byte
 	copy(recHdr[:32], key[:])
@@ -648,7 +855,49 @@ func (s *SegmentStore) put(key [32]byte, value []byte) (err error) {
 	}
 	s.live[key] = &DBBKey{Offset: offset + segRecHdrSize, Length: uint64(len(value))}
 	s.liveRecords++
+	if s.keys != nil {
+		s.keys.Set(key)
+	}
 	return nil
+}
+
+// PutIfAbsent
+// Write a key/value pair only if the key is not already present, and
+// report what was found either way.
+//
+// This exists because the layer above -- KV2.Put, deciding which layer
+// a key belongs to -- asked "is this key here?" and then called Put,
+// which asked again to enforce immutability.  On a miss each question
+// costs a full lookup, and a new key is a miss by definition, so every
+// new key paid for the answer twice.  Asking once is also the atomic
+// version: the check and the write no longer straddle a gap that
+// another writer could reach through.
+//
+// A read that fails is not proof of absence, so only errNotFound
+// authorises the write; anything else is returned.
+func (s *SegmentStore) PutIfAbsent(key [32]byte, value []byte) (existing []byte, existed bool, err error) {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+	if err = s.checkOpen(); err != nil {
+		return nil, false, err
+	}
+	s.stats.PutTotal++
+	switch existing, err = s.get(key); {
+	case err == nil:
+		// Split the two ways a key can already be here, because they
+		// mean opposite things: an identical rewrite is a write this
+		// check avoided, a differing one is a write it caught.
+		if bytes.Equal(existing, value) {
+			s.stats.PutDuplicate++
+		} else {
+			s.stats.PutConflict++
+		}
+		return existing, true, nil
+	case !errors.Is(err, errNotFound):
+		return nil, false, err
+	}
+	s.stats.PutNew++
+	return nil, false, s.writeRecord(key, value)
 }
 
 // LiveCount
@@ -1129,6 +1378,16 @@ func (s *SegmentStore) compact(height uint64) (meta SegmentMeta, err error) {
 		os.Remove(strings.TrimSuffix(path, segDataSuffix) + segIndexSuffix)
 	}
 
+	// Compaction is the one moment the true key set is already in hand:
+	// what survived is exactly the new generation plus the live tail.
+	// Keeping the old filter would only cost lookups -- it can name
+	// keys that are gone but never miss one that stayed -- but a
+	// rebuild here is free of that drift and bounds the layer count.
+	if s.keys != nil {
+		if err := s.rebuildKeyFilter(); err != nil {
+			s.keys = nil // Correct, just slower: lookups walk again
+		}
+	}
 	return meta, nil
 }
 
@@ -1217,6 +1476,11 @@ func (s *SegmentStore) ImportSegmentFile(path string, meta SegmentMeta) (err err
 	}
 
 	s.segments = append(s.segments, seg)
+	if s.keys != nil {
+		if err = s.addSegmentKeys(seg); err != nil {
+			s.keys = nil // The filter must never under-report; drop it
+		}
+	}
 	return s.writeManifest() // Commit
 }
 
@@ -1263,6 +1527,21 @@ func (s *SegmentStore) checkNoConflicts(seg *segment) (err error) {
 func (s *SegmentStore) Close() (err error) {
 	s.Mutex.Lock()
 	defer s.Mutex.Unlock()
+
+	// Persist the key filter, then record in the manifest that it is
+	// current -- in that order, so a crash between the two leaves a
+	// manifest saying "rebuild" rather than one pointing at a filter
+	// that has fallen behind the segments.  A save that fails is not a
+	// reason to fail the close: the next open rebuilds.
+	if !s.closed && s.keys != nil {
+		if err := s.keys.Save(s.Directory); err == nil {
+			s.bloomAt, _ = s.newestMeta() // Zero when there are none, which is what covers none
+			s.bloomValid = true
+			if err := s.writeManifest(); err != nil {
+				return err
+			}
+		}
+	}
 
 	if s.liveFile != nil && s.liveFile.File != nil {
 		if err = s.liveFile.Close(); err != nil {

--- a/database/segstore.go
+++ b/database/segstore.go
@@ -197,6 +197,7 @@ type SegmentStore struct {
 	live        map[[32]byte]*DBBKey // Keys written since the last seal
 	liveFile    *BFile               // Their records
 	liveRecords uint64               // Physical records in liveFile (>= len(live) if keys repeat)
+	liveDirty   bool                 // Records written to the tail since the last fsync of it
 	closed      bool                 // Set by Close; cleared by Open
 
 	// keys is a membership filter over everything the store holds --
@@ -295,6 +296,10 @@ func (s *SegmentStore) newLiveFile() (err error) {
 		return err
 	}
 	s.liveRecords = 0
+	// The header is buffered, not written: a crash here leaves a 0-byte
+	// file, and open rewrites the header rather than trusting it to be
+	// there.  So there is nothing to lose until a record is appended.
+	s.liveDirty = false
 	return nil
 }
 
@@ -591,6 +596,8 @@ func (s *SegmentStore) openLive() (err error) {
 		}
 		s.liveFile.EOD = offset
 	}
+	// Everything replayed came off the disk, so it is already durable
+	s.liveDirty = false
 	return nil
 }
 
@@ -869,6 +876,7 @@ func (s *SegmentStore) writeRecord(key [32]byte, value []byte) (err error) {
 	}
 	s.live[key] = &DBBKey{Offset: offset + segRecHdrSize, Length: uint64(len(value))}
 	s.liveRecords++
+	s.liveDirty = true
 	if s.keys != nil {
 		s.keys.Set(key)
 	}
@@ -931,6 +939,61 @@ func (s *SegmentStore) LiveRecords() uint64 {
 	s.Mutex.Lock()
 	defer s.Mutex.Unlock()
 	return s.liveRecords
+}
+
+// BlockHeight
+// The block the live tail is accumulating into: the lowest height
+// Seal will accept.  A caller sealing at its own block numbers does
+// not need this, but one resuming after a crash does -- the block it
+// was about to seal may already be sealed and recorded.
+func (s *SegmentStore) BlockHeight() uint64 {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+	return s.blockHeight
+}
+
+// Sync
+// Make the live tail durable without sealing it: flush the buffer and
+// fsync the file, so every record written so far survives a power loss.
+//
+// This is the durability point for a store that is not being sealed.
+// Sealing is the other one, and it is the only one the Perm layer
+// needs, because a block boundary seals its whole tail.  The Dyna
+// layer is not sealed at a block boundary -- its segments are local,
+// not a peer's unit of sync -- so without this its newest writes sat
+// in a 32 KB buffer until the tail filled, and a crash restarted the
+// node with permanent records newer than the mutable state that
+// indexes them (issue #29).
+//
+// No manifest is written: the manifest names sealed segments, and the
+// live tail is recovered by replaying the file itself.  A tail
+// fsynced mid-record is fine -- open truncates a torn record and
+// replay resumes on the boundary before it.
+//
+// Sync is a no-op on a tail that has taken no writes since the last
+// one, so the shards a block did not touch cost nothing.
+func (s *SegmentStore) Sync() (err error) {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+	return s.sync()
+}
+
+// sync is Sync; the caller must hold the Mutex
+func (s *SegmentStore) sync() (err error) {
+	if err = s.checkOpen(); err != nil {
+		return err
+	}
+	if !s.liveDirty {
+		return nil
+	}
+	if err = s.liveFile.Flush(); err != nil {
+		return err
+	}
+	if err = s.liveFile.File.Sync(); err != nil {
+		return err
+	}
+	s.liveDirty = false
+	return nil
 }
 
 // SealNext

--- a/database/segstore.go
+++ b/database/segstore.go
@@ -69,20 +69,45 @@ const (
 
 // SegmentMeta
 // One sealed segment as recorded in the manifest
+// A segment is identified by (Height, Seq), not by Height alone.
+// Height is the block the segment belongs to and is globally agreed,
+// which is what lets a peer decide whether it already has a segment.
+// Seq orders the segments within one block: a live tail that fills
+// mid-block seals on its own, and those auto-seals must not consume
+// block numbers -- doing so made every later block boundary fail
+// permanently (issue #27).
 type SegmentMeta struct {
-	Height uint64 `json:"height"` // Block height the segment was sealed at
+	Height uint64 `json:"height"` // Block the segment belongs to
+	Seq    uint64 `json:"seq"`    // Order within that block
 	File   string `json:"file"`   // Data file name within the store directory
 	Count  uint64 `json:"count"`  // Number of keys indexed
 	Hash   string `json:"hash"`   // SHA-256 of the data file, hex
+}
+
+// after reports whether a is a strictly later segment than b
+func (a SegmentMeta) after(b SegmentMeta) bool {
+	if a.Height != b.Height {
+		return a.Height > b.Height
+	}
+	return a.Seq > b.Seq
 }
 
 // StoreManifest
 // The authoritative list of a store's sealed segments.  Replacing it
 // is the commit point for both sealing and compaction.
 type StoreManifest struct {
-	Mutable   bool          `json:"mutable"`
-	SealLimit uint64        `json:"sealLimit"` // 0: unset, caller decides
-	Segments  []SegmentMeta `json:"segments"`  // Oldest first
+	Mutable     bool          `json:"mutable"`
+	SealLimit   uint64        `json:"sealLimit"`   // 0: unset, caller decides
+	BlockHeight uint64        `json:"blockHeight"` // Block currently being accumulated
+	Segments    []SegmentMeta `json:"segments"`    // Oldest first
+
+	// BloomValid says the persisted key filter (bloom.dat) covers
+	// exactly the sealed segments listed here, and BloomHeight/BloomSeq
+	// name the newest of them.  Height 0, Seq 0 is a legitimate
+	// segment, so the flag carries the claim rather than the numbers.
+	BloomValid  bool   `json:"bloomValid,omitempty"`
+	BloomHeight uint64 `json:"bloomHeight,omitempty"`
+	BloomSeq    uint64 `json:"bloomSeq,omitempty"`
 }
 
 // segment
@@ -161,6 +186,12 @@ type SegmentStore struct {
 	// before this was persisted a reopened database silently fell back
 	// to a default, discarding the only parameter its constructor takes.
 	SealLimit uint64
+
+	// blockHeight is the block whose writes the live tail is
+	// accumulating.  A block boundary seals at its own height and then
+	// advances this, so auto-seals in between are tagged with the block
+	// they actually belong to rather than allocating one of their own.
+	blockHeight uint64
 
 	segments    []*segment           // Sealed segments, oldest first
 	live        map[[32]byte]*DBBKey // Keys written since the last seal
@@ -252,6 +283,7 @@ func (s *SegmentStore) load() (err error) {
 	}
 	s.Mutable = m.Mutable
 	s.SealLimit = m.SealLimit
+	s.blockHeight = m.BlockHeight
 
 	for _, meta := range m.Segments {
 		seg, err := s.openSegment(meta)
@@ -406,7 +438,7 @@ func (s *SegmentStore) recoverOrphans() (err error) {
 	for _, seg := range s.segments {
 		known[seg.meta.File] = true
 	}
-	newest, haveSegments := s.newestHeight()
+	newest, haveSegments := s.newestMeta()
 
 	var adopted []SegmentMeta
 	for _, e := range entries {
@@ -418,12 +450,13 @@ func (s *SegmentStore) recoverOrphans() (err error) {
 		if !strings.HasPrefix(name, segFilePrefix) || !strings.HasSuffix(name, segDataSuffix) || known[name] {
 			continue
 		}
-		height, err := heightFromName(name)
+		height, seq, err := keyFromName(name)
 		if err != nil {
 			continue // Not ours
 		}
+		orphan := SegmentMeta{Height: height, Seq: seq}
 		path := filepath.Join(s.Directory, name)
-		if haveSegments && height <= newest { // Superseded by a committed compaction
+		if haveSegments && !orphan.after(newest) { // Superseded by a committed compaction
 			os.Remove(path)
 			os.Remove(strings.TrimSuffix(path, segDataSuffix) + segIndexSuffix)
 			continue
@@ -432,13 +465,13 @@ func (s *SegmentStore) recoverOrphans() (err error) {
 		if err != nil {
 			return err
 		}
-		adopted = append(adopted, SegmentMeta{Height: height, File: name, Count: count, Hash: hash})
+		adopted = append(adopted, SegmentMeta{Height: height, Seq: seq, File: name, Count: count, Hash: hash})
 	}
 	if len(adopted) == 0 {
 		return nil
 	}
 
-	sort.Slice(adopted, func(i, j int) bool { return adopted[i].Height < adopted[j].Height })
+	sort.Slice(adopted, func(i, j int) bool { return adopted[j].after(adopted[i]) })
 	for _, meta := range adopted {
 		seg, err := s.openSegment(meta)
 		if err != nil {
@@ -452,15 +485,25 @@ func (s *SegmentStore) recoverOrphans() (err error) {
 }
 
 // heightFromName parses seg-<height>.dat
-func heightFromName(name string) (height uint64, err error) {
+// keyFromName recovers (height, seq) from a data file name.  Files
+// written before segments carried a sequence have no "-seq" part and
+// read back as seq 0, which is what they were.
+func keyFromName(name string) (height, seq uint64, err error) {
 	body := strings.TrimSuffix(strings.TrimPrefix(name, segFilePrefix), segDataSuffix)
+	if h, s, ok := strings.Cut(body, "-"); ok {
+		if _, err = fmt.Sscanf(h, "%d", &height); err != nil {
+			return 0, 0, err
+		}
+		_, err = fmt.Sscanf(s, "%d", &seq)
+		return height, seq, err
+	}
 	_, err = fmt.Sscanf(body, "%d", &height)
-	return height, err
+	return height, 0, err
 }
 
-// segmentFileName is the data file name for a height
-func segmentFileName(height uint64) string {
-	return fmt.Sprintf("%s%08d%s", segFilePrefix, height, segDataSuffix)
+// segmentFileName is the data file name for a (height, seq)
+func segmentFileName(height, seq uint64) string {
+	return fmt.Sprintf("%s%08d-%04d%s", segFilePrefix, height, seq, segDataSuffix)
 }
 
 // readManifest loads segments.json
@@ -480,7 +523,7 @@ func (s *SegmentStore) readManifest() (m *StoreManifest, err error) {
 // Replace the manifest atomically.  This is the commit point for
 // sealing, importing, and compaction.
 func (s *SegmentStore) writeManifest() (err error) {
-	m := StoreManifest{Mutable: s.Mutable, SealLimit: s.SealLimit}
+	m := StoreManifest{Mutable: s.Mutable, SealLimit: s.SealLimit, BlockHeight: s.blockHeight}
 	for _, seg := range s.segments {
 		m.Segments = append(m.Segments, seg.meta)
 	}
@@ -519,6 +562,12 @@ func (s *SegmentStore) writeManifest() (err error) {
 // answer "not found" for keys that are simply not loaded.  Callers
 // reopen with Open, which is cheap and safe on an already-open store.
 var errStoreClosed = errors.New("segment store is closed")
+
+// errNotFound is what a lookup returns for a key the store does not
+// hold.  It is a single value rather than a fresh error per call so
+// that a caller can tell "absent" from "the read failed", which
+// matters wherever absence is what authorises a write.
+var errNotFound = errors.New("not found")
 
 // checkOpen reports whether the store can be operated on.  The caller
 // must hold the Mutex.
@@ -559,7 +608,7 @@ func (s *SegmentStore) get(key [32]byte) (value []byte, err error) {
 			return s.segments[i].value(dbb)
 		}
 	}
-	return nil, errors.New("not found")
+	return nil, errNotFound
 }
 
 // Put
@@ -587,7 +636,6 @@ func (s *SegmentStore) put(key [32]byte, value []byte) (err error) {
 			return errors.New("cannot overwrite immutable value")
 		}
 	}
-
 	offset := s.liveFile.EOD + s.liveFile.EOB
 	var recHdr [segRecHdrSize]byte
 	copy(recHdr[:32], key[:])
@@ -622,24 +670,15 @@ func (s *SegmentStore) LiveRecords() uint64 {
 	return s.liveRecords
 }
 
-// nextHeight
-// The height at which a seal or compaction lands above every existing
-// segment.  The caller must hold the Mutex.
-func (s *SegmentStore) nextHeight() uint64 {
-	if newest, ok := s.newestHeight(); ok {
-		return newest + 1
-	}
-	return 0
-}
-
 // SealNext
-// Seal the live tail at the next available height.  Used to bound the
-// live tail when no block boundary has arrived; block boundaries call
-// Seal with the block height instead.
+// Seal the live tail without a block boundary, to bound the tail when
+// it fills mid-block.  The segment is tagged with the block currently
+// being accumulated and takes the next sequence within it, so an
+// auto-seal never consumes a block number (issue #27).
 func (s *SegmentStore) SealNext() (meta SegmentMeta, err error) {
 	s.Mutex.Lock()
 	defer s.Mutex.Unlock()
-	return s.seal(s.nextHeight())
+	return s.seal(s.blockHeight, false)
 }
 
 // Seal
@@ -649,25 +688,40 @@ func (s *SegmentStore) SealNext() (meta SegmentMeta, err error) {
 // When the tail holds no shadowed records -- the usual case for an
 // immutable store -- the file is renamed into place rather than
 // copied, so sealing costs a header write, an index build, and a hash.
+// Sealing at a block boundary also advances the block the live tail
+// accumulates into, so the auto-seals that follow are tagged with the
+// next block rather than the one just closed.
 func (s *SegmentStore) Seal(height uint64) (meta SegmentMeta, err error) {
 	s.Mutex.Lock()
 	defer s.Mutex.Unlock()
-	return s.seal(height)
+	return s.seal(height, true)
 }
 
-// seal is Seal; the caller must hold the Mutex
-func (s *SegmentStore) seal(height uint64) (meta SegmentMeta, err error) {
+// seal is Seal; the caller must hold the Mutex.  blockBoundary marks
+// the seal as closing `height` rather than merely bounding the tail
+// inside it.
+func (s *SegmentStore) seal(height uint64, blockBoundary bool) (meta SegmentMeta, err error) {
 	if err = s.checkOpen(); err != nil {
 		return meta, err
 	}
-	if len(s.live) == 0 {
-		return meta, nil // Nothing to seal
+	if blockBoundary && s.blockHeight > height {
+		return meta, fmt.Errorf("block %d is already closed; now accumulating block %d", height, s.blockHeight)
 	}
-	if newest, ok := s.newestHeight(); ok && height <= newest {
-		return meta, fmt.Errorf("seal height %d is not above the newest segment height %d", height, newest)
+	seq, err := s.nextKeyAt(height)
+	if err != nil {
+		return meta, err
+	}
+	if len(s.live) == 0 {
+		// Nothing to seal, but a block boundary still closes the block:
+		// the next writes belong to the block after this one
+		if blockBoundary && s.blockHeight <= height {
+			s.blockHeight = height + 1
+			return meta, s.writeManifest()
+		}
+		return meta, nil
 	}
 
-	dataName := segmentFileName(height)
+	dataName := segmentFileName(height, seq)
 	dataPath := filepath.Join(s.Directory, dataName)
 
 	var sl sealed
@@ -688,12 +742,18 @@ func (s *SegmentStore) seal(height uint64) (meta SegmentMeta, err error) {
 		return meta, err
 	}
 
-	meta = SegmentMeta{Height: height, File: dataName, Count: uint64(len(sl.order)), Hash: sl.hash}
+	meta = SegmentMeta{Height: height, Seq: seq, File: dataName, Count: uint64(len(sl.order)), Hash: sl.hash}
 	seg, err := s.openSegment(meta)
 	if err != nil {
 		return meta, err
 	}
 	s.segments = append(s.segments, seg)
+	if s.blockHeight < height {
+		s.blockHeight = height
+	}
+	if blockBoundary {
+		s.blockHeight = height + 1 // The next writes belong to the next block
+	}
 
 	if err = s.writeManifest(); err != nil { // Commit
 		return meta, err
@@ -707,17 +767,37 @@ func (s *SegmentStore) seal(height uint64) (meta SegmentMeta, err error) {
 	return meta, nil
 }
 
-// newestHeight
-// The height of the newest sealed segment.  ok is false when the store
-// has no sealed segments, so that height 0 (a genesis block) is a
-// usable height rather than a sentinel.
-func (s *SegmentStore) newestHeight() (newest uint64, ok bool) {
+// newestMeta
+// The newest sealed segment by (Height, Seq).  ok is false when the
+// store has no sealed segments, so that height 0 (a genesis block) is
+// a usable height rather than a sentinel.
+func (s *SegmentStore) newestMeta() (newest SegmentMeta, ok bool) {
 	for _, seg := range s.segments {
-		if !ok || seg.meta.Height > newest {
-			newest, ok = seg.meta.Height, true
+		if !ok || seg.meta.after(newest) {
+			newest, ok = seg.meta, true
 		}
 	}
 	return newest, ok
+}
+
+// nextKeyAt
+// The identity a new segment takes when it is sealed into block
+// `height`: the next sequence within that block, or 0 if the block has
+// no segments yet.  Returns an error if the store already holds a
+// segment from a later block, which would break the ordering every
+// other part of the store relies on.
+func (s *SegmentStore) nextKeyAt(height uint64) (seq uint64, err error) {
+	newest, ok := s.newestMeta()
+	if !ok {
+		return 0, nil
+	}
+	if height < newest.Height {
+		return 0, fmt.Errorf("block height %d is below the newest segment's block %d", height, newest.Height)
+	}
+	if height == newest.Height {
+		return newest.Seq + 1, nil
+	}
+	return 0, nil
 }
 
 // sealed
@@ -890,7 +970,7 @@ func (s *SegmentStore) Compact(height uint64) (meta SegmentMeta, err error) {
 func (s *SegmentStore) CompactNext() (meta SegmentMeta, err error) {
 	s.Mutex.Lock()
 	defer s.Mutex.Unlock()
-	return s.compact(s.nextHeight())
+	return s.compact(s.blockHeight)
 }
 
 // compact is Compact; the caller must hold the Mutex
@@ -901,8 +981,12 @@ func (s *SegmentStore) compact(height uint64) (meta SegmentMeta, err error) {
 	if len(s.segments) == 0 {
 		return meta, nil
 	}
-	if newest, ok := s.newestHeight(); ok && height <= newest {
-		return meta, fmt.Errorf("compaction height %d is not above the newest segment height %d", height, newest)
+	seq, err := s.nextKeyAt(height)
+	if err != nil {
+		return meta, err
+	}
+	if s.blockHeight < height {
+		s.blockHeight = height
 	}
 
 	// Newest wins: walk segments newest to oldest, keeping the first
@@ -945,7 +1029,7 @@ func (s *SegmentStore) compact(height uint64) (meta SegmentMeta, err error) {
 	}
 	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i][:], keys[j][:]) < 0 })
 
-	dataName := segmentFileName(height)
+	dataName := segmentFileName(height, seq)
 	dataPath := filepath.Join(s.Directory, dataName)
 	tmpPath := filepath.Join(s.Directory, segCompactName+segTmpSuffix)
 	f, err := os.Create(tmpPath)
@@ -1018,7 +1102,7 @@ func (s *SegmentStore) compact(height uint64) (meta SegmentMeta, err error) {
 		return meta, err
 	}
 
-	meta = SegmentMeta{Height: height, File: dataName, Count: uint64(len(keys)), Hash: ""}
+	meta = SegmentMeta{Height: height, Seq: seq, File: dataName, Count: uint64(len(keys)), Hash: ""}
 	if h != nil {
 		meta.Hash = fmt.Sprintf("%x", h.Sum(nil))
 	}
@@ -1044,6 +1128,7 @@ func (s *SegmentStore) compact(height uint64) (meta SegmentMeta, err error) {
 		os.Remove(path)
 		os.Remove(strings.TrimSuffix(path, segDataSuffix) + segIndexSuffix)
 	}
+
 	return meta, nil
 }
 
@@ -1077,18 +1162,19 @@ func (s *SegmentStore) ImportSegmentFile(path string, meta SegmentMeta) (err err
 	}
 
 	for _, seg := range s.segments {
-		if seg.meta.Height == meta.Height && seg.meta.Hash == meta.Hash {
+		if seg.meta.Height == meta.Height && seg.meta.Seq == meta.Seq && seg.meta.Hash == meta.Hash {
 			return nil // Already have it
 		}
 	}
-	if newest, ok := s.newestHeight(); ok && meta.Height <= newest {
-		return fmt.Errorf("segment height %d is not above the newest segment height %d", meta.Height, newest)
+	if newest, ok := s.newestMeta(); ok && !meta.after(newest) {
+		return fmt.Errorf("segment (block %d, seq %d) is not above the newest segment (block %d, seq %d)",
+			meta.Height, meta.Seq, newest.Height, newest.Seq)
 	}
 	if err = VerifySegmentFile(path, meta.Hash); err != nil {
 		return err
 	}
 
-	dataName := segmentFileName(meta.Height)
+	dataName := segmentFileName(meta.Height, meta.Seq)
 	dataPath := filepath.Join(s.Directory, dataName)
 	tmpPath := dataPath + segTmpSuffix
 	if err = copyFileSynced(path, tmpPath); err != nil {
@@ -1112,6 +1198,9 @@ func (s *SegmentStore) ImportSegmentFile(path string, meta SegmentMeta) (err err
 	}
 	meta.Count = uint64(seg.count)
 	seg.meta = meta
+	if s.blockHeight < meta.Height {
+		s.blockHeight = meta.Height
+	}
 
 	// An immutable store must not silently shadow a value it already
 	// holds: that is a divergence, not an update.  Checking is cheap
@@ -1174,6 +1263,7 @@ func (s *SegmentStore) checkNoConflicts(seg *segment) (err error) {
 func (s *SegmentStore) Close() (err error) {
 	s.Mutex.Lock()
 	defer s.Mutex.Unlock()
+
 	if s.liveFile != nil && s.liveFile.File != nil {
 		if err = s.liveFile.Close(); err != nil {
 			return err

--- a/database/segstore.go
+++ b/database/segstore.go
@@ -751,6 +751,20 @@ var errStoreClosed = errors.New("segment store is closed")
 // matters wherever absence is what authorises a write.
 var errNotFound = errors.New("not found")
 
+// ErrImmutable is returned when a key already in an immutable store is
+// written with a different value.
+//
+// It is exported because refusing the write is a fact about the
+// caller's record model, not a store failure: a caller that classifies
+// its own records into the two layers -- which is the point of having
+// two, and what ShardWriter assumes by exposing only PutPerm and
+// PutDyna -- can carry on from a refusal by writing the record to the
+// dynamic layer, but must stop for a store that failed.  Without a
+// sentinel the two arrive as a bare error and the only way to separate
+// them is to match the message, which made the wording load-bearing
+// API that nothing here knew it had promised (issue #28).
+var ErrImmutable = errors.New("cannot overwrite immutable value")
+
 // checkOpen reports whether the store can be operated on.  The caller
 // must hold the Mutex.
 func (s *SegmentStore) checkOpen() error {
@@ -831,7 +845,7 @@ func (s *SegmentStore) put(key [32]byte, value []byte) (err error) {
 				return nil // Same value: no-op
 			}
 			s.stats.PutConflict++
-			return errors.New("cannot overwrite immutable value")
+			return ErrImmutable
 		}
 	}
 	s.stats.PutNew++

--- a/database/segstore_test.go
+++ b/database/segstore_test.go
@@ -535,3 +535,74 @@ func TestSegmentStoreTornTailIsTruncated(t *testing.T) {
 	require.Error(t, err, "the torn record must not resolve")
 	require.NoError(t, s3.Close())
 }
+
+// TestAutoSealDoesNotConsumeBlockHeights
+// Regression test for issue #27.  Auto-seals used to allocate
+// newest+1 -- the same namespace block boundaries use -- so once a
+// shard's live tail had filled more times than the current block
+// number, every SealBlock/ExportBlock failed permanently.
+func TestAutoSealDoesNotConsumeBlockHeights(t *testing.T) {
+	dir := storeDir(t, "autoseal")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+
+	// Eight auto-seals before the first block boundary ever arrives
+	kr := NewFastRandom([]byte{41})
+	for i := 0; i < 8; i++ {
+		for j := 0; j < 5; j++ {
+			require.NoError(t, store.Put(kr.NextHash(), []byte("v")))
+		}
+		_, err = store.SealNext()
+		require.NoError(t, err)
+	}
+	require.Len(t, store.segments, 8)
+	for i, seg := range store.segments {
+		assert.Equal(t, uint64(0), seg.meta.Height, "auto-seal %d must stay in block 0", i)
+		assert.Equal(t, uint64(i), seg.meta.Seq, "auto-seal %d must take the next sequence", i)
+	}
+
+	// The first block boundary must still be sealable
+	require.NoError(t, store.Put(kr.NextHash(), []byte("v")))
+	meta, err := store.Seal(1)
+	require.NoError(t, err, "block 1 must be sealable after auto-seals")
+	assert.Equal(t, uint64(1), meta.Height)
+	assert.Equal(t, uint64(0), meta.Seq, "a new block starts a new sequence")
+
+	// And auto-seals after the boundary belong to the NEXT block, not
+	// the one just closed -- they hold writes that arrived after it
+	require.NoError(t, store.Put(kr.NextHash(), []byte("v")))
+	auto, err := store.SealNext()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), auto.Height, "an auto-seal after block 1 belongs to block 2")
+
+	require.NoError(t, store.Put(kr.NextHash(), []byte("v")))
+	meta, err = store.Seal(2)
+	require.NoError(t, err, "block 2 must be sealable after an auto-seal inside it")
+	assert.Equal(t, uint64(2), meta.Height)
+	assert.Equal(t, uint64(1), meta.Seq)
+	require.NoError(t, store.Close())
+}
+
+// TestAutoSealBlockSurvivesReopen
+// The accumulating block is part of the store's durable state: losing
+// it on reopen would let a post-restart auto-seal land back in a block
+// that was already closed and exported.
+func TestAutoSealBlockSurvivesReopen(t *testing.T) {
+	dir := storeDir(t, "autoseal-reopen")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+	kr := NewFastRandom([]byte{42})
+	require.NoError(t, store.Put(kr.NextHash(), []byte("v")))
+	_, err = store.Seal(7)
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+
+	re, err := OpenSegmentStore(dir)
+	require.NoError(t, err)
+	require.NoError(t, re.Put(kr.NextHash(), []byte("v")))
+	auto, err := re.SealNext()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(8), auto.Height,
+		"after reopening a store that closed block 7, writes belong to block 8")
+	require.NoError(t, re.Close())
+}

--- a/database/segstore_test.go
+++ b/database/segstore_test.go
@@ -99,13 +99,16 @@ func TestSegmentStoreImmutability(t *testing.T) {
 	require.NoError(t, store.Put(key, []byte("original")))
 
 	require.NoError(t, store.Put(key, []byte("original")), "identical rewrite must be a no-op")
-	require.Error(t, store.Put(key, []byte("different")), "conflicting value must fail")
+	// ErrorIs, not Error: a caller routing its own records between the
+	// layers has to tell a refusal from a store failure without matching
+	// on the message (issue #28)
+	require.ErrorIs(t, store.Put(key, []byte("different")), ErrImmutable, "conflicting value must fail")
 
 	_, err = store.Seal(1)
 	require.NoError(t, err)
 
 	require.NoError(t, store.Put(key, []byte("original")), "identical rewrite of a sealed key must be a no-op")
-	require.Error(t, store.Put(key, []byte("different")), "conflicting value with a sealed key must fail")
+	require.ErrorIs(t, store.Put(key, []byte("different")), ErrImmutable, "conflicting value with a sealed key must fail")
 
 	v, err := store.Get(key)
 	require.NoError(t, err)

--- a/docs/design/block-segmentation.md
+++ b/docs/design/block-segmentation.md
@@ -22,12 +22,23 @@ and hashed, is a **segment**: the verifiable unit of node sync.
     ...more writes...
     m2, _ := kvs.ExportBlock(exportDir, 2, m1)    // block 2: only what's new
 
-Each block directory holds one segment file per shard plus a
-`manifest.json` recording, per shard: record count, the `values.dat`
-end offset reached, and the SHA-256 of the segment file. Manifests
-chain: block N+1 exports from block N's end offsets, so consecutive
-blocks partition the data exactly. The manifest is written last (tmp +
-rename), so its presence marks a complete export.
+Each block directory holds a `manifest.json` and the segment files it
+names, recording for each: its shard, its `(height, seq)`, its record
+count, and the SHA-256 of the file. A shard contributes as many
+segments as it sealed during the block — one per auto-seal when its
+live tail filled, plus the boundary seal — and a shard that took no
+writes contributes none. The manifest is written last (tmp + rename),
+so its presence marks a complete export.
+
+Manifests chain on the **block number**: block N+1 exports every
+segment whose height is above N. That works because a boundary seal
+advances the block each shard accumulates into, so every segment
+sealed after block N's export carries a height above N. It is
+deliberately not a per-shard high-water mark taken from the previous
+manifest: a shard quiet during block N appears nowhere in it, and a
+per-shard rule has no entry to skip that shard by, so it re-exports
+every segment the shard holds — into every block until it next seals
+(`TestExportBlockQuietShardNotReexported`).
 
 **Syncing (new node):**
 

--- a/docs/design/durability.md
+++ b/docs/design/durability.md
@@ -8,8 +8,8 @@ Tracks issue #5.
 ## The contract
 
 **`KV2.Close()` is a durability point**, as is a `Seal` (and so
-`KVShard.SealBlock`). After a process dies (SIGKILL, power loss) at an
-arbitrary moment:
+`KVShard.SealBlock` and `ExportBlock`) — **for both layers**. After a
+process dies (SIGKILL, power loss) at an arbitrary moment:
 
 1. `OpenKV2` succeeds — the database is never left unopenable.
 2. Every key written before the last completed durability point is
@@ -17,6 +17,37 @@ arbitrary moment:
 3. Writes after the last durability point may be wholly present,
    partially present, or absent — but they never corrupt the database,
    and **replaying them succeeds** (see below).
+
+### A block boundary covers both layers
+
+`Seal` closes a block on a *running* store, and until issue #29 it
+only half did.  Sealing is the Perm layer's durability point, so
+permanent records were on disk the moment it returned.  The Dyna layer
+was not sealed at a block boundary — its segments are local, never a
+peer's unit of sync — so its newest writes sat in `BFile`'s 32 KB
+buffer until the tail filled, a compaction ran, or the store was
+closed.
+
+That is not a slow write, it is a *torn commit*.  In Accumulate every
+chain element is permanent and every mutable record — account state,
+chain heads, BPT nodes — is dynamic, so a node killed after a commit
+came back holding chain elements newer than the heads that index them:
+the two layers disagreed about where the block ended.
+
+`KV2.Seal` now seals Perm and **syncs** Dyna: flush the live tail,
+fsync it, done.  Syncing rather than sealing is deliberate — cutting a
+Dyna segment per block per shard would buy nothing (no peer receives
+one) and cost a seal's hash and manifest commit every block.  No
+manifest is written either, because the live tail is recovered by
+replaying the file, and a tail fsynced mid-record is fine: open
+truncates the torn record and resumes on the boundary before it.  A
+sync of a tail that took no writes is a no-op, so the shards a block
+did not touch cost nothing.
+
+`SegmentStore.Sync()` is exported, so a caller wanting a durability
+point without a block boundary has one.
+
+## The tests
 
 `TestCrashRecovery` enforces this: a child process writes to both
 layers with checkpoints at each `Close`, the parent SIGKILLs it at
@@ -27,6 +58,19 @@ because nothing in `KV2` compacts by itself -- `sealPermIfFull` and
 `sealDynaIfFull` seal and stop there -- so without it the compaction
 path would never be under the kill.  Adding it is what surfaced the
 three defects listed under *Fixed here*.
+
+`TestCrashRecoverySeal` runs the same rounds against the other
+durability point: the child checkpoints at `Seal` and never closes.
+It is the only one of the two that can see issue #29, because `Close`
+flushes and fsyncs both layers and so hides a layer that a block
+boundary was leaving buffered.  Against the unfixed code it loses the
+first dynamic key in the first round.
+
+The child seals the block the store is *accumulating*
+(`PermKV.BlockHeight()`) rather than a counted one: a kill between a
+seal and the `CHECKPOINT` line that reports it rolls the parent's
+restart point back to before that seal, and re-sealing a block the
+store has already closed is an error.
 
 ## How the windows are covered
 
@@ -95,10 +139,11 @@ unfixed code.
   directory. Create once, verify, then rely on the contract. Recovery:
   delete and recreate.
 - `Flush` on the `ShardWriter` is an application barrier, not an
-  fsync; pair it with `Close` (or `SealBlock`) at block boundaries that
-  must be durable. Wiring `Flush` to `Seal` so that a block boundary is
-  one durability, sync, and compaction boundary is the next step in
-  [Segments as storage](segment-store.md).
+  fsync: it drains the queues so the writes have *reached* the store,
+  and says nothing about the disk. Follow it with `SealBlock` (or
+  `Close`) at a block boundary that must be durable — `SealBlock` is
+  now the whole durability point for both layers, so that pair is the
+  block boundary.
 - A key written to Dyna keeps a stale copy in Perm. `Get` resolves the
   layer order, so the copy is dead weight rather than a wrong answer,
   but compaction does not reclaim it.

--- a/docs/design/segment-store.md
+++ b/docs/design/segment-store.md
@@ -10,13 +10,28 @@ v1 keeps data in `kfile.dat` + `history.dat` + `values.dat` and treats
 segments as an *export format*: syncing a peer re-inserts every record.
 v2 makes the segment format the *storage* itself.
 
-    live.dat            records accepted since the last seal
-    seg-<height>.dat    a sealed, immutable segment (the transport format)
-    seg-<height>.idx    its index: sorted 48-byte key records + a bloom
-    segments.json       the manifest: segments, counts, hashes
+    live.dat                  records accepted since the last seal
+    seg-<block>-<seq>.dat     a sealed, immutable segment (the transport format)
+    seg-<block>-<seq>.idx     its index: sorted 48-byte key records + a bloom
+    segments.json             the manifest: segments, counts, hashes
 
 Writes append to the live tail. `Seal(height)` turns the tail into an
 immutable segment; nothing already written is ever moved or rewritten.
+
+A segment is identified by **(block, seq)**, not by block alone. The
+block is globally agreed, which is what lets a peer decide whether it
+already holds a segment; `seq` orders the segments within one block. A
+tail that fills mid-block seals itself, and those auto-seals take the
+next `seq` rather than a block number of their own. Conflating the two
+was issue #27: auto-seals consumed block numbers, so once a shard's
+tail had filled more times than the current block, every subsequent
+block boundary failed permanently and block export stopped working
+altogether.
+
+`Seal(height)` closes a block and advances the block the tail
+accumulates into, so auto-seals that follow are tagged with the block
+they actually belong to. Re-closing a block that is already closed is
+rejected.
 Lookups check the tail, then segments newest to oldest — each segment's
 bloom filter (sized from its own key count) keeps that to about one
 binary search.
@@ -88,13 +103,13 @@ pins the behaviour.)
 ## Crash recovery
 
 The manifest is the commit point for sealing, importing, and
-compaction, and its newest height decides what to do with a data file
-the manifest does not name:
+compaction, and its newest `(block, seq)` decides what to do with a
+data file the manifest does not name:
 
-- **above** the newest height — a seal or import that reached disk but
-  not the manifest. It is complete by construction (fsync precedes the
-  rename), so it is adopted, its index rebuilt if missing, and the
-  manifest updated.
+- **above** the newest `(block, seq)` — a seal or import that reached
+  disk but not the manifest. It is complete by construction (fsync
+  precedes the rename), so it is adopted, its index rebuilt if missing,
+  and the manifest updated.
 - **at or below** — superseded by a committed compaction; deleted.
 - `*.tmp` — never complete; deleted.
 
@@ -172,7 +187,13 @@ record from a crash mid-write is dropped.
    `TestCrashRecovery` was retargeted from `KV` to `KV2` rather than
    deleted, so the SIGKILL durability contract is still enforced end
    to end.
-4. Next — wire `ShardWriter.Flush` to `Seal` so a block boundary is one
+4. **Done** — a segment is identified by `(block, seq)` rather than by
+   block alone, so a tail that fills mid-block no longer consumes block
+   numbers (issue #27). `ExportBlock` also seals every shard before
+   copying any of them: sealing is durable and cannot be rolled back,
+   so a failure partway through the copy phase would otherwise leave a
+   block half-built with some shards already closed at that height.
+5. Next — wire `ShardWriter.Flush` to `Seal` so a block boundary is one
    durability, sync, and compaction boundary.
 
 Not yet done here: a per-segment key count cap (segments grow with the


### PR DESCRIPTION
Five commits: the two already on this branch, plus fixes for #27, #28 and #29.

### Already on the branch

- **`82c3ad1`** persists `SealLimit`, corrects auto-seal block numbering by splitting `SegmentMeta` into `(Height, Seq)`, and documents both — the substance of #27.
- **`8b8b07c`** proves a key absent without walking every sealed segment.

### #27 — `f7150af` Skip a block export by block number, not by shard

`ExportBlock` decided what a peer already had from a per-shard high-water mark built out of the previous manifest. A shard that takes no writes during a block seals nothing and so appears nowhere in that block's manifest — the map has no entry to skip it by, the `ok &&` guard falls through, and every segment the shard holds is copied again, into every block until it next seals.

The block number needs no map and is the right boundary: a boundary seal advances the block each shard accumulates into, so a segment sealed after block N's export carries a height above N.

`TestExportBlockQuietShardNotReexported` is the three-block sequence that shows it. Against the old code, block 3 re-exports shard 3's block-1 segment.

Also routes the seal phase through `SealBlock`, which opens each shard first where the inline loop did not, and corrects `block-segmentation.md` — it still described manifests chaining on per-shard `values.dat` end offsets, which sealed segments replaced.

### #28 — `6ca5495` Give the immutable-overwrite refusal a sentinel error

`ErrImmutable`, so a caller classifying its own records can tell "I put this in the wrong layer" (survivable — the write belongs in the dynamic layer) from "the store failed" (not survivable) without matching on the message, which Accumulate's `bcdb` backend is doing today. The message is unchanged, so text matching keeps working. `errors.Is` reaches it through `KV2.PutPerm`, `KVShard.PutPerm` and `ShardWriter`.

### #29 — `7766d52` Make a block boundary durable for both layers, not just Perm

`KV2.Seal` sealed Perm and stopped. Dyna is not sealed at a block boundary, so its newest writes sat in `BFile`'s 32 KB buffer until the tail filled, a compaction ran, or the store closed. That is a torn commit, not a slow write: in Accumulate every chain element is permanent and every mutable record is dynamic, so a node killed after a commit came back holding chain elements newer than the heads that index them.

`Seal` now seals Perm and **syncs** Dyna. Syncing rather than sealing is the point — a Dyna segment per block per shard buys nothing (no peer receives one) and costs a hash and a manifest commit every block. A tail with no writes since the last sync is a no-op, so quiet shards cost nothing.

`TestCrashRecoverySeal` runs the existing crash-injection rounds against this durability point: the child checkpoints at `Seal` and never closes. It is the only mode that can see this, because `Close` flushes and fsyncs both layers and so hid it. Against the unfixed code it loses key 1 — odd, so a Dyna key — in round 0.

### Verification

Full suite: **66 passed, 6 skipped** (the opt-in load tests), 0 failed. Each new test was also confirmed to fail against the unfixed code. Every commit builds and vets on its own.

### Filed, not fixed here

Measuring this work turned up two defects with no issue: #32 (a block boundary costs two fsyncs per shard even for shards with no writes — ~5.6s/block at 512 shards) and #33 (a seal costs six fsyncs and rewrites the whole manifest).

Closes #27
Closes #28
Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKAh7mFDHChAtKQtJYP3a3