### PR TITLE
Bound segment descriptors, unlock iteration, gate compaction, and add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,98 @@
+# What runs on every push and pull request.
+#
+# Split by cost, so a mistake that a compiler or vet catches reports in
+# a minute rather than behind a twenty-minute suite.  The full suite and
+# the full race build are in nightly.yml: they are too slow to gate a
+# push, and the failures they catch are mostly intermittent, which a
+# nightly run over a week finds better than any single pre-merge run.
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  GO_VERSION: "1.22.1" # Matches go.mod
+
+jobs:
+  build:
+    name: Build, vet, and format
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Build
+        run: go build ./...
+
+      # Vet catches the class of mistake that a split or a rebase
+      # introduces -- an unused import, a shadowed error, a Printf that
+      # does not match its arguments -- and costs seconds
+      - name: Vet
+        run: go vet ./...
+
+      - name: Check formatting
+        run: |
+          unformatted="$(gofmt -l .)"
+          if [ -n "$unformatted" ]; then
+            echo "These files are not gofmt'd:"
+            echo "$unformatted"
+            gofmt -d $unformatted
+            exit 1
+          fi
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    # Measured 21m17s here with -short, of which 38s is user time and
+    # 52s system: ~93% is waiting on fsync, not computing (issues #32,
+    # #33).  So a slower runner disk hurts and more cores do not help.
+    # Allow generously more before calling it hung.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      # -short skips the measurement tests (TestMultiCoreScaling,
+      # TestSyncCost, TestDynaCost), which report numbers rather than
+      # assert behaviour and are worth nothing on a shared runner whose
+      # disk is somebody else's too.  Every correctness test still runs.
+      #
+      # It saves ~6 of the 27 minutes; the rest is correctness tests
+      # that are slow for the reasons #32 and #33 describe, not for
+      # anything -short can skip.
+      - name: Test
+        run: go test -short -timeout 55m ./...
+
+  race:
+    name: Race detector
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      # The tests that actually exercise concurrency: the sharded write
+      # path, the shared file pool, and iteration running alongside a
+      # compaction.  The whole suite under -race is a nightly job --
+      # here the point is fast feedback on the code where a data race
+      # is plausible.
+      - name: Test with -race
+        run: |
+          go test -short -race -timeout 25m ./database/ \
+            -run 'Concurrent|FileCache|SegmentFDs|ForEach|ShardWriter|MultiCore'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,74 @@
+# The slow half: the full suite, the full race build, and the
+# measurement tests.
+#
+# These run on a schedule rather than on a push because they take the
+# best part of an hour and because what they catch is mostly
+# INTERMITTENT.  Issue #35 -- an empty key filter accepted as covering
+# segment (0,0), so Get reported keys absent that were on disk -- failed
+# twice in fifty-five runs.  A pre-merge run sees green and merges it; a
+# nightly run over a week does not.
+name: Nightly
+
+on:
+  schedule:
+    - cron: "0 4 * * *" # 04:00 UTC daily
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  GO_VERSION: "1.22.1" # Matches go.mod
+
+jobs:
+  full:
+    name: Full suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      # Everything, including the measurement tests.  -v so that the log
+      # carries the per-test timings, which is what says whether a
+      # change made the fsync cost worse (issues #32, #33).
+      - name: Test
+        run: go test -v -timeout 170m ./...
+
+  full-race:
+    name: Full suite with -race
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      # -short under the race detector: the measurement tests are slow
+      # enough already and prove nothing about races
+      - name: Test with -race
+        run: go test -short -race -timeout 170m ./...
+
+  repeat:
+    name: Crash recovery, repeated
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      # The durability tests kill a child process at a random moment, so
+      # each run samples a different window and one run proves little.
+      # This is the job that would have caught #35 on its own.
+      - name: Repeat the crash tests
+        run: |
+          go test -count=25 -timeout 55m ./database/ \
+            -run 'TestCrashRecovery$|TestCrashRecoverySeal$'

--- a/database/crash_test.go
+++ b/database/crash_test.go
@@ -259,10 +259,69 @@ func runCrashRounds(t *testing.T, mode string) {
 			key := kr.NextHash()
 			value := vr.RandBuff(10, 50)
 			got, err := kv.Get(key)
-			require.NoErrorf(t, err, "round %d: durable key %d lost (durable=%d)", round, i, durable)
+			if err != nil {
+				t.Fatalf("round %d: durable key %d lost (durable=%d): %v\n%s",
+					round, i, durable, err, crashDiagnose(kv, dir, i, key))
+			}
 			require.Equalf(t, value, got, "round %d: durable key %d corrupt", round, i)
 		}
 		require.NoError(t, kv.Close())
 		t.Logf("round %d: killed with %d durable keys; all verified", round, durable)
 	}
