### PR TITLE
Close everything before reporting a failure, and keep the garbage estimate across restarts

### DIFF
--- a/database/dyna_test.go
+++ b/database/dyna_test.go
@@ -302,3 +302,58 @@ func copyFile(t *testing.T, src, dst string) {
 	require.NoError(t, err)
 	require.NoError(t, out.Sync())
 }
+
+// TestCompressEstimateSurvivesReopen
+// The estimate that decides whether Compress is worth running is
+// maintained as writes arrive.  It used to be process state, so a
+// reopened store believed it held no garbage whatever it actually
+// held, and would not compact until it had accumulated a threshold
+// fraction of the whole layer again in fresh overwrites (issue #40).
+func TestCompressEstimateSurvivesReopen(t *testing.T) {
+	dir := storeDir(t, "kv2")
+	kv2, err := NewKV2(dir, 1000)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{204})
+	vr := NewFastRandom([]byte{204, 204})
+	keys := make([][32]byte, 40)
+	for i := range keys {
+		keys[i] = kr.NextHash()
+		_, err = kv2.PutDyna(keys[i], vr.RandBuff(20, 100))
+		require.NoError(t, err)
+	}
+	// Overwrite every one of them, so most of the layer is garbage
+	values := make([][]byte, len(keys))
+	for round := 0; round < 3; round++ {
+		for i := range keys {
+			values[i] = vr.RandBuff(20, 100)
+			_, err = kv2.PutDyna(keys[i], values[i])
+			require.NoError(t, err)
+		}
+	}
+
+	// Seal, so the estimate reaches the manifest, then reopen
+	_, err = kv2.DynaKV.SealNext()
+	require.NoError(t, err)
+	before := kv2.DynaKV.shadowed
+	require.Greater(t, before, uint64(0), "the writes must have been counted as superseded")
+	require.NoError(t, kv2.Close())
+
+	reopened, err := OpenKV2(dir)
+	require.NoError(t, err)
+	require.NoError(t, reopened.Open())
+	assert.Equal(t, before, reopened.DynaKV.shadowed,
+		"the reopened store must know the garbage it holds")
+
+	// And it acts on it: a Compress right after reopening compacts,
+	// rather than waiting to re-accumulate the same garbage
+	require.NoError(t, reopened.Compress())
+	assert.Len(t, reopened.DynaKV.segments, 1, "a reopened store must still compact what it holds")
+
+	for i, key := range keys {
+		v, err := reopened.Get(key)
+		require.NoErrorf(t, err, "key %d", i)
+		assert.Equal(t, values[i], v)
+	}
+	require.NoError(t, reopened.Close())
+}

--- a/database/kv_2.go
+++ b/database/kv_2.go
@@ -136,13 +136,24 @@ func (k *KV2) Open() error {
 	return k.DynaKV.Open()
 }
 
