### PR TITLE
Say what the CI timing does and does not mean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,16 @@ jobs:
   test:
     name: Tests
     runs-on: ubuntu-latest
-    # Measured 21m17s here with -short, of which 38s is user time and
-    # 52s system: ~93% is waiting on fsync, not computing (issues #32,
-    # #33).  So a slower runner disk hurts and more cores do not help.
-    # Allow generously more before calling it hung.
+    # This job measured 3m4s on a GitHub runner, against 21m17s for the
+    # same -short suite on the developer machine it was written on.
+    # The suite is almost entirely fsync wait (38s user, 52s system out
+    # of those 21 minutes), and a runner's virtual disk acknowledges an
+    # fsync far faster than a physical one honouring a cache flush.
+    #
+    # Do not read the 3 minutes as "the suite is fast".  The number
+    # that describes a real node is the local one, which is what
+    # issues #32 and #33 are measured against.  The timeout below is
+    # generous because a busy runner is not a fast one.
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -70,9 +76,9 @@ jobs:
       # assert behaviour and are worth nothing on a shared runner whose
       # disk is somebody else's too.  Every correctness test still runs.
       #
-      # It saves ~6 of the 27 minutes; the rest is correctness tests
-      # that are slow for the reasons #32 and #33 describe, not for
-      # anything -short can skip.
+      # It saves ~6 of the 27 minutes locally; the rest is correctness
+      # tests that are slow for the reasons #32 and #33 describe, not
+      # for anything -short can skip.
       - name: Test
         run: go test -short -timeout 55m ./...
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -222,11 +222,19 @@ sitting on disk — failed **twice in fifty-five runs**. A pre-merge run
 sees green and merges it. Repetition is what finds that class of bug,
 and repetition is too slow to gate a push.
 
-The suite is slow enough (~27 minutes, ~20 with `-short`) that this
-split is a necessity rather than a preference. Most of that time is
-fsync: a block boundary seals all 512 shards, and a shard with no
-writes still pays two fsyncs for a manifest it did not change. That is
-issues #32 and #33; if they are fixed, the gate can be simpler.
+The suite is slow enough locally (~27 minutes, 21m17s with `-short`)
+that this split is a necessity rather than a preference. Most of that
+time is fsync: a block boundary seals all 512 shards, and a shard with
+no writes still pays two fsyncs for a manifest it did not change. That
+is issues #32 and #33.
+
+A GitHub runner ran the same `-short` suite in **3m4s**. The gap is
+worth understanding rather than celebrating: the work is 93% fsync wait
+(38s user and 52s system out of the local 21 minutes), and a runner's
+virtual disk acknowledges an fsync far faster than a physical one
+honouring a cache flush. **The local number is the one that describes a
+real node**, and it is what #32 and #33 are measured against. A green
+CI run says the code is correct, not that the fsync cost is acceptable.
 
 ## Conclusion
 


### PR DESCRIPTION
Docs and comments only.

The first CI run put the `-short` suite at **3m4s** on a GitHub runner. The same suite takes **21m17s** on the machine the workflows were written on, and the comments I put in `ci.yml` implied a reader should expect the latter.

The gap is not a mystery and it is not good news. The suite is ~93% fsync wait — 38s user and 52s system out of those 21 minutes — and a runner's virtual disk acknowledges an fsync far faster than a physical one honouring a cache flush. The runner is not measuring what a node pays; it is measuring a disk that answers before the data is down.

Worth writing down because the wrong conclusion is available and attractive: that the suite is fast, and that #32 and #33 overstate the cost. The local numbers are the ones that describe a real node, and they are what those issues are measured against.

**A green CI run says the code is correct, not that the fsync cost is acceptable.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKAh7mFDHChAtKQtJYP3a3