+}
+
+// crashDiagnose
+// Describe where a key that should have been durable actually is, so
+// that an intermittent failure says something more useful than "not
+// found".  Which layer holds it, what each layer's tail and segments
+// look like, and what is on disk.
+func crashDiagnose(kv *KV2, dir string, i int, key [32]byte) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "\n--- diagnosis for key %d (%x), %s layer ---\n",
+		i, key[:8], map[bool]string{true: "Perm", false: "Dyna"}[i%2 == 0])
+
+	for _, l := range []struct {
+		name  string
+		store *SegmentStore
+	}{{"Perm", kv.PermKV}, {"Dyna", kv.DynaKV}} {
+		s := l.store
+		s.Mutex.Lock()
+		_, inLive := s.live[key]
+		inFilter := s.keys == nil || s.keys.Test(key)
+		fmt.Fprintf(&b, "%s: %d segments, live keys %d, records %d, blockHeight %d, filter=%v inLive=%v filterSays=%v\n",
+			l.name, len(s.segments), len(s.live), s.liveRecords, s.blockHeight,
+			s.keys != nil, inLive, inFilter)
+		for _, seg := range s.segments {
+			dbb, found, err := seg.lookup(key)
+			mark := ""
+			if found {
+				mark = fmt.Sprintf("  <-- HOLDS IT at offset %d", dbb.Offset)
+			}
+			if err != nil {
+				mark = fmt.Sprintf("  <-- lookup error: %v", err)
+			}
+			fmt.Fprintf(&b, "   seg (%d,%d) count=%d records=%d file=%s%s\n",
+				seg.meta.Height, seg.meta.Seq, seg.count, seg.records, seg.meta.File, mark)
+		}
+		s.Mutex.Unlock()
+	}
+
+	for _, sub := range []string{PermDirName, DynaDirName} {
+		entries, err := os.ReadDir(filepath.Join(dir, sub))
+		if err != nil {
+			fmt.Fprintf(&b, "%s dir: %v\n", sub, err)
+			continue
+		}
+		fmt.Fprintf(&b, "%s dir:", sub)
+		for _, e := range entries {
+			info, _ := e.Info()
+			size := int64(-1)
+			if info != nil {
+				size = info.Size()
+			}
+			fmt.Fprintf(&b, " %s(%d)", e.Name(), size)
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
 }

--- a/database/dyna_test.go
+++ b/database/dyna_test.go
@@ -67,9 +67,15 @@ func TestDynaCompressReclaims(t *testing.T) {
 }
 
 // TestDynaCompressIsIdempotent
-// Compress on an already-compacted layer must not rewrite it, and must
-// not lose anything.  KVShard compresses on a write count, so a shard
-// whose keys rarely repeat hits this path often.
+// Compress must not rewrite a layer that has nothing to reclaim, and
+// must not lose anything either way.  KVShard compresses on a write
+// count, so a shard whose keys rarely repeat hits this path often.
+//
+// "Nothing to reclaim" now means Compress does nothing at all, rather
+// than sealing the tail and rewriting the single generation that
+// produced.  The seal was the reason it could not opt out: it added a
+// second segment, so the single-generation early-out never applied and
+// every call paid for a full rewrite of the layer (issue #31).
 func TestDynaCompressIsIdempotent(t *testing.T) {
 	dir := storeDir(t, "kv2")
 	kv2, err := NewKV2(dir, 1000)
@@ -85,10 +91,29 @@ func TestDynaCompressIsIdempotent(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	// Distinct keys, so not one record is superseded
 	require.NoError(t, kv2.Compress())
-	require.Len(t, kv2.DynaKV.segments, 1)
+	assert.Empty(t, kv2.DynaKV.segments,
+		"nothing was overwritten: Compress must not seal a generation in order to rewrite it")
+	for i := range keys {
+		v, err := kv2.Get(keys[i])
+		require.NoErrorf(t, err, "key %d after a no-op compress", i)
+		assert.Equal(t, values[i], v)
+	}
+
+	// Now overwrite every key enough times to be worth reclaiming
+	for round := 0; round < 3; round++ {
+		for i := range keys {
+			values[i] = vr.RandBuff(20, 100)
+			_, err = kv2.PutDyna(keys[i], values[i])
+			require.NoError(t, err)
+		}
+	}
+	require.NoError(t, kv2.Compress())
+	require.Len(t, kv2.DynaKV.segments, 1, "three quarters of the layer is garbage: it must compact")
 	first := kv2.DynaKV.segments[0].meta
 
+	// The generation just written has nothing superseded in it
 	require.NoError(t, kv2.Compress(), "second compress")
 	require.Len(t, kv2.DynaKV.segments, 1)
 	assert.Equal(t, first, kv2.DynaKV.segments[0].meta, "nothing to reclaim: the generation should stand as it is")

--- a/database/filecache.go
+++ b/database/filecache.go
@@ -1,0 +1,217 @@
+package blockchainDB
+
+import (
+	"container/list"
+	"os"
+	"sync"
+)
+
+// A bounded pool of open, read-only files.
+//
+// A sealed segment is two files, and the store used to hold both open
+// for the life of the process: nothing ever closed them, and nothing
+// merged the segments they belonged to.  A node sealing per block
+// therefore leaked two descriptors per block -- EMFILE inside ten
+// minutes at the default 1024, and a measured 14,935 descriptors in one
+// test process here (issue #30).
+//
+// The fix is not to hold them.  A segment keeps its metadata in memory
+// -- the key count and the bloom filter, which is what makes a lookup
+// cheap -- and borrows a descriptor only while it is reading.  The pool
+// closes the least recently used file once it is over its limit, so the
+// descriptor count is bounded by the limit rather than by the segment
+// count.
+//
+// Borrowing is reference counted, which buys the other half: a file
+// with a live borrow is never closed, and on Unix an open descriptor
+// keeps reading correctly after the path is unlinked.  So a reader can
+// hold a segment open across a compaction that retires and deletes it
+// -- which is what lets iteration run without the store's lock
+// (issue #31).
+
+// defaultOpenFiles is the pool's limit unless SetOpenFileLimit changes
+// it.  It is a process-wide budget: a sharded database is 512 shards of
+// two stores each, so a per-store limit would multiply by 1024 and be
+// no bound at all.
+//
+// 512 is chosen to sit an order of magnitude below the 1024 descriptor
+// limit that is still a common default, leaving room for the live tails
+// (one per store), the manifests being rewritten, and whatever the host
+// application holds.
+const defaultOpenFiles = 512
+
+// fileCache hands out shared read-only descriptors, keyed by path, and
+// closes the least recently used once it is over its limit.
+//
+// Only files with no live borrow are eviction candidates: `lru` holds
+// exactly the entries whose refs have fallen to zero, most recently
+// released at the front.  A file borrowed more times than the limit
+// allows simply exceeds it -- the limit bounds what the pool keeps
+// open for its own convenience, never what a caller is actively using,
+// because closing that would break a read in flight.
+type fileCache struct {
+	mu    sync.Mutex
+	limit int
+	open  map[string]*cachedFile
+	lru   *list.List // *cachedFile, front = most recently released
+}
+
+type cachedFile struct {
+	path string
+	f    *os.File
+	refs int
+	el   *list.Element // Its place in lru while refs == 0; nil otherwise
+
+	// dropped marks a file forget() removed from the pool while a
+	// borrow was live.  It is no longer reachable by path, so the last
+	// release closes it rather than returning it to the pool.
+	dropped bool
+}
+
+func newFileCache(limit int) *fileCache {
+	if limit < 1 {
+		limit = 1
+	}
+	return &fileCache{limit: limit, open: make(map[string]*cachedFile), lru: list.New()}
+}
+
+// segmentFiles is the pool every store borrows from.  It is process
+// wide on purpose; see defaultOpenFiles.
+var segmentFiles = newFileCache(defaultOpenFiles)
+
+// SetOpenFileLimit
+// Bound how many segment files the process keeps open.  Files
+// currently being read are not closed, so the limit is a target the
+// pool returns to rather than a hard ceiling at every instant.
+//
+// Lowering it closes the least recently used files immediately.
+func SetOpenFileLimit(limit int) {
+	segmentFiles.setLimit(limit)
+}
+
+func (c *fileCache) setLimit(limit int) {
+	if limit < 1 {
+		limit = 1
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.limit = limit
+	c.evict()
+}
+
+// acquire
+// Borrow the file at path, opening it if the pool does not already
+// hold it.  The returned release must be called exactly once; until it
+// is, the file is not an eviction candidate and will not be closed.
+func (c *fileCache) acquire(path string) (f *os.File, release func(), err error) {
+	c.mu.Lock()
+	if cf, ok := c.open[path]; ok {
+		cf.refs++
+		if cf.el != nil { // Was idle: no longer a candidate
+			c.lru.Remove(cf.el)
+			cf.el = nil
+		}
+		c.mu.Unlock()
+		return cf.f, func() { c.release(cf) }, nil
+	}
+	c.mu.Unlock()
+
+	// Open outside the lock: opening is a syscall, and another
+	// goroutine opening a different segment should not wait behind it.
+	opened, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	c.mu.Lock()
+	if cf, ok := c.open[path]; ok {
+		// Someone else opened the same path while we were; keep theirs
+		// so the pool holds one descriptor per path, not one per race
+		opened.Close()
+		cf.refs++
+		if cf.el != nil {
+			c.lru.Remove(cf.el)
+			cf.el = nil
+		}
+		c.mu.Unlock()
+		return cf.f, func() { c.release(cf) }, nil
+	}
+	cf := &cachedFile{path: path, f: opened, refs: 1}
+	c.open[path] = cf
+	c.evict() // The new file has a ref, so it is not a candidate itself
+	c.mu.Unlock()
+	return cf.f, func() { c.release(cf) }, nil
+}
+
+// release gives back one borrow, making the file evictable at zero
+func (c *fileCache) release(cf *cachedFile) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cf.refs--
+	if cf.refs > 0 {
+		return
+	}
+	if cf.refs < 0 {
+		panic("blockchainDB: segment file released more times than acquired")
+	}
+	if cf.dropped {
+		cf.f.Close() // Retired while we were reading it; we were the last
+		return
+	}
+	// Still in the map, so a later acquire reuses it rather than
+	// reopening; the pool closes it only when it needs the room
+	cf.el = c.lru.PushFront(cf)
+	c.evict()
+}
+
+// forget
+// Close and drop the pool's descriptor for path, if it holds an idle
+// one.  A file still being read is left alone: it is unreachable by
+// path once the caller deletes it, and its last release will close it.
+//
+// This exists so that retiring a segment does not leave the pool
+// holding a descriptor to a deleted file, which on Unix keeps the
+// blocks allocated until the descriptor goes.
+func (c *fileCache) forget(path string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cf, ok := c.open[path]
+	if !ok {
+		return
+	}
+	delete(c.open, path)
+	if cf.refs > 0 {
+		// In use: whoever holds it finishes the read against the open
+		// descriptor, and dropCloses it when the last borrow ends
+		cf.dropped = true
+		return
+	}
+	if cf.el != nil {
+		c.lru.Remove(cf.el)
+		cf.el = nil
+	}
+	cf.f.Close()
+}
+
+// evict closes idle files while the pool is over its limit.  The
+// caller must hold mu.
+func (c *fileCache) evict() {
+	for len(c.open) > c.limit {
+		el := c.lru.Back()
+		if el == nil {
+			return // Everything open is in use; the limit yields to that
+		}
+		cf := el.Value.(*cachedFile)
+		c.lru.Remove(el)
+		cf.el = nil
+		delete(c.open, cf.path)
+		cf.f.Close()
+	}
+}
+
+// stats reports what the pool holds, for tests and diagnostics
+func (c *fileCache) stats() (open, idle, limit int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.open), c.lru.Len(), c.limit
+}

--- a/database/filecache_test.go
+++ b/database/filecache_test.go
@@ -1,0 +1,202 @@
+package blockchainDB
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// openFDs counts this process's open file descriptors.  Linux only,
+// which is where the limit bites and where the tests run.
+func openFDs(t *testing.T) int {
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		t.Skipf("no /proc/self/fd: %v", err)
+	}
+	return len(entries)
+}
+
+// TestSegmentFDsStayBounded
+// The point of issue #30: a store that seals many times must not hold
+// two descriptors per segment for the life of the process.
+//
+// Sealing 400 times used to cost 800 descriptors and nothing ever gave
+// them back, so a node sealing per block hit EMFILE at the common 1024
+// limit inside ten minutes.  The count must now track the pool's
+// limit, not the segment count -- and lookups must still work, which
+// is the half a leak-free implementation could get wrong.
+func TestSegmentFDsStayBounded(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
+
+	const limit = 16
+	SetOpenFileLimit(limit)
+	defer SetOpenFileLimit(defaultOpenFiles)
+
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+
+	const seals = 400
+	before := openFDs(t)
+	kr := NewFastRandom([]byte{131})
+	keys := make([][32]byte, seals)
+	for i := 0; i < seals; i++ {
+		keys[i] = kr.NextHash()
+		require.NoError(t, store.Put(keys[i], []byte(fmt.Sprintf("value-%d", i))))
+		_, err = store.Seal(uint64(i + 1))
+		require.NoError(t, err)
+	}
+	require.Len(t, store.segments, seals, "every seal must have produced a segment")
+
+	after := openFDs(t)
+	growth := after - before
+	assert.LessOrEqualf(t, growth, limit+8,
+		"descriptors grew by %d across %d seals; the pool limit is %d", growth, seals, limit)
+
+	// The bound is worth nothing if the data is not still reachable:
+	// every key lives in a segment whose files the pool has closed
+	for i, key := range keys {
+		v, err := store.Get(key)
+		require.NoErrorf(t, err, "key %d unreachable after its segment's files were closed", i)
+		assert.Equal(t, []byte(fmt.Sprintf("value-%d", i)), v)
+	}
+
+	open, _, _ := segmentFiles.stats()
+	assert.LessOrEqual(t, open, limit, "pool holds more files than its limit")
+	require.NoError(t, store.Close())
+}
+
+// TestFileCacheReusesAndEvicts
+// The pool keeps one descriptor per path, hands the same one to
+// concurrent borrowers, and evicts only what nobody is reading.
+func TestFileCacheReusesAndEvicts(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(dir)
+	require.NoError(t, os.MkdirAll(dir, os.ModePerm))
+	defer os.RemoveAll(dir)
+
+	paths := make([]string, 4)
+	for i := range paths {
+		paths[i] = filepath.Join(dir, fmt.Sprintf("f%d", i))
+		require.NoError(t, os.WriteFile(paths[i], []byte{byte(i)}, 0644))
+	}
+
+	c := newFileCache(2)
+
+	// Two borrows of the same path share one descriptor
+	f1, rel1, err := c.acquire(paths[0])
+	require.NoError(t, err)
+	f2, rel2, err := c.acquire(paths[0])
+	require.NoError(t, err)
+	assert.Same(t, f1, f2, "the same path must yield the same descriptor")
+	open, idle, _ := c.stats()
+	assert.Equal(t, 1, open)
+	assert.Equal(t, 0, idle, "a file with live borrows is not idle")
+
+	rel1()
+	open, idle, _ = c.stats()
+	assert.Equal(t, 0, idle, "still borrowed once")
+	rel2()
+	_, idle, _ = c.stats()
+	assert.Equal(t, 1, idle, "fully released: now an eviction candidate")
+
+	// Filling past the limit evicts the idle one
+	_, r1, err := c.acquire(paths[1])
+	require.NoError(t, err)
+	_, r2, err := c.acquire(paths[2])
+	require.NoError(t, err)
+	open, _, _ = c.stats()
+	assert.LessOrEqual(t, open, 2, "over the limit with an idle file available to evict")
+
+	// With both in use, the limit yields rather than closing a file
+	// someone is reading
+	_, r3, err := c.acquire(paths[3])
+	require.NoError(t, err)
+	open, _, _ = c.stats()
+	assert.Equal(t, 3, open, "the limit must never close a file in use")
+	r1()
+	r2()
+	r3()
+	open, _, _ = c.stats()
+	assert.LessOrEqual(t, open, 2, "back under the limit once the borrows end")
+}
+
+// TestFileCacheForgetDuringBorrow
+// Retiring a file that is being read must not close it underneath the
+// reader.  This is what lets a compaction delete the generation an
+// iteration is still walking.
+func TestFileCacheForgetDuringBorrow(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(dir)
+	require.NoError(t, os.MkdirAll(dir, os.ModePerm))
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, "f")
+	require.NoError(t, os.WriteFile(path, []byte("hello"), 0644))
+
+	c := newFileCache(4)
+	f, release, err := c.acquire(path)
+	require.NoError(t, err)
+
+	c.forget(path)                      // Retired while we hold it
+	require.NoError(t, os.Remove(path)) // And unlinked
+
+	buf := make([]byte, 5)
+	_, err = f.ReadAt(buf, 0)
+	require.NoError(t, err, "an open descriptor must survive forget and unlink")
+	assert.Equal(t, "hello", string(buf))
+
+	release() // The last borrow closes it
+	open, _, _ := c.stats()
+	assert.Equal(t, 0, open)
+}
+
+// TestFileCacheConcurrentAcquire
+// The pool is shared across shards, so it is hit from many goroutines
+// at once.  Run under -race.
+func TestFileCacheConcurrentAcquire(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(dir)
+	require.NoError(t, os.MkdirAll(dir, os.ModePerm))
+	defer os.RemoveAll(dir)
+
+	const files = 20
+	paths := make([]string, files)
+	for i := range paths {
+		paths[i] = filepath.Join(dir, fmt.Sprintf("f%d", i))
+		require.NoError(t, os.WriteFile(paths[i], []byte("x"), 0644))
+	}
+
+	c := newFileCache(4) // Deliberately far below the working set
+	var wg sync.WaitGroup
+	for w := 0; w < 8; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			buf := make([]byte, 1)
+			for i := 0; i < 200; i++ {
+				p := paths[(w*7+i)%files]
+				f, release, err := c.acquire(p)
+				if err != nil {
+					t.Errorf("acquire %s: %v", p, err)
+					return
+				}
+				if _, err := f.ReadAt(buf, 0); err != nil {
+					t.Errorf("read %s: %v", p, err)
+				}
+				release()
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	open, idle, _ := c.stats()
+	assert.LessOrEqual(t, open, 4, "pool over its limit with nothing borrowed")
+	assert.Equal(t, open, idle, "everything released must be idle")
+}

--- a/database/iterate.go
+++ b/database/iterate.go
@@ -28,24 +28,30 @@ import (
 // Call fn for every key the store holds, with its current value.
 // Iteration stops and returns the error if fn returns one.
 //
-// The order is unspecified.  A store must not be written to while
-// ForEach runs: it holds the store's lock for the duration.
+// The order is unspecified.  What fn sees is a SNAPSHOT: the sealed
+// segments and live tail as they stood when ForEach was called.
+// Writes made while it runs are not reported, and neither are the
+// results of a compaction that commits underneath it.
+//
+// fn is called with no lock held, so it may read and write the store
+// it is iterating.  It used to run under the store's lock for the
+// whole iteration, which made a callback that called Get deadlock and
+// made any callback block every other reader and writer for as long as
+// it ran (issue #31).
 func (s *SegmentStore) ForEach(fn func(key [32]byte, value []byte) error) (err error) {
 	s.Mutex.Lock()
-	defer s.Mutex.Unlock()
-	if err = s.checkOpen(); err != nil {
+	segs, live, err := s.beginIterate()
+	s.Mutex.Unlock()
+	if err != nil {
 		return err
 	}
+	defer s.endIterate()
 
-	seen := make(map[[32]byte]struct{}, len(s.live))
+	seen := make(map[[32]byte]struct{}, len(live))
 
 	// The live tail first: it is the newest thing in the store, so
 	// anything it holds shadows every sealed copy
-	for key, dbb := range s.live {
-		value := make([]byte, dbb.Length)
-		if err = s.liveFile.ReadAt(dbb.Offset, value); err != nil {
-			return err
-		}
+	for key, value := range live {
 		seen[key] = struct{}{}
 		if err = fn(key, value); err != nil {
 			return err
@@ -54,39 +60,60 @@ func (s *SegmentStore) ForEach(fn func(key [32]byte, value []byte) error) (err e
 
 	const batch = 4096
 	buff := make([]byte, batch*DBKeyFullSize)
-	for i := len(s.segments) - 1; i >= 0; i-- { // Newest segment wins
-		seg := s.segments[i]
-		for at := int64(0); at < seg.count; {
-			n := seg.count - at
-			if n > batch {
-				n = batch
+	for i := len(segs) - 1; i >= 0; i-- { // Newest segment wins
+		if err = forEachInSegment(segs[i], buff, batch, seen, fn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// forEachInSegment
+// Emit the keys of one sealed segment that no newer segment already
+// covered.  It is a function rather than the body of the loop so that
+// the segment's index file is borrowed for exactly this segment and
+// given back before the next one -- a deferred release inside the loop
+// would hold one descriptor per segment, which is the cost ForEach
+// exists downstream of (issue #30).
+func forEachInSegment(
+	seg *segment, buff []byte, batch int64,
+	seen map[[32]byte]struct{}, fn func(key [32]byte, value []byte) error,
+) error {
+	index, release, err := seg.index()
+	if err != nil {
+		return err
+	}
+	defer release()
+	for at := int64(0); at < seg.count; {
+		n := seg.count - at
+		if n > batch {
+			n = batch
+		}
+		b := buff[:n*DBKeyFullSize]
+		if _, err = index.ReadAt(b, segIndexHdrSize+at*DBKeyFullSize); err != nil {
+			return err
+		}
+		for j := int64(0); j < n; j++ {
+			rec := b[j*DBKeyFullSize:]
+			var key [32]byte
+			copy(key[:], rec[:32])
+			if _, ok := seen[key]; ok {
+				continue // A newer copy was already emitted
 			}
-			b := buff[:n*DBKeyFullSize]
-			if _, err = seg.index.ReadAt(b, segIndexHdrSize+at*DBKeyFullSize); err != nil {
+			seen[key] = struct{}{}
+			dbb := &DBBKey{
+				Offset: binary.BigEndian.Uint64(rec[32:]),
+				Length: binary.BigEndian.Uint64(rec[40:]),
+			}
+			value, err := seg.value(dbb)
+			if err != nil {
 				return err
 			}
-			for j := int64(0); j < n; j++ {
-				rec := b[j*DBKeyFullSize:]
-				var key [32]byte
-				copy(key[:], rec[:32])
-				if _, ok := seen[key]; ok {
-					continue // A newer copy was already emitted
-				}
-				seen[key] = struct{}{}
-				dbb := &DBBKey{
-					Offset: binary.BigEndian.Uint64(rec[32:]),
-					Length: binary.BigEndian.Uint64(rec[40:]),
-				}
-				value, err := seg.value(dbb)
-				if err != nil {
-					return err
-				}
-				if err = fn(key, value); err != nil {
-					return err
-				}
+			if err = fn(key, value); err != nil {
+				return err
 			}
-			at += n
 		}
+		at += n
 	}
 	return nil
 }
@@ -96,10 +123,13 @@ func (s *SegmentStore) ForEach(fn func(key [32]byte, value []byte) error) (err e
 // first, and a key it holds is not emitted again from Perm: a key that
 // moved to Dyna leaves its original behind in Perm, and the Dyna copy
 // is the one Get answers with.
+//
+// The KV2 lock is NOT held: each layer snapshots itself, and fn runs
+// unlocked, so a callback is free to use the database it is walking.
+// Holding it here would have reinstated exactly the deadlock the
+// per-layer fix removed -- fn calling KV2.Get would block on the mutex
+// its own iteration was holding (issue #31).
 func (k *KV2) ForEach(fn func(key [32]byte, value []byte) error) error {
-	k.Mutex.Lock()
-	defer k.Mutex.Unlock()
-
 	dyna := make(map[[32]byte]struct{})
 	err := k.DynaKV.ForEach(func(key [32]byte, value []byte) error {
 		dyna[key] = struct{}{}

--- a/database/iterate_test.go
+++ b/database/iterate_test.go
@@ -2,7 +2,9 @@ package blockchainDB
 
 import (
 	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -135,4 +137,110 @@ func TestForEachStopsOnError(t *testing.T) {
 	require.ErrorIs(t, err, stop)
 	require.Equal(t, 10, seen, "iteration continued past the error")
 	require.NoError(t, store.Close())
+}
+
+// TestForEachCallbackMayUseTheStore
+// The callback runs with no lock held, so it can read and write the
+// store it is walking.  Both used to deadlock: ForEach took the
+// store's mutex for the whole iteration, so the first Get inside the
+// callback blocked forever on a lock its own caller held (issue #31).
+//
+// A deadlock hangs rather than failing, so this runs on its own
+// goroutine against a deadline: a timeout is the failure.
+func TestForEachCallbackMayUseTheStore(t *testing.T) {
+	dir := storeDir(t, "cb")
+	store, err := NewSegmentStore(dir, true)
+	require.NoError(t, err)
+	defer store.Close()
+
+	kr := NewFastRandom([]byte{47})
+	keys := make([][32]byte, 50)
+	for i := range keys {
+		keys[i] = kr.NextHash()
+		require.NoError(t, store.Put(keys[i], []byte(fmt.Sprintf("v%d", i))))
+	}
+	_, err = store.Seal(1)
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() {
+		seen := 0
+		done <- store.ForEach(func(key [32]byte, value []byte) error {
+			// Read the store from inside its own iteration
+			got, err := store.Get(key)
+			if err != nil {
+				return fmt.Errorf("Get inside ForEach: %w", err)
+			}
+			if string(got) != string(value) {
+				return fmt.Errorf("Get disagreed with ForEach for a key")
+			}
+			// And write to it: the snapshot means this is not re-emitted
+			if seen == 0 {
+				if err := store.Put(kr.NextHash(), []byte("added during iteration")); err != nil {
+					return fmt.Errorf("Put inside ForEach: %w", err)
+				}
+			}
+			seen++
+			return nil
+		})
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("ForEach deadlocked: the callback could not use the store")
+	}
+}
+
+// TestForEachSurvivesConcurrentCompaction
+// A compaction that commits mid-iteration replaces the sealed
+// generation and deletes the files the iteration is reading.  The
+// iteration must still complete and still report the snapshot it
+// started from.
+func TestForEachSurvivesConcurrentCompaction(t *testing.T) {
+	dir := storeDir(t, "compact")
+	store, err := NewSegmentStore(dir, true)
+	require.NoError(t, err)
+	defer store.Close()
+
+	kr := NewFastRandom([]byte{48})
+	keys := make([][32]byte, 400)
+	for i := range keys {
+		keys[i] = kr.NextHash()
+		require.NoError(t, store.Put(keys[i], []byte(fmt.Sprintf("v%d", i))))
+		if i%100 == 99 {
+			_, err = store.Seal(uint64(i/100 + 1))
+			require.NoError(t, err)
+		}
+	}
+	require.Greater(t, len(store.segments), 1, "need several generations to compact away")
+
+	compacted := make(chan error, 1)
+	var once sync.Once
+	seen := 0
+	err = store.ForEach(func(key [32]byte, value []byte) error {
+		seen++
+		if seen == 10 { // Well into the sealed segments
+			once.Do(func() {
+				go func() {
+					_, err := store.CompactNext()
+					compacted <- err
+				}()
+			})
+			// Give the compaction a chance to commit and delete
+			time.Sleep(200 * time.Millisecond)
+		}
+		return nil
+	})
+	require.NoError(t, err, "iteration must survive the files being retired under it")
+	require.NoError(t, <-compacted, "the compaction itself must succeed")
+	require.Equal(t, len(keys), seen, "the snapshot must still report every key")
+
+	// And the store is intact afterwards
+	for i, key := range keys {
+		v, err := store.Get(key)
+		require.NoErrorf(t, err, "key %d lost", i)
+		require.Equal(t, fmt.Sprintf("v%d", i), string(v))
+	}
 }

--- a/database/keyfilter_test.go
+++ b/database/keyfilter_test.go
@@ -1,6 +1,8 @@
 package blockchainDB
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -278,4 +280,68 @@ func TestStoreStatsCountWhatHappened(t *testing.T) {
 	require.Equal(t, s.FilterMisled, s.FilterWalked-uint64(5),
 		"the only walks that found something were the 4 duplicates and the conflict")
 	require.NoError(t, store.Close())
+}
+
+// TestKeyFilterEmptyDoesNotCoverSegmentZero
+// A saved filter that covered NO segments must not be mistaken for one
+// covering the first segment a store seals.
+//
+// Both record (0, 0) as the newest segment they cover -- the empty one
+// because that is the zero value, the other because (0, 0) is a real
+// identity, and the Dyna layer numbers every segment at height 0 so its
+// first segment is exactly that.  A crash that leaves a sealed segment
+// for recoverOrphans to adopt without rewriting the manifest produces
+// the pair: the manifest still claims a valid filter covering "the
+// newest segment (0,0)", and the segment now present is (0,0).
+//
+// Accepting the empty filter there is silent data loss, not a slow
+// lookup: the filter answers "definitely absent" for every key in the
+// segment, and Get returns not-found without ever opening it.  Found
+// intermittently by TestCrashRecoverySeal.
+func TestKeyFilterEmptyDoesNotCoverSegmentZero(t *testing.T) {
+	dir := storeDir(t, "bloom0")
+
+	// A store closed with no segments: bloom.dat covers nothing, and the
+	// manifest says so with (0, 0) because that is the zero value
+	store, err := NewSegmentStore(dir, true)
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+
+	saved, err := os.ReadFile(filepath.Join(dir, segManifestName))
+	require.NoError(t, err)
+	var m StoreManifest
+	require.NoError(t, json.Unmarshal(saved, &m))
+	require.True(t, m.BloomValid, "the close must have left a coverage claim to test")
+	require.Empty(t, m.Segments)
+
+	// Fill a tail and seal it, which produces segment (0, 0)
+	store, err = OpenSegmentStore(dir)
+	require.NoError(t, err)
+	kr := NewFastRandom([]byte{61})
+	keys := make([][32]byte, 40)
+	for i := range keys {
+		keys[i] = kr.NextHash()
+		require.NoError(t, store.Put(keys[i], []byte(fmt.Sprintf("v%d", i))))
+	}
+	_, err = store.SealNext()
+	require.NoError(t, err)
+	require.Len(t, store.segments, 1)
+	require.Equal(t, uint64(0), store.segments[0].meta.Height)
+	require.Equal(t, uint64(0), store.segments[0].meta.Seq, "the case only arises for segment (0,0)")
+
+	// Now put the manifest back as it was before the seal: this is a
+	// crash after the segment file reached disk but before the manifest
+	// commit, which is the window recoverOrphans exists for
+	require.NoError(t, os.WriteFile(filepath.Join(dir, segManifestName), saved, 0644))
+
+	reopened, err := OpenSegmentStore(dir)
+	require.NoError(t, err)
+	require.Len(t, reopened.segments, 1, "the orphan segment must have been adopted")
+
+	for i, key := range keys {
+		v, err := reopened.Get(key)
+		require.NoErrorf(t, err, "key %d reported absent by the filter but held by segment (0,0)", i)
+		require.Equal(t, fmt.Sprintf("v%d", i), string(v))
+	}
+	require.NoError(t, reopened.Close())
 }

--- a/database/kv_2.go
+++ b/database/kv_2.go
@@ -327,6 +327,26 @@ func (k *KV2) Put(key [32]byte, value []byte) (writes int, err error) {
 func (k *KV2) Compress() error {
 	k.Mutex.Lock()
 	defer k.Mutex.Unlock()
+
+	// Do nothing unless there is enough garbage to be worth a rewrite
+	// of the layer.  A caller drives this on a cadence -- every K
+	// commits -- and the cadence says when to *consider* compacting,
+	// not that a compaction is due: obeying it literally cost O(N) per
+	// call and O(N × commits/K) over a run, so reclaiming a fixed
+	// amount of garbage got more expensive the larger the database grew
+	// (issue #31).
+	//
+	// The seal is inside the check for the same reason.  Sealing first
+	// and then compacting is what made compaction unable to opt out:
+	// the seal had already added a second segment, so the
+	// single-generation early-out never applied.
+	k.DynaKV.Mutex.Lock()
+	worth := k.DynaKV.worthCompacting(CompactRatio)
+	k.DynaKV.Mutex.Unlock()
+	if !worth {
+		return nil
+	}
+
 	if _, err := k.DynaKV.SealNext(); err != nil { // Everything to reclaim must be sealed
 		return err
 	}

--- a/database/segstore.go
+++ b/database/segstore.go
@@ -115,7 +115,7 @@ type StoreManifest struct {
 	// manifest produced exactly that pair.  The empty filter was then
 	// accepted as covering it, and every key in that segment answered
 	// "not found" -- a false negative, which is silent data loss rather
-	// than the slow lookup a false positive costs (issue #35).
+	// than the slow lookup a false positive costs.
 	BloomValid    bool   `json:"bloomValid,omitempty"`
 	BloomHeight   uint64 `json:"bloomHeight,omitempty"`
 	BloomSeq      uint64 `json:"bloomSeq,omitempty"`
@@ -123,26 +123,43 @@ type StoreManifest struct {
 }
 
 // segment
-// An open sealed segment
+// A sealed segment.
+//
+// What it keeps in memory is what a lookup needs to decide *whether* to
+// read: the key count and the bloom filter.  The two files are
+// borrowed from the shared pool for the length of a read and given
+// back, so a store holds no descriptors between reads and the process
+// stays under a bound no matter how many segments it has sealed
+// (issue #30).
 type segment struct {
-	meta    SegmentMeta
-	data    *os.File
-	index   *os.File
-	count   int64  // Indexed keys
-	records int64  // Physical records in the data file; > count if any key repeats
-	bloom   *Bloom // Membership filter over this segment's keys
+	meta      SegmentMeta
+	dataPath  string
+	indexPath string
+	count     int64  // Indexed keys
+	records   int64  // Physical records in the data file; > count if any key repeats
+	bloom     *Bloom // Membership filter over this segment's keys
 }
 
-// close releases a segment's file handles
+// close
+// Retire a segment: drop the pool's descriptors for its files.
+//
+// This is not "close what we hold" -- a segment holds nothing between
+// reads -- it is "stop holding these paths open on our behalf", which
+// matters when the caller is about to delete them.  A file being read
+// right now is left to its reader, whose last release closes it.
 func (s *segment) close() {
-	if s.data != nil {
-		s.data.Close()
-		s.data = nil
-	}
-	if s.index != nil {
-		s.index.Close()
-		s.index = nil
-	}
+	segmentFiles.forget(s.dataPath)
+	segmentFiles.forget(s.indexPath)
+}
+
+// data borrows the segment's data file; release when the read is done
+func (s *segment) data() (f *os.File, release func(), err error) {
+	return segmentFiles.acquire(s.dataPath)
+}
+
+// index borrows the segment's index file; release when the read is done
+func (s *segment) index() (f *os.File, release func(), err error) {
+	return segmentFiles.acquire(s.indexPath)
 }
 
 // lookup
@@ -150,13 +167,19 @@ func (s *segment) close() {
 // segment's data file.
 func (s *segment) lookup(key [32]byte) (dbb *DBBKey, found bool, err error) {
 	if s.bloom != nil && !s.bloom.Test(key) {
-		return nil, false, nil // Definitely not in this segment
+		return nil, false, nil // Definitely not in this segment: no file needed
 	}
+	// One borrow for the whole binary search rather than one per probe
+	index, release, err := s.index()
+	if err != nil {
+		return nil, false, err
+	}
+	defer release()
 	var rec [DBKeyFullSize]byte
 	lo, hi := int64(0), s.count-1
 	for lo <= hi { //                        Index records are sorted by key
 		mid := (lo + hi) / 2
-		if _, err = s.index.ReadAt(rec[:], segIndexHdrSize+mid*DBKeyFullSize); err != nil {
+		if _, err = index.ReadAt(rec[:], segIndexHdrSize+mid*DBKeyFullSize); err != nil {
 			return nil, false, err
 		}
 		switch bytes.Compare(key[:], rec[:32]) {
@@ -177,8 +200,13 @@ func (s *segment) lookup(key [32]byte) (dbb *DBBKey, found bool, err error) {
 
 // value reads a value out of the segment's data file
 func (s *segment) value(dbb *DBBKey) (value []byte, err error) {
+	data, release, err := s.data()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	value = make([]byte, dbb.Length)
-	if _, err = s.data.ReadAt(value, int64(dbb.Offset)); err != nil {
+	if _, err = data.ReadAt(value, int64(dbb.Offset)); err != nil {
 		return nil, err
 	}
 	return value, nil
@@ -211,6 +239,47 @@ type SegmentStore struct {
 	liveRecords uint64               // Physical records in liveFile (>= len(live) if keys repeat)
 	liveDirty   bool                 // Records written to the tail since the last fsync of it
 	closed      bool                 // Set by Close; cleared by Open
+
+	// iterating counts the iterations in flight, and pendingDelete
+	// holds the files a compaction wanted to delete while one was.
+	//
+	// ForEach runs its callback without the store's lock (issue #31),
+	// so a compaction can commit underneath it.  That is fine for what
+	// the iteration reports -- it snapshots the segment list and shows
+	// the store as it was when it started -- but not for the files:
+	// compaction deletes the generation it replaced, and the iterator
+	// is still reading it.  Deferring the unlink until the last
+	// iteration finishes keeps those reads valid.  The files are
+	// already unreachable through the manifest, so a crash in between
+	// costs nothing: recoverOrphans sweeps them on the next open.
+	iterating     int
+	pendingDelete []string
+
+	// shadowed estimates how many records this store holds that a later
+	// write has superseded -- its garbage -- counted since the last
+	// compaction.
+	//
+	// It exists so that "is there anything worth reclaiming?" can be
+	// answered without reading anything.  Compaction itself is the only
+	// exact answer, and it costs a scan of every index plus a copy of
+	// every live value, so asking it that question is the thing being
+	// avoided (issue #31).
+	//
+	// A mutable store appends without checking, on purpose, so the count
+	// comes from a probe of the store's own key filter before the write
+	// is recorded in it: a key already there means this write shadows an
+	// older copy.  The filter's false positives make that an
+	// over-estimate and its lack of false negatives keeps it from ever
+	// being an under-estimate, so the error is on the side of compacting
+	// slightly early.  Nil filter means no estimate, and the caller
+	// falls back to compacting unconditionally.
+	//
+	// It is process state: not persisted, and not reconstructed by
+	// load, so a reopened store believes it holds no garbage until it
+	// accumulates more.  That defers reclamation rather than losing
+	// anything, and it is the trade the threshold makes -- compacting
+	// unconditionally had no such state to lose (issue #40).
+	shadowed uint64
 
 	// keys is a membership filter over everything the store holds --
 	// every sealed segment and the live tail.  It exists to make
@@ -477,6 +546,11 @@ func (s *SegmentStore) rebuildKeyFilter() (err error) {
 // Add every key in a sealed segment to the filter, read from the
 // segment's index: the keys are already there, sorted, 48 bytes apart.
 func (s *SegmentStore) addSegmentKeys(seg *segment) (err error) {
+	index, release, err := seg.index() // One borrow for the whole scan
+	if err != nil {
+		return err
+	}
+	defer release()
 	const batch = 4096 // Index records per read
 	buff := make([]byte, batch*DBKeyFullSize)
 	for i := int64(0); i < seg.count; {
@@ -485,7 +559,7 @@ func (s *SegmentStore) addSegmentKeys(seg *segment) (err error) {
 			n = batch
 		}
 		b := buff[:n*DBKeyFullSize]
-		if _, err = seg.index.ReadAt(b, segIndexHdrSize+i*DBKeyFullSize); err != nil {
+		if _, err = index.ReadAt(b, segIndexHdrSize+i*DBKeyFullSize); err != nil {
 			return err
 		}
 		for j := int64(0); j < n; j++ {
@@ -498,33 +572,44 @@ func (s *SegmentStore) addSegmentKeys(seg *segment) (err error) {
 	return nil
 }
 
-// openSegment opens a sealed segment's data and index files
+// openSegment
+// Adopt a sealed segment: read what a lookup needs to keep in memory
+// -- the record count, the key count, and the bloom filter -- and give
+// the descriptors straight back.  Reads borrow them again as needed,
+// so adopting a segment costs two opens once, not two descriptors
+// forever (issue #30).
 func (s *SegmentStore) openSegment(meta SegmentMeta) (seg *segment, err error) {
-	seg = &segment{meta: meta}
 	dataPath := filepath.Join(s.Directory, meta.File)
-	if seg.data, err = os.Open(dataPath); err != nil {
+	indexPath := strings.TrimSuffix(dataPath, segDataSuffix) + segIndexSuffix
+	seg = &segment{meta: meta, dataPath: dataPath, indexPath: indexPath}
+
+	data, releaseData, err := seg.data()
+	if err != nil {
 		return nil, err
 	}
 	var dataHdr [segDataHdrSize]byte
-	if _, err = seg.data.ReadAt(dataHdr[:], 0); err != nil {
-		seg.close()
+	if _, err = data.ReadAt(dataHdr[:], 0); err != nil {
+		releaseData()
 		return nil, err
 	}
 	seg.records = int64(binary.BigEndian.Uint64(dataHdr[16:]))
-	indexPath := strings.TrimSuffix(dataPath, segDataSuffix) + segIndexSuffix
+	releaseData()
+
 	if _, err = os.Stat(indexPath); err != nil { // Rebuild a missing index
 		if err = buildIndexFor(dataPath, indexPath); err != nil {
 			seg.close()
 			return nil, err
 		}
 	}
-	if seg.index, err = os.Open(indexPath); err != nil {
+	index, releaseIndex, err := seg.index()
+	if err != nil {
 		seg.close()
 		return nil, err
 	}
+	defer releaseIndex()
 
 	var header [segIndexHdrSize]byte
-	if _, err = seg.index.ReadAt(header[:], 0); err != nil {
+	if _, err = index.ReadAt(header[:], 0); err != nil {
 		seg.close()
 		return nil, err
 	}
@@ -537,7 +622,7 @@ func (s *SegmentStore) openSegment(meta SegmentMeta) (seg *segment, err error) {
 	bloomK := int(binary.BigEndian.Uint32(header[24:]))
 	if bloomBytes > 0 {
 		bitmap := make([]byte, bloomBytes)
-		if _, err = seg.index.ReadAt(bitmap, segIndexHdrSize+seg.count*DBKeyFullSize); err != nil {
+		if _, err = index.ReadAt(bitmap, segIndexHdrSize+seg.count*DBKeyFullSize); err != nil {
 			seg.close()
 			return nil, err
 		}
@@ -897,6 +982,13 @@ func (s *SegmentStore) writeRecord(key [32]byte, value []byte) (err error) {
 	s.liveRecords++
 	s.liveDirty = true
 	if s.keys != nil {
+		// Probe before Set: a key the store already holds means this
+		// record supersedes an older one, which is what compaction has
+		// to reclaim.  Only a mutable store can shadow -- an immutable
+		// one refuses the write instead -- so only it counts.
+		if s.Mutable && s.keys.Test(key) {
+			s.shadowed++
+		}
 		s.keys.Set(key)
 	}
 	return nil
@@ -958,6 +1050,59 @@ func (s *SegmentStore) LiveRecords() uint64 {
 	s.Mutex.Lock()
 	defer s.Mutex.Unlock()
 	return s.liveRecords
+}
+
+// retire
+// Delete a file a commit has made unreachable, or defer the delete
+// until the iterations reading it have finished.  The caller must hold
+// the Mutex.
+func (s *SegmentStore) retire(path string) {
+	if s.iterating > 0 {
+		s.pendingDelete = append(s.pendingDelete, path)
+		return
+	}
+	os.Remove(path)
+}
+
+// beginIterate
+// Take a snapshot to iterate: the sealed segments as they stand, and
+// the live tail's values copied out.  Holding the segments in a local
+// slice is what makes the iteration a snapshot; holding off deletion
+// is what keeps their files readable.  The caller must hold the Mutex.
+func (s *SegmentStore) beginIterate() (segs []*segment, live map[[32]byte][]byte, err error) {
+	if err = s.checkOpen(); err != nil {
+		return nil, nil, err
+	}
+	// The live tail is not a file the pool can hold open for us -- it is
+	// still being appended to -- so its values are copied out under the
+	// lock rather than read during the iteration
+	live = make(map[[32]byte][]byte, len(s.live))
+	for key, dbb := range s.live {
+		value := make([]byte, dbb.Length)
+		if err = s.liveFile.ReadAt(dbb.Offset, value); err != nil {
+			return nil, nil, err
+		}
+		live[key] = value
+	}
+	segs = append([]*segment(nil), s.segments...)
+	s.iterating++
+	return segs, live, nil
+}
+
+// endIterate
+// Finish an iteration and, if it was the last, delete what a
+// compaction retired while it ran.
+func (s *SegmentStore) endIterate() {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+	s.iterating--
+	if s.iterating > 0 {
+		return
+	}
+	for _, path := range s.pendingDelete {
+		os.Remove(path)
+	}
+	s.pendingDelete = nil
 }
 
 // BlockHeight
@@ -1295,6 +1440,50 @@ func (s *SegmentStore) rewriteLiveFile(dataPath string) (sl sealed, err error) {
 	return sl, nil
 }
 
+// DefaultCompactRatio
+// The share of a mutable store's records that must be superseded
+// before compacting is worth what it costs.
+//
+// Compaction rewrites the whole layer: every live value is copied.
+// Doing that on a cadence -- every K commits, which is how a node
+// drives it -- costs O(N) each time and O(N × commits/K) over a run,
+// so the price of reclaiming a fixed amount of garbage grows with the
+// database (issue #31).  Waiting until a fixed *fraction* is garbage
+// makes the amortised cost constant instead: a compaction still costs
+// O(N), but roughly N/(1-r) × r overwrites happen before the next one
+// is due, so the cost per overwrite settles at a constant that depends
+// on r and not on N.
+//
+// 0.25 spends at most a third of the layer's space on garbage and
+// compacts about once per quarter-layer of overwrites.
+const DefaultCompactRatio = 0.25
+
+// CompactRatio is the ratio Compress uses.  Raise it to compact less
+// often and hold more garbage; lower it for the reverse.
+var CompactRatio = DefaultCompactRatio
+
+// worthCompacting
+// Whether enough of this store is superseded records to pay for a
+// compaction.  The caller must hold the Mutex.
+//
+// An unmeasurable store -- no key filter, so no estimate -- says yes:
+// compacting when it was not needed costs time, and skipping when it
+// was needed costs unbounded space.
+func (s *SegmentStore) worthCompacting(ratio float64) bool {
+	if !s.Mutable || s.keys == nil {
+		return true
+	}
+	var records uint64
+	for _, seg := range s.segments {
+		records += uint64(seg.records)
+	}
+	records += s.liveRecords
+	if records == 0 {
+		return false
+	}
+	return float64(s.shadowed) >= ratio*float64(records)
+}
+
 // Compact
 // Replace every sealed segment with one new segment holding only the
 // keys that are still live, and commit it by replacing the manifest.
@@ -1344,7 +1533,13 @@ func (s *SegmentStore) compact(height uint64) (meta SegmentMeta, err error) {
 	for i := len(s.segments) - 1; i >= 0; i-- {
 		seg := s.segments[i]
 		entries := make([]byte, seg.count*DBKeyFullSize)
-		if _, err = seg.index.ReadAt(entries, segIndexHdrSize); err != nil {
+		index, release, err := seg.index()
+		if err != nil {
+			return meta, err
+		}
+		_, err = index.ReadAt(entries, segIndexHdrSize)
+		release()
+		if err != nil {
 			return meta, err
 		}
 		for pos := 0; pos+DBKeyFullSize <= len(entries); pos += DBKeyFullSize {
@@ -1468,10 +1663,9 @@ func (s *SegmentStore) compact(height uint64) (meta SegmentMeta, err error) {
 	// Committed.  The old files are unreachable; removing them is
 	// cleanup, and anything left behind is swept on the next open.
 	for _, o := range old {
-		path := filepath.Join(s.Directory, o.meta.File)
 		o.close()
-		os.Remove(path)
-		os.Remove(strings.TrimSuffix(path, segDataSuffix) + segIndexSuffix)
+		s.retire(o.dataPath)
+		s.retire(o.indexPath)
 	}
 
 	// Compaction is the one moment the true key set is already in hand:
@@ -1484,6 +1678,9 @@ func (s *SegmentStore) compact(height uint64) (meta SegmentMeta, err error) {
 			s.keys = nil // Correct, just slower: lookups walk again
 		}
 	}
+	// Everything that was superseded has just been dropped; the count
+	// starts again from what the new generation accumulates
+	s.shadowed = 0
 	return meta, nil
 }
 
@@ -1585,6 +1782,11 @@ func (s *SegmentStore) ImportSegmentFile(path string, meta SegmentMeta) (err err
 // value in this store.  The caller must hold the Mutex, and seg must
 // not yet be in s.segments.
 func (s *SegmentStore) checkNoConflicts(seg *segment) (err error) {
+	index, release, err := seg.index() // One borrow for the whole scan
+	if err != nil {
+		return err
+	}
+	defer release()
 	const batch = 4096 // Index records read per pass
 	buff := make([]byte, batch*DBKeyFullSize)
 	for i := int64(0); i < seg.count; i += batch {
@@ -1593,7 +1795,7 @@ func (s *SegmentStore) checkNoConflicts(seg *segment) (err error) {
 			n = batch
 		}
 		chunk := buff[:n*DBKeyFullSize]
-		if _, err = seg.index.ReadAt(chunk, segIndexHdrSize+i*DBKeyFullSize); err != nil {
+		if _, err = index.ReadAt(chunk, segIndexHdrSize+i*DBKeyFullSize); err != nil {
 			return err
 		}
 		for pos := 0; pos+DBKeyFullSize <= len(chunk); pos += DBKeyFullSize {

--- a/database/segstore.go
+++ b/database/segstore.go
@@ -102,12 +102,24 @@ type StoreManifest struct {
 	Segments    []SegmentMeta `json:"segments"`    // Oldest first
 
 	// BloomValid says the persisted key filter (bloom.dat) covers
-	// exactly the sealed segments listed here, and BloomHeight/BloomSeq
-	// name the newest of them.  Height 0, Seq 0 is a legitimate
-	// segment, so the flag carries the claim rather than the numbers.
-	BloomValid  bool   `json:"bloomValid,omitempty"`
-	BloomHeight uint64 `json:"bloomHeight,omitempty"`
-	BloomSeq    uint64 `json:"bloomSeq,omitempty"`
+	// exactly the sealed segments listed here; BloomHeight/BloomSeq name
+	// the newest of them and BloomSegments counts them.
+	//
+	// The count is not redundant.  A filter saved when the store had no
+	// segments records the zero value for the newest one -- (0, 0) --
+	// and (0, 0) is also the identity of the FIRST segment a store
+	// seals.  The Dyna layer numbers every segment at height 0, so its
+	// first is exactly (0, 0): an empty filter's "covers nothing" was
+	// indistinguishable from "covers segment (0, 0)", and a crash that
+	// left a segment for recoverOrphans to adopt without rewriting the
+	// manifest produced exactly that pair.  The empty filter was then
+	// accepted as covering it, and every key in that segment answered
+	// "not found" -- a false negative, which is silent data loss rather
+	// than the slow lookup a false positive costs (issue #35).
+	BloomValid    bool   `json:"bloomValid,omitempty"`
+	BloomHeight   uint64 `json:"bloomHeight,omitempty"`
+	BloomSeq      uint64 `json:"bloomSeq,omitempty"`
+	BloomSegments uint64 `json:"bloomSegments,omitempty"`
 }
 
 // segment
@@ -223,8 +235,9 @@ type SegmentStore struct {
 	// bloomValid/bloomAt are the coverage claim writeManifest records.
 	// It is a one-shot: only the manifest written immediately after a
 	// save carries it.
-	bloomValid bool
-	bloomAt    SegmentMeta
+	bloomValid    bool
+	bloomAt       SegmentMeta
+	bloomSegments uint64
 
 	stats StoreStats // Counted under the Mutex, like everything else here
 }
@@ -416,9 +429,14 @@ func (s *SegmentStore) load() (err error) {
 // behind the segment list, so each of them rebuilds.
 func (s *SegmentStore) loadKeyFilter(m *StoreManifest) (err error) {
 	newest, ok := s.newestMeta()
-	covered := m.BloomValid &&
-		((ok && newest.Height == m.BloomHeight && newest.Seq == m.BloomSeq) ||
-			(!ok && len(s.segments) == 0)) // An empty filter covers no segments
+	// The count first: it is what separates "covers nothing" from
+	// "covers segment (0, 0)", which the newest-segment identity alone
+	// cannot do.  A manifest written before the count existed reads as
+	// 0, so a store with segments falls through to a rebuild -- slower,
+	// and correct.
+	covered := m.BloomValid && uint64(len(s.segments)) == m.BloomSegments &&
+		(m.BloomSegments == 0 || // An empty filter covers no segments
+			(ok && newest.Height == m.BloomHeight && newest.Seq == m.BloomSeq))
 	if covered {
 		if s.keys, err = LoadBloomSet(s.Directory); err == nil {
 			return nil
@@ -712,7 +730,8 @@ func (s *SegmentStore) writeManifest() (err error) {
 	defer func() { s.bloomValid = false }()
 
 	m := StoreManifest{Mutable: s.Mutable, SealLimit: s.SealLimit, BlockHeight: s.blockHeight,
-		BloomValid: s.bloomValid, BloomHeight: s.bloomAt.Height, BloomSeq: s.bloomAt.Seq}
+		BloomValid: s.bloomValid, BloomHeight: s.bloomAt.Height, BloomSeq: s.bloomAt.Seq,
+		BloomSegments: s.bloomSegments}
 	for _, seg := range s.segments {
 		m.Segments = append(m.Segments, seg.meta)
 	}
@@ -1612,7 +1631,8 @@ func (s *SegmentStore) Close() (err error) {
 	// reason to fail the close: the next open rebuilds.
 	if !s.closed && s.keys != nil {
 		if err := s.keys.Save(s.Directory); err == nil {
-			s.bloomAt, _ = s.newestMeta() // Zero when there are none, which is what covers none
+			s.bloomAt, _ = s.newestMeta()
+			s.bloomSegments = uint64(len(s.segments)) // What "covers none" needs to say so
 			s.bloomValid = true
 			if err := s.writeManifest(); err != nil {
 				return err

--- a/docs/design/durability.md
+++ b/docs/design/durability.md
@@ -126,11 +126,29 @@ of which lost keys that a completed `Close` had made durable:
    left its bytes on disk, so the next append landed after them and
    the following open mis-parsed everything written since.
 
-Each has a regression test in `segstore_test.go`
+4. **An empty key filter accepted as covering segment (0,0).** Not a
+   durability defect — the data was durable and intact — but reached
+   only through one. `loadKeyFilter` judged a saved filter still valid
+   by comparing the newest segment's `(Height, Seq)` to what the
+   manifest recorded, and a filter saved with *no* segments records the
+   zero value, `(0,0)`. That is also the identity of the first segment
+   a store seals, and the Dyna layer numbers every segment at height 0.
+   So when a crash left a sealed segment for `recoverOrphans` to adopt
+   without a manifest rewrite, the empty filter matched it, was loaded,
+   and answered "definitely absent" for all 40 of its keys: `Get`
+   returned not-found for records sitting on disk. The manifest now
+   records how many segments the filter covered, which is what "covers
+   nothing" needs to say out loud (issue #35).
+
+   `TestCrashRecoverySeal` found it, intermittently — twice in 55 runs.
+   `TestKeyFilterEmptyDoesNotCoverSegmentZero` builds the same state
+   deterministically.
+
+The first three have a regression test in `segstore_test.go`
 (`TestSegmentStoreLiveTailAfterInterruptedSeal`,
 `TestSegmentStoreClosedRejectsOperations`,
-`TestSegmentStoreTornTailIsTruncated`); all three fail against the
-unfixed code.
+`TestSegmentStoreTornTailIsTruncated`) and the fourth one in
+`keyfilter_test.go`; all four fail against the unfixed code.
 
 ## Known gaps (accepted, documented)
 

--- a/docs/design/segment-store.md
+++ b/docs/design/segment-store.md
@@ -196,10 +196,52 @@ record from a crash mid-write is dropped.
 5. Next — wire `ShardWriter.Flush` to `Seal` so a block boundary is one
    durability, sync, and compaction boundary.
 
-Not yet done here: a per-segment key count cap (segments grow with the
-seal cadence; a size-triggered seal or a tiered merge keeps the
-segment count bounded on long chains), and reading a value with one
-`ReadAt` on the value bytes rather than through the record header.
+Not yet done here: a tiered merge of sealed segments, so the segment
+count is bounded on long chains rather than growing with the seal
+cadence, and reading a value with one `ReadAt` on the value bytes
+rather than through the record header.
+
+A merge of *permanent* segments is not just a scheduling question: it
+would destroy the block→segment mapping `ExportBlock` depends on, which
+is the same mapping issue #27 established. Either the merge stays below
+the last exported block, or the manifest carries the mapping
+separately. The Dyna layer has no such constraint — no peer receives
+one of its segments.
+
+### File descriptors are borrowed, not held
+
+A segment used to keep its data and index files open for the life of
+the process, and nothing closed or merged them: a node sealing per
+block leaked two descriptors per block, and one test process here was
+measured holding 14,935 (issue #30).
+
+A segment now keeps only what a lookup needs in order to decide
+*whether* to read — the key count and the bloom filter — and borrows
+its files from a process-wide pool for the length of a read.
+`SetOpenFileLimit` bounds the pool; the default is 512, an order of
+magnitude under the 1024 that is still a common `ulimit -n`, leaving
+room for the live tails and the host application. So the descriptor
+count tracks the limit rather than the segment count
+(`TestSegmentFDsStayBounded`).
+
+Borrowing is reference counted, and that buys the second half: a file
+with a live borrow is never closed, and on Unix an open descriptor
+keeps reading after the path is unlinked. A reader can therefore hold
+a segment open across a compaction that retires and deletes it, which
+is what lets iteration run without the store's lock.
+
+### Iteration takes a snapshot and holds no lock
+
+`ForEach` used to hold the store's mutex for the whole iteration, so a
+callback that called `Get` deadlocked and any callback blocked every
+other reader and writer for as long as it ran (issue #31).
+
+It now copies the live tail's values and the segment list under the
+lock, releases it, and calls back with nothing held. What the callback
+sees is the store as it stood when iteration began. A compaction is
+free to commit underneath it; the files it retires are unlinked when
+the last iteration finishes rather than immediately, so the reads stay
+valid (`TestForEachSurvivesConcurrentCompaction`).
 
 Sealing is also still where the Perm layer's time goes — about 60% of
 it at a 25,000-key block, of which the largest remaining piece is the

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -52,6 +52,26 @@ The Perm layer seals on distinct keys; the Dyna layer seals on
 write and a handful of hot keys rewritten every block would hold the
 key count flat while the tail grew without bound.
 
+### Open File Limit
+
+`SetOpenFileLimit(n)` bounds how many segment files the process keeps
+open (default 512). Segments borrow their files from a shared pool for
+the length of a read rather than holding them, so the descriptor count
+tracks this number and not the number of segments sealed. Raise it to
+spend descriptors on avoiding reopens; lower it under a tight
+`ulimit -n`. Files being read are never closed, so the limit is a
+target the pool returns to rather than a ceiling at every instant.
+
+### Compaction Ratio
+
+`CompactRatio` (default 0.25) is the share of a mutable layer that must
+be superseded records before `Compress` does anything. `Compress` on a
+cadence used to rewrite the whole layer every call, so reclaiming a
+fixed amount of garbage grew more expensive as the database grew;
+waiting for a fixed *fraction* makes the amortised cost per overwrite
+constant instead. Raise it to compact less often and hold more
+garbage; lower it for the reverse.
+
 ### Buffer Size
 
 The `BufferSize` constant (default: 32KB) is the buffer `BFile` uses
@@ -124,10 +144,12 @@ go test -load ./database/
 **Possible causes:**
 - Many small segments, because `sealLimit` is too low
 - A compaction that has not run, leaving stale generations to search
+- An open-file limit far below the working set, so every lookup reopens
 
 **Solutions:**
 - Raise `sealLimit` so seals produce fewer, larger segments
 - Run `Compress()` on the Dyna layer
+- Raise `SetOpenFileLimit` if the process can afford the descriptors
 
 ### Issue: Slow open
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -194,8 +194,39 @@ Two flags change what runs:
   They are skipped by default so `go test ./...` stays a suite someone
   can wait for; the skip line names the flag.
 - `-short` skips the measurement tests (`TestSyncCost`,
-  `TestDynaCost`), which are correctness-neutral and exist to report
-  numbers.
+  `TestDynaCost`, `TestMultiCoreScaling`), which are
+  correctness-neutral and exist to report numbers.
+
+## What CI runs
+
+Split by cost, so that a mistake a compiler catches reports in a
+minute rather than behind the suite.
+
+**On every push and pull request** (`.github/workflows/ci.yml`):
+
+| job | what | why |
+|---|---|---|
+| `build` | `go build`, `go vet`, `gofmt -l` | seconds; catches the unused import, the shadowed error, the unformatted file |
+| `test` | `go test -short ./...` | every correctness test; the measurement tests prove nothing on a shared runner |
+| `race` | `-race` over the concurrency tests | the sharded write path, the file pool, iteration alongside compaction |
+
+**Nightly** (`.github/workflows/nightly.yml`): the full suite with
+timings, the full suite under `-race`, and the crash-recovery tests
+repeated 25 times.
+
+That last job earns its place. The durability tests kill a child
+process at a random moment, so each run samples a different window and
+a single run proves little. Issue #35 — an empty key filter accepted
+as covering segment `(0,0)`, so `Get` reported keys absent that were
+sitting on disk — failed **twice in fifty-five runs**. A pre-merge run
+sees green and merges it. Repetition is what finds that class of bug,
+and repetition is too slow to gate a push.
+
+The suite is slow enough (~27 minutes, ~20 with `-short`) that this
+split is a necessity rather than a preference. Most of that time is
+fsync: a block boundary seals all 512 shards, and a shard with no
+writes still pays two fsyncs for a manifest it did not change. That is
+issues #32 and #33; if they are fixed, the gate can be simpler.
 
 ## Conclusion
 


### PR DESCRIPTION
Three commits: a silent-data-loss fix, the two tractable halves of #30 and #31, and CI.

### `7eb9fce` — Stop an empty key filter from covering segment (0,0)  (#35)

Found by `TestCrashRecoverySeal`, which failed intermittently — **twice in 55 runs on `main`**, and not at all in 60 with the fix.

`loadKeyFilter` judged a saved filter valid by comparing the newest segment's `(Height, Seq)` to the manifest. `Close` records that as `newestMeta()`, which returns the **zero value** when there are no segments — so a filter covering nothing was written down as covering "the newest segment, `(0,0)`". `(0,0)` is also the first segment a store seals, and the Dyna layer numbers everything at height 0.

A crash leaving a segment for `recoverOrphans` to adopt without a manifest rewrite produced the pair: `(0,0)` matched `(0,0)`, the empty filter was loaded, and every key in that segment answered "not found" while sitting intact on disk. A false negative, which the code's own comment identifies as the one non-survivable failure mode.

The manifest now records how many segments the filter covered. The crash test also reports *where* a missing key actually is, which is what identified this — it showed the segment holding the key and the filter denying it in the same breath.

### `1ec53b0` — Borrow segment files; let iteration and compaction opt out  (#30, #31)

Three costs that grew with the database rather than with the work asked of it.

**Descriptors.** A segment held its two files open forever, so a node sealing per block leaked two per block — EMFILE inside ten minutes at a 1024 limit, and **14,935 measured in one test process here**. A segment now keeps only what a lookup needs to decide *whether* to read, and borrows its files from a bounded pool (`SetOpenFileLimit`, default 512). Borrowing is reference counted, so a file being read is never closed and keeps working after its path is unlinked.

**Iteration.** `ForEach` held the store mutex across the callback, so a callback calling `Get` deadlocked. It now snapshots and calls back with nothing held. `TestForEachCallbackMayUseTheStore` **times out against the old code**. Compaction can now commit mid-iteration, so retirement defers the unlink until the last iteration finishes.

**Compaction.** `Compress` rewrote the whole layer every call — O(N) per call, O(N × commits/K) over a run. It now does nothing unless a threshold fraction is superseded records, making the amortised cost per overwrite constant. Deciding is O(1): a probe of the store's own key filter before each write. The seal moved inside that check, because sealing first is what made compaction unable to opt out.

`TestDynaCompressIsIdempotent` asserted that `Compress` seals even with nothing to reclaim — the behaviour being removed — so it now covers both cases rather than being relaxed.

### `17bf15a` — CI  (#36)

Nothing ran on a push. Split by cost: `build`/`test`/`race` on every push, and a nightly job that runs the full suite, the full suite under `-race`, and **the crash tests 25 times over** — which is the only thing that would have caught #35.

Measured, and the reason the gate has to be split: 27 minutes in full, 21m17s with `-short`, of which 38s is user and 52s system. Over 90% is fsync wait, so a slower disk is worse and more cores do not help. That is #32 and #33; fix those and this can be simpler.

### Verification

Full suite **74 passed, 6 skipped, 0 failed**. Every new test was confirmed to fail against the unfixed code. Both code commits build and vet on their own.

### Not done here

#30's tiered merge is **#37** — it conflicts with the block→segment mapping `ExportBlock` depends on, which is a design decision rather than effort. #38, #39 and #40 were filed along the way.

Closes #31
Closes #35
Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKAh7mFDHChAtKQtJYP3a3