+// Close
+// Close both layers, and report the first failure.
+//
+// Both, even when the first one fails.  Close is a durability point --
+// it is what flushes and fsyncs the Dyna layer's live tail, which is
+// buffered 32 KB at a time in process memory -- so returning early
+// left that tail unflushed and dropped it.  A caller told "the close
+// failed" was not told that one layer is durable and the other's
+// newest writes are gone, which is the torn commit across layers that
+// Seal was fixed for in issue #29 (issue #38).
 func (k *KV2) Close() error {
 	k.Mutex.Lock()
 	defer k.Mutex.Unlock()
-	if err := k.PermKV.Close(); err != nil {
-		return err
+	err := k.PermKV.Close()
+	if dynaErr := k.DynaKV.Close(); err == nil {
+		err = dynaErr
 	}
-	return k.DynaKV.Close()
+	return err
 }
 
 // GetDyna
@@ -295,7 +306,13 @@ func (k *KV2) Put(key [32]byte, value []byte) (writes int, err error) {
 		return k.DWrites, k.sealPermIfFull() // PermKV is never compacted; report DWrites
 	}
 	if bytes.Equal(existing, value) { // If no change, ignore;
-		return k.PWrites, nil
+		// DWrites, like every other path here: the count the caller
+		// gets back is what it uses to decide when to compact, and only
+		// the Dyna layer has anything to reclaim.  This branch -- a
+		// permanent key rewritten with the value it already has, which
+		// is what a replay looks like -- used to report the permanent
+		// count instead, a larger and unrelated number (issue #39).
+		return k.DWrites, nil
 	}
 	k.DWrites++
 	if err = k.DynaKV.Put(key, value); err != nil { // If the perm value changed, it is now a DynaKV

--- a/database/kv_2_test.go
+++ b/database/kv_2_test.go
@@ -229,3 +229,89 @@ func TestPutPermImmutableSentinel(t *testing.T) {
 	require.ErrorIs(t, kvs.PutPerm(key, []byte("different")), ErrImmutable)
 	require.NoError(t, kvs.Close())
 }
+
+// TestCloseFlushesBothLayersWhenOneFails
+// Close is a durability point: it is what flushes and fsyncs the Dyna
+// layer's live tail, which is otherwise buffered 32 KB at a time in
+// process memory.  Returning as soon as the Perm layer failed left
+// that tail unflushed and dropped it -- so a caller that saw an error
+// from Close had one layer durable, the other's newest writes gone,
+// and no way to tell (issue #38).
+//
+// The Perm layer is made to fail by closing the descriptor under its
+// live file, so flushing that file errors while the store still
+// believes it is open.
+func TestCloseFlushesBothLayersWhenOneFails(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
+	require.NoError(t, os.MkdirAll(dir, os.ModePerm))
+	dbDir := filepath.Join(dir, "kv2")
+
+	kv, err := NewKV2(dbDir, 1000)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{71})
+	keys := make([][32]byte, 20)
+	for i := range keys {
+		keys[i] = kr.NextHash()
+		_, err = kv.PutDyna(keys[i], []byte(fmt.Sprintf("dyna-%d", i)))
+		require.NoError(t, err)
+	}
+	// Still buffered: nothing has flushed the tail yet
+	require.True(t, kv.DynaKV.liveDirty, "the tail must be unflushed for this to test anything")
+
+	// Break the Perm layer, so KV2.Close hits an error on its first step
+	require.NoError(t, kv.PermKV.liveFile.File.Close())
+	require.Error(t, kv.Close(), "Close must report the Perm layer's failure")
+
+	// ...and the Dyna layer must still have been closed, which is what
+	// made its records durable
+	reopened, err := OpenKV2(dbDir)
+	require.NoError(t, err)
+	require.NoError(t, reopened.Open())
+	for i, key := range keys {
+		v, err := reopened.GetDyna(key)
+		require.NoErrorf(t, err, "dynamic key %d dropped by a Close that gave up early", i)
+		assert.Equal(t, fmt.Sprintf("dyna-%d", i), string(v))
+	}
+	require.NoError(t, reopened.Close())
+}
+
+// TestPutReportsDynamicWriteCount
+// The count Put returns is what a caller uses to decide when to
+// compact, and only the Dyna layer has anything to reclaim -- so every
+// path reports DWrites.  A permanent key rewritten with the value it
+// already has, which is what a replay looks like, used to report the
+// permanent count instead (issue #39).
+func TestPutReportsDynamicWriteCount(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
+
+	kv, err := NewKV2(dir, 1000)
+	require.NoError(t, err)
+	defer kv.Close()
+
+	kr := NewFastRandom([]byte{72})
+
+	// Some dynamic writes, so the two counts cannot coincide
+	for i := 0; i < 3; i++ {
+		_, err = kv.PutDyna(kr.NextHash(), []byte("d"))
+		require.NoError(t, err)
+	}
+	// And more permanent ones, so PWrites is the larger number
+	permKeys := make([][32]byte, 10)
+	for i := range permKeys {
+		permKeys[i] = kr.NextHash()
+		_, err = kv.Put(permKeys[i], []byte("p"))
+		require.NoError(t, err)
+	}
+	require.Greater(t, kv.PWrites, kv.DWrites, "the two counts must differ for this to test anything")
+
+	// The replay: same key, same value, already permanent
+	writes, err := kv.Put(permKeys[0], []byte("p"))
+	require.NoError(t, err)
+	assert.Equal(t, kv.DWrites, writes,
+		"an identical permanent rewrite must report the dynamic write count, like every other path")
+}

--- a/database/kv_shard.go
+++ b/database/kv_shard.go
@@ -196,12 +196,17 @@ func (k *KVShard) Compress() (err error) {
 }
 
 // Close
-// Close all the shards
+// Close every shard, and report the first failure.
+//
+// Every shard, even after one fails.  Close is the durability point
+// that flushes and fsyncs each shard's buffered live tail, so stopping
+// at the first error abandoned the tail of every shard after it -- 511
+// of them, in the worst case, for one bad shard (issue #38).
 func (k *KVShard) Close() (err error) {
-	for _, kvs := range k.Shards {
-		if err = kvs.Close(); err != nil {
-			return err
+	for i, kvs := range k.Shards {
+		if closeErr := kvs.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("shard %d: %w", i, closeErr)
 		}
 	}
-	return nil
+	return err
 }

--- a/database/segstore.go
+++ b/database/segstore.go
@@ -101,6 +101,18 @@ type StoreManifest struct {
 	BlockHeight uint64        `json:"blockHeight"` // Block currently being accumulated
 	Segments    []SegmentMeta `json:"segments"`    // Oldest first
 
+	// Shadowed carries the store's estimate of how many of its records
+	// a later write has superseded -- its garbage -- across a restart.
+	//
+	// Without it a reopened store believed it held none, whatever it
+	// actually held, and deferred reclaiming until it had accumulated a
+	// threshold fraction of the whole layer again in fresh overwrites
+	// (issue #40).  It is written whenever the manifest is, so a crash
+	// costs the writes since the last seal, import, or compaction: an
+	// under-estimate, which defers compaction rather than forcing a
+	// pointless one.
+	Shadowed uint64 `json:"shadowed,omitempty"`
+
 	// BloomValid says the persisted key filter (bloom.dat) covers
 	// exactly the sealed segments listed here; BloomHeight/BloomSeq name
 	// the newest of them and BloomSegments counts them.
@@ -274,11 +286,11 @@ type SegmentStore struct {
 	// slightly early.  Nil filter means no estimate, and the caller
 	// falls back to compacting unconditionally.
 	//
-	// It is process state: not persisted, and not reconstructed by
-	// load, so a reopened store believes it holds no garbage until it
-	// accumulates more.  That defers reclamation rather than losing
-	// anything, and it is the trade the threshold makes -- compacting
-	// unconditionally had no such state to lose (issue #40).
+	// It survives a restart: the manifest carries it, so a reopened
+	// store resumes its estimate rather than believing it holds no
+	// garbage at all (issue #40).  What a crash costs is the writes
+	// since the last manifest -- an under-estimate, which defers a
+	// compaction rather than forcing a pointless one.
 	shadowed uint64
 
 	// keys is a membership filter over everything the store holds --
@@ -459,6 +471,7 @@ func (s *SegmentStore) load() (err error) {
 	s.Mutable = m.Mutable
 	s.SealLimit = m.SealLimit
 	s.blockHeight = m.BlockHeight
+	s.shadowed = m.Shadowed
 
 	for _, meta := range m.Segments {
 		seg, err := s.openSegment(meta)
@@ -816,7 +829,7 @@ func (s *SegmentStore) writeManifest() (err error) {
 
 	m := StoreManifest{Mutable: s.Mutable, SealLimit: s.SealLimit, BlockHeight: s.blockHeight,
 		BloomValid: s.bloomValid, BloomHeight: s.bloomAt.Height, BloomSeq: s.bloomAt.Seq,
-		BloomSegments: s.bloomSegments}
+		BloomSegments: s.bloomSegments, Shadowed: s.shadowed}
 	for _, seg := range s.segments {
 		m.Segments = append(m.Segments, seg.meta)
 	}

--- a/docs/design/durability.md
+++ b/docs/design/durability.md
@@ -8,7 +8,12 @@ Tracks issue #5.
 ## The contract
 
 **`KV2.Close()` is a durability point**, as is a `Seal` (and so
-`KVShard.SealBlock` and `ExportBlock`) — **for both layers**. After a
+`KVShard.SealBlock` and `ExportBlock`) — **for both layers**.  Close
+closes both even when the first fails, and `KVShard.Close` closes every
+shard even after one fails, reporting the first error: stopping early
+abandoned the buffered live tail of everything after the failure, which
+is the same torn commit across layers that `Seal` was fixed for
+(issue #38). After a
 process dies (SIGKILL, power loss) at an arbitrary moment:
 
 1. `OpenKV2` succeeds — the database is never left unopenable.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -72,6 +72,11 @@ waiting for a fixed *fraction* makes the amortised cost per overwrite
 constant instead. Raise it to compact less often and hold more
 garbage; lower it for the reverse.
 
+The estimate behind it is maintained as writes arrive -- a probe of the
+store's own key filter, so deciding costs nothing -- and is carried in
+the manifest, so a reopened store resumes it rather than believing it
+holds no garbage.
+
 ### Buffer Size
 
 The `BufferSize` constant (default: 32KB) is the buffer `BFile` uses


### PR DESCRIPTION
Three of the issues filed while working #30/#31. All small, all with a regression test confirmed to fail against the unfixed code.

### `421c297` — Close every layer and shard, even after one fails  (#38, #39)

Close is a durability point: it is what flushes and fsyncs a store's live tail, which is otherwise buffered 32 KB at a time in process memory. Both Close methods returned at the first failure, so everything after it was never closed and its buffered writes were dropped.

`KV2.Close` abandoned the **Dyna** layer whenever Perm failed — and Dyna is the buffered one. `KVShard.Close` abandoned every shard after the one that failed, up to 511 for a single bad shard.

A caller that got an error back was told the close failed. It was not told that one layer is durable and the other's newest writes are gone — the same torn commit across layers that #29 fixed for `Seal`. Both now close everything and report the first error, the way `Seal` already advances both layers before returning either.

Also `KV2.Put` reports `DWrites` from the one branch that reported `PWrites` (#39). That branch is a permanent key rewritten with the value it already has — what a replay looks like — so it returned a larger, unrelated number precisely when a node was recovering.

### `cfd3fb9` — Carry the garbage estimate across a restart  (#40)

`Compress` skips unless a threshold fraction of a mutable layer is superseded records (#31). That estimate was process state, so a reopened store believed it held no garbage whatever it actually held, and would not compact until it had re-accumulated a threshold fraction of the **whole layer** in fresh overwrites. A node restarted often enough deferred reclaiming space indefinitely.

The manifest carries it now, written whenever the manifest is. A crash costs the writes since the last one — an under-estimate, which defers a compaction rather than forcing a pointless one.

This arrived with the threshold rather than being an old defect: the unconditional `Compress` it replaced had no such state to lose. Raised against my own change rather than left to be discovered.

### Verification

`go test -short ./database/` — **green**, 1975s. Both commits build and vet on their own. CI will run build/vet/gofmt, the suite, and `-race` on this branch.

Closes #38
Closes #39
Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKAh7mFDHChAtKQtJYP3a3