### PR TITLE
Merge a finished block set into one segment per shard

### DIFF
--- a/database/kv_2.go
+++ b/database/kv_2.go
@@ -275,6 +275,20 @@ func (k *KV2) Seal(height uint64) (meta SegmentMeta, err error) {
 	return meta, err
 }
 
+// MergeBelow
+// Merge the Perm layer's sealed segments below a block height into one.
+// Reports whether anything was merged.
+//
+// Only the Perm layer.  The Dyna layer already has Compress, which
+// merges for a different reason -- to reclaim what overwriting left
+// behind -- and its segments are local, so their count is bounded by
+// how often it compacts rather than by the chain's length.
+func (k *KV2) MergeBelow(height uint64) (meta SegmentMeta, merged bool, err error) {
+	k.Mutex.Lock()
+	defer k.Mutex.Unlock()
+	return k.PermKV.MergeBelow(height)
+}
+
 // Put
 // Returns the number of writes since the last compress, and an err if the put failed
 func (k *KV2) Put(key [32]byte, value []byte) (writes int, err error) {

--- a/database/kv_shard.go
+++ b/database/kv_shard.go
@@ -281,6 +281,48 @@ func (k *KVShard) SealBlock(height uint64) (err error) {
 	return k.writeBlockHeight(height + 1)
 }
 
+// MergeFinalized
+// Merge each shard's Perm segments below a block height into one, and
+// report how many shards merged anything.
+//
+// This is meant to be driven in the background, on a cadence the
+// caller chooses, and deliberately is not a goroutine this package
+// starts.  Only the caller knows its block rate and how far back
+// healing may still write, which is what sets the watermark; and a
+// background goroutine owned by the store would need a lifecycle,
+// somewhere to report errors, and a way to not be running during a
+// block boundary.  A method the caller calls from its own scheduler
+// has none of those problems and is testable besides.
+//
+// Shards merge independently -- each under its own lock, over its own
+// few hundred entries -- so this can be spread out or run
+// concurrently.  It walks them in order and keeps going past a failure
+// so that one bad shard does not stop the rest from being merged,
+// reporting the first error.
+func (k *KVShard) MergeFinalized(height uint64) (mergedShards int, err error) {
+	for i, shard := range k.Shards {
+		if shard == nil {
+			continue
+		}
+		if openErr := shard.Open(); openErr != nil {
+			if err == nil {
+				err = fmt.Errorf("shard %d: %w", i, openErr)
+			}
+			continue
+		}
+		_, merged, mergeErr := shard.MergeBelow(height)
+		switch {
+		case mergeErr != nil:
+			if err == nil {
+				err = fmt.Errorf("shard %d: %w", i, mergeErr)
+			}
+		case merged:
+			mergedShards++
+		}
+	}
+	return mergedShards, err
+}
+
 // Compress
 // Compress all the shards
 func (k *KVShard) Compress() (err error) {

--- a/database/merge_test.go
+++ b/database/merge_test.go
@@ -1,0 +1,313 @@
+package blockchainDB
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMergeBelowKeepsEveryKeyAndCutsFiles
+// Tier one of issue #47: a block boundary seals a segment per shard
+// that took writes, so a store accumulates one file pair per block and
+// the count is bounded by nothing.  Merging a finished block set down
+// to one segment must cut the files without losing a key.
+func TestMergeBelowKeepsEveryKeyAndCutsFiles(t *testing.T) {
+	dir := storeDir(t, "merge")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{171})
+	const blocks = 20
+	const perBlock = 25
+	keys := make([][32]byte, 0, blocks*perBlock)
+	values := make(map[[32]byte]string)
+	for h := uint64(1); h <= blocks; h++ {
+		for i := 0; i < perBlock; i++ {
+			key := kr.NextHash()
+			val := fmt.Sprintf("b%d-k%d", h, i)
+			require.NoError(t, store.Put(key, []byte(val)))
+			keys = append(keys, key)
+			values[key] = val
+		}
+		_, err = store.Seal(h)
+		require.NoError(t, err)
+	}
+	require.Len(t, store.segments, blocks, "one segment per block before merging")
+
+	// Finalise everything below block 20, leaving the newest alone
+	meta, merged, err := store.MergeBelow(20)
+	require.NoError(t, err)
+	require.True(t, merged, "19 segments below the watermark must merge")
+	assert.Len(t, store.segments, 2, "19 merged into 1, plus the segment at block 20")
+	assert.Equal(t, uint64(19*perBlock), meta.Count, "the merged segment holds every key below the watermark")
+
+	// The merged segment must order before what was left standing
+	assert.True(t, store.segments[1].meta.after(store.segments[0].meta),
+		"the merged segment must still order before the segments it did not replace")
+
+	// Every key still reads back, from a segment that no longer exists
+	for i, key := range keys {
+		v, err := store.Get(key)
+		require.NoErrorf(t, err, "key %d lost by the merge", i)
+		assert.Equal(t, values[key], string(v))
+	}
+
+	// The files the merge replaced are gone
+	segFiles := 0
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == segDataSuffix {
+			segFiles++
+		}
+	}
+	assert.Equal(t, 3, segFiles, "2 sealed segments plus live.dat")
+
+	// And it survives a reopen: the manifest names the merged segment
+	require.NoError(t, store.Close())
+	reopened, err := OpenSegmentStore(dir)
+	require.NoError(t, err)
+	require.Len(t, reopened.segments, 2)
+	for i, key := range keys {
+		v, err := reopened.Get(key)
+		require.NoErrorf(t, err, "key %d lost across the reopen", i)
+		assert.Equal(t, values[key], string(v))
+	}
+	require.NoError(t, reopened.Close())
+}
+
+// TestMergeBelowLeavesTheWatermarkAlone
+// The watermark is what keeps block export working: a block a peer
+// might still ask for by number must not be merged away.
+func TestMergeBelowLeavesTheWatermarkAlone(t *testing.T) {
+	dir := storeDir(t, "watermark")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+	defer store.Close()
+
+	kr := NewFastRandom([]byte{172})
+	for h := uint64(1); h <= 10; h++ {
+		require.NoError(t, store.Put(kr.NextHash(), []byte("v")))
+		_, err = store.Seal(h)
+		require.NoError(t, err)
+	}
+
+	_, merged, err := store.MergeBelow(6)
+	require.NoError(t, err)
+	require.True(t, merged)
+
+	// Blocks 6..10 must still be individually present
+	heights := map[uint64]bool{}
+	for _, seg := range store.segments {
+		heights[seg.meta.Height] = true
+	}
+	for h := uint64(6); h <= 10; h++ {
+		assert.Truef(t, heights[h], "block %d is at or above the watermark and must not be merged", h)
+	}
+	assert.Len(t, store.segments, 6, "blocks 1-5 merged into one, 6..10 left standing")
+
+	// Merging again changes nothing: only one segment is below 6 now
+	_, merged, err = store.MergeBelow(6)
+	require.NoError(t, err)
+	assert.False(t, merged, "a single segment below the watermark is not worth merging")
+}
+
+// TestMergeFinalizedAcrossShards
+// The sharded wrapper merges each shard independently.
+func TestMergeFinalizedAcrossShards(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
+
+	kvs, err := NewKVShard(dir, 100_000) // High, so only block boundaries seal
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{173})
+	vr := NewFastRandom([]byte{173, 173})
+	keys := make([][32]byte, 0, 400)
+	values := make(map[[32]byte][]byte)
+	for h := uint64(1); h <= 8; h++ {
+		for i := 0; i < 50; i++ {
+			key := kr.NextHash()
+			val := vr.RandBuff(20, 60)
+			require.NoError(t, kvs.PutPerm(key, val))
+			keys = append(keys, key)
+			values[key] = val
+		}
+		require.NoError(t, kvs.SealBlock(h))
+	}
+
+	before := 0
+	for _, sh := range kvs.Shards {
+		before += len(sh.PermKV.segments)
+	}
+
+	mergedShards, err := kvs.MergeFinalized(7)
+	require.NoError(t, err)
+	require.Greater(t, mergedShards, 0, "some shard must have had two segments below the watermark")
+
+	after := 0
+	for _, sh := range kvs.Shards {
+		after += len(sh.PermKV.segments)
+	}
+	assert.Less(t, after, before, "merging must reduce the segment count (%d -> %d)", before, after)
+
+	for i, key := range keys {
+		v, err := kvs.GetPerm(key)
+		require.NoErrorf(t, err, "key %d lost by the merge", i)
+		assert.Equal(t, values[key], v)
+	}
+	require.NoError(t, kvs.Close())
+}
+
+// TestMergeDoesNotDisturbBlockExport
+// The reason merging was blocked (issue #37): merging permanent
+// segments destroys the block->segment mapping ExportBlock depends on.
+// The watermark is what makes it safe -- nothing at or above it is
+// merged, so a block a peer is still fetching is never merged away.
+// This checks the whole round trip across a merge, which is the claim
+// that actually matters.
+func TestMergeDoesNotDisturbBlockExport(t *testing.T) {
+	dirA := filepath.Join(os.TempDir(), t.Name()+"_A")
+	dirB := filepath.Join(os.TempDir(), t.Name()+"_B")
+	exportDir := filepath.Join(os.TempDir(), t.Name()+"_export")
+	for _, d := range []string{dirA, dirB, exportDir} {
+		os.RemoveAll(d)
+		defer os.RemoveAll(d)
+	}
+
+	nodeA, err := NewKVShard(dirA, 100_000)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{174})
+	vr := NewFastRandom([]byte{174, 174})
+	keys := make([][32]byte, 0, 300)
+	values := make(map[[32]byte][]byte)
+
+	// Export blocks 1..6 as a peer would fetch them
+	var prev *Manifest
+	for h := uint64(1); h <= 6; h++ {
+		for i := 0; i < 50; i++ {
+			key := kr.NextHash()
+			val := vr.RandBuff(20, 60)
+			require.NoError(t, nodeA.PutPerm(key, val))
+			keys = append(keys, key)
+			values[key] = val
+		}
+		prev, err = nodeA.ExportBlock(exportDir, h, prev)
+		require.NoError(t, err)
+	}
+
+	// Now finalise the blocks a peer has already taken
+	mergedShards, err := nodeA.MergeFinalized(5)
+	require.NoError(t, err)
+	require.Greater(t, mergedShards, 0, "the merge must have done something for this to test anything")
+
+	// A later block still exports correctly after the merge
+	for i := 0; i < 50; i++ {
+		key := kr.NextHash()
+		val := vr.RandBuff(20, 60)
+		require.NoError(t, nodeA.PutPerm(key, val))
+		keys = append(keys, key)
+		values[key] = val
+	}
+	_, err = nodeA.ExportBlock(exportDir, 7, prev)
+	require.NoError(t, err)
+
+	// A fresh node syncs from the exported blocks and gets everything
+	nodeB, err := NewKVShard(dirB, 100_000)
+	require.NoError(t, err)
+	var total uint64
+	for h := 1; h <= 7; h++ {
+		n, err := nodeB.ImportBlock(filepath.Join(exportDir, fmt.Sprintf("block-%08d", h)))
+		require.NoErrorf(t, err, "import block %d after a merge on the exporting node", h)
+		total += n
+	}
+	assert.Equal(t, uint64(len(keys)), total, "every record must reach the peer")
+	for i, key := range keys {
+		v, err := nodeB.GetPerm(key)
+		require.NoErrorf(t, err, "key %d never reached the peer", i)
+		assert.Equal(t, values[key], v)
+	}
+	require.NoError(t, nodeA.Close())
+	require.NoError(t, nodeB.Close())
+}
+
+// TestRepeatedMergesKeepDeepEntriesReachable
+// The steady state, which one merge does not exercise: a node merges
+// every completed set, forever, so a later merge's input run includes
+// segments a previous merge produced.  What has to keep working is a
+// lookup of an entry written long ago and merged repeatedly since --
+// the "reach back 20N blocks" case.
+func TestRepeatedMergesKeepDeepEntriesReachable(t *testing.T) {
+	dir := storeDir(t, "deep")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+
+	const sets = 8    // Eight completed block sets
+	const setSize = 5 // Blocks per set, standing in for N
+	const perBlock = 10
+
+	kr := NewFastRandom([]byte{175})
+	type entry struct {
+		key   [32]byte
+		value string
+		block uint64
+	}
+	var all []entry
+
+	block := uint64(0)
+	for set := 0; set < sets; set++ {
+		for b := 0; b < setSize; b++ {
+			block++
+			for i := 0; i < perBlock; i++ {
+				key := kr.NextHash()
+				val := fmt.Sprintf("blk%d-%d", block, i)
+				require.NoError(t, store.Put(key, []byte(val)))
+				all = append(all, entry{key, val, block})
+			}
+			_, err = store.Seal(block)
+			require.NoError(t, err)
+		}
+		// Finalise every set but the one just written, so each merge
+		// after the first folds in what the previous merge produced
+		watermark := block - uint64(setSize) + 1
+		if watermark > 1 {
+			_, merged, err := store.MergeBelow(watermark)
+			require.NoErrorf(t, err, "merge after set %d", set)
+			require.Truef(t, merged, "set %d should have merged", set)
+		}
+	}
+
+	// The oldest entries have now been through several merges.  Every
+	// entry must still be reachable, and with the right value.
+	for i, e := range all {
+		v, err := store.Get(e.key)
+		require.NoErrorf(t, err, "entry %d from block %d unreachable after repeated merges", i, e.block)
+		require.Equalf(t, e.value, string(v), "entry %d from block %d has the wrong value", i, e.block)
+	}
+
+	// A key that was never written must still be absent -- the filter
+	// and the segment walk have to agree after all that rewriting
+	for i := 0; i < 50; i++ {
+		_, err := store.Get(kr.NextHash())
+		require.ErrorIsf(t, err, errNotFound, "an unwritten key %d must be reported absent", i)
+	}
+
+	// And it all survives a reopen, which rebuilds from the manifest
+	require.NoError(t, store.Close())
+	reopened, err := OpenSegmentStore(dir)
+	require.NoError(t, err)
+	for i, e := range all {
+		v, err := reopened.Get(e.key)
+		require.NoErrorf(t, err, "entry %d from block %d lost across the reopen", i, e.block)
+		require.Equal(t, e.value, string(v))
+	}
+	t.Logf("%d entries over %d blocks, %d merges, %d segments standing",
+		len(all), block, sets-1, len(reopened.segments))
+	require.NoError(t, reopened.Close())
+}

--- a/database/segstore.go
+++ b/database/segstore.go
@@ -1569,74 +1569,24 @@ func (s *SegmentStore) CompactNext() (meta SegmentMeta, err error) {
 	return s.compact(s.blockHeight)
 }
 
-// compact is Compact; the caller must hold the Mutex
-func (s *SegmentStore) compact(height uint64) (meta SegmentMeta, err error) {
-	if err = s.checkOpen(); err != nil {
-		return meta, err
-	}
-	if len(s.segments) == 0 {
-		return meta, nil
-	}
-	seq, err := s.nextKeyAt(height)
-	if err != nil {
-		return meta, err
-	}
-	if s.blockHeight < height {
-		s.blockHeight = height
-	}
-
-	// Newest wins: walk segments newest to oldest, keeping the first
-	// value seen for each key
-	type liveVal struct {
-		seg *segment
-		dbb *DBBKey
-	}
-	winners := make(map[[32]byte]liveVal)
-	for i := len(s.segments) - 1; i >= 0; i-- {
-		seg := s.segments[i]
-		entries := make([]byte, seg.count*DBKeyFullSize)
-		index, release, err := seg.index()
-		if err != nil {
-			return meta, err
-		}
-		_, err = index.ReadAt(entries, segIndexHdrSize)
-		release()
-		if err != nil {
-			return meta, err
-		}
-		for pos := 0; pos+DBKeyFullSize <= len(entries); pos += DBKeyFullSize {
-			key, dbb, err := GetDBBKey(entries[pos : pos+DBKeyFullSize])
-			if err != nil {
-				return meta, err
-			}
-			if _, seen := winners[key]; !seen {
-				winners[key] = liveVal{seg, dbb}
-			}
-		}
-	}
-
-	// A single generation holding one record per key has nothing to
-	// reclaim: rewriting it would copy every value to produce the same
-	// file.  The Dyna layer compacts on a write count, so it lands here
-	// whenever a compaction has already run since the last seal.  The
-	// meta returned is the standing generation's, at its own height --
-	// not the height asked for, since no segment was written.
-	if len(s.segments) == 1 && int64(len(winners)) == s.segments[0].records {
-		return s.segments[0].meta, nil
-	}
-
-	keys := make([][32]byte, 0, len(winners))
-	for key := range winners {
-		keys = append(keys, key)
-	}
-	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i][:], keys[j][:]) < 0 })
-
+// writeMergedSegment
+// Write the resolved keys and values of a merge into a new sealed
+// segment at (height, seq), build its index, and open it.  The caller
+// must hold the Mutex and is responsible for committing it into the
+// segment list.
+//
+// The segment is complete and durable when this returns; it is simply
+// not yet named by the manifest, which is what makes the commit that
+// follows the only thing that decides whether the merge happened.
+func (s *SegmentStore) writeMergedSegment(
+	winners map[[32]byte]mergeInput, keys [][32]byte, height, seq uint64,
+) (meta SegmentMeta, merged *segment, err error) {
 	dataName := segmentFileName(height, seq)
 	dataPath := filepath.Join(s.Directory, dataName)
 	tmpPath := filepath.Join(s.Directory, segCompactName+segTmpSuffix)
 	f, err := os.Create(tmpPath)
 	if err != nil {
-		return meta, err
+		return meta, nil, err
 	}
 	defer func() {
 		if f != nil {
@@ -1657,7 +1607,7 @@ func (s *SegmentStore) compact(height uint64) (meta SegmentMeta, err error) {
 	binary.BigEndian.PutUint32(header[4:], segmentVersion)
 	binary.BigEndian.PutUint64(header[16:], uint64(len(keys)))
 	if _, err = out.Write(header[:]); err != nil {
-		return meta, err
+		return meta, nil, err
 	}
 
 	// Record where each value lands, so the index needs no read-back
@@ -1669,37 +1619,37 @@ func (s *SegmentStore) compact(height uint64) (meta SegmentMeta, err error) {
 		w := winners[key]
 		value, err := w.seg.value(w.dbb)
 		if err != nil {
-			return meta, err
+			return meta, nil, err
 		}
 		copy(recHdr[:32], key[:])
 		binary.BigEndian.PutUint64(recHdr[32:], uint64(len(value)))
 		if _, err = out.Write(recHdr[:]); err != nil {
-			return meta, err
+			return meta, nil, err
 		}
 		if _, err = out.Write(value); err != nil {
-			return meta, err
+			return meta, nil, err
 		}
 		entries[key] = &DBBKey{Offset: offset + segRecHdrSize, Length: uint64(len(value))}
 		offset += segRecHdrSize + uint64(len(value))
 	}
 	if err = bw.Flush(); err != nil {
-		return meta, err
+		return meta, nil, err
 	}
 	if err = f.Sync(); err != nil {
-		return meta, err
+		return meta, nil, err
 	}
 	if err = f.Close(); err != nil {
 		f = nil
-		return meta, err
+		return meta, nil, err
 	}
 	f = nil
 	if err = os.Rename(tmpPath, dataPath); err != nil {
-		return meta, err
+		return meta, nil, err
 	}
 	// The manifest commit's directory fsync covers this rename
 	indexPath := strings.TrimSuffix(dataPath, segDataSuffix) + segIndexSuffix
 	if err = writeIndexFile(indexPath, keys, entries); err != nil {
-		return meta, err
+		return meta, nil, err
 	}
 
 	meta = SegmentMeta{Height: height, Seq: seq, File: dataName, Count: uint64(len(keys)), Hash: ""}
@@ -1707,6 +1657,187 @@ func (s *SegmentStore) compact(height uint64) (meta SegmentMeta, err error) {
 		meta.Hash = fmt.Sprintf("%x", h.Sum(nil))
 	}
 	seg, err := s.openSegment(meta)
+	if err != nil {
+		return meta, nil, err
+	}
+	return meta, seg, nil
+}
+
+// MergeBelow
+// Merge every sealed segment belonging to a block below `height` into
+// one, leaving the rest untouched.  Reports whether it merged anything.
+//
+// This is tier one of keeping the file count survivable.  A block
+// boundary seals one segment per shard that took writes, so a shard
+// accumulates one file pair per block -- measured at ~1,016 files per
+// block across 512 shards at 5,000 entries a block, which is ~88M
+// files a day and exhausts a 240M-inode filesystem in under three days
+// (issue #47).  Merging a finished block set down to one segment per
+// shard cuts that by the number of blocks in the set.
+//
+// It merges WITHIN one store, never across shards.  That keeps the
+// working set small -- a shard holds a few hundred entries per set --
+// and keeps the merge under the shard's own lock, so shards merge
+// independently and in parallel.  Merging across shards is what
+// produces globally sorted runs, and it is a separate, rarer pass.
+//
+// `height` is the caller's finalisation watermark: the block below
+// which nothing more will arrive and nothing is still being healed.
+// Segments at or above it are left alone, so a block a peer might
+// still ask for by number is never merged away, and block export is
+// untouched.
+//
+// Crash safety follows the same rule as compaction.  The merged file
+// is written and renamed before the manifest names it, and it takes an
+// identity BELOW the newest segment, so a crash before the commit
+// leaves it as an orphan at or below the manifest's newest height --
+// which recoverOrphans deletes.  The originals are still named by the
+// manifest and are only retired after the commit succeeds, so the
+// discarded merge costs space and nothing else.
+func (s *SegmentStore) MergeBelow(height uint64) (meta SegmentMeta, merged bool, err error) {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+	if err = s.checkOpen(); err != nil {
+		return meta, false, err
+	}
+
+	// Segments are oldest first, so the finalised ones are a prefix
+	n := 0
+	for _, seg := range s.segments {
+		if seg.meta.Height >= height {
+			break
+		}
+		n++
+	}
+	if n < 2 {
+		return meta, false, nil // Nothing to gain from merging one segment
+	}
+	run := s.segments[:n]
+
+	// The merged segment takes the sequence after the newest it
+	// replaces.  That is free and correctly ordered: everything merged
+	// is at or below (H, S), and the first segment left standing is in
+	// a block above H, because the run is exactly the segments below
+	// `height` and the remainder is exactly those at or above it.
+	last := run[n-1].meta
+	outHeight, outSeq := last.Height, last.Seq+1
+
+	winners, keys, err := s.mergeInputs(run)
+	if err != nil {
+		return meta, false, err
+	}
+
+	meta, seg, err := s.writeMergedSegment(winners, keys, outHeight, outSeq)
+	if err != nil {
+		return meta, false, err
+	}
+
+	// Commit: the manifest names the merged segment in place of the run
+	old := s.segments
+	s.segments = append([]*segment{seg}, old[n:]...)
+	if err = s.writeManifest(); err != nil {
+		s.segments = old // Uncommitted; the originals still stand
+		seg.close()
+		s.retire(seg.dataPath)
+		s.retire(seg.indexPath)
+		return meta, false, err
+	}
+
+	for _, o := range run {
+		o.close()
+		s.retire(o.dataPath)
+		s.retire(o.indexPath)
+	}
+	return meta, true, nil
+}
+
+// mergeInput names where a key's surviving value lives
+type mergeInput struct {
+	seg *segment
+	dbb *DBBKey
+}
+
+// mergeInputs
+// Resolve what a merge of segs should write: one entry per key, taking
+// the newest where a key appears more than once, and the keys sorted so
+// the output is a sorted run.
+//
+// Newest-wins matters even in the Perm layer, where a key is written
+// once and never overwritten: adopting a peer's segment can introduce a
+// second copy of a key the store already holds, because
+// checkNoConflicts rejects a DIFFERING value and permits an identical
+// one.  The copies agree, so which one survives does not matter -- but
+// the merge still has to emit only one.
+//
+// The caller must hold the Mutex.
+func (s *SegmentStore) mergeInputs(segs []*segment) (winners map[[32]byte]mergeInput, keys [][32]byte, err error) {
+	winners = make(map[[32]byte]mergeInput)
+	for i := len(segs) - 1; i >= 0; i-- { // Newest first, so it wins
+		seg := segs[i]
+		entries := make([]byte, seg.count*DBKeyFullSize)
+		index, release, err := seg.index()
+		if err != nil {
+			return nil, nil, err
+		}
+		_, err = index.ReadAt(entries, segIndexHdrSize)
+		release()
+		if err != nil {
+			return nil, nil, err
+		}
+		for pos := 0; pos+DBKeyFullSize <= len(entries); pos += DBKeyFullSize {
+			key, dbb, err := GetDBBKey(entries[pos : pos+DBKeyFullSize])
+			if err != nil {
+				return nil, nil, err
+			}
+			if _, seen := winners[key]; !seen {
+				winners[key] = mergeInput{seg, dbb}
+			}
+		}
+	}
+	keys = make([][32]byte, 0, len(winners))
+	for key := range winners {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i][:], keys[j][:]) < 0 })
+	return winners, keys, nil
+}
+
+// compact is Compact; the caller must hold the Mutex
+func (s *SegmentStore) compact(height uint64) (meta SegmentMeta, err error) {
+	if err = s.checkOpen(); err != nil {
+		return meta, err
+	}
+	if len(s.segments) == 0 {
+		return meta, nil
+	}
+	seq, err := s.nextKeyAt(height)
+	if err != nil {
+		return meta, err
+	}
+	if s.blockHeight < height {
+		s.blockHeight = height
+	}
+
+	// A single generation holding one record per key has nothing to
+	// reclaim: rewriting it would copy every value to produce the same
+	// file.  The Dyna layer compacts on a write count, so it lands here
+	// whenever a compaction has already run since the last seal.  The
+	// meta returned is the standing generation's, at its own height --
+	// not the height asked for, since no segment was written.
+	//
+	// count is the index's key count and records the data file's
+	// physical count, so their being equal is exactly "no key appears
+	// twice", which is what there would be to reclaim.
+	if len(s.segments) == 1 && s.segments[0].count == s.segments[0].records {
+		return s.segments[0].meta, nil
+	}
+
+	winners, keys, err := s.mergeInputs(s.segments)
+	if err != nil {
+		return meta, err
+	}
+
+	meta, seg, err := s.writeMergedSegment(winners, keys, height, seq)
 	if err != nil {
 		return meta, err
 	}

--- a/docs/design/segment-store.md
+++ b/docs/design/segment-store.md
@@ -196,17 +196,57 @@ record from a crash mid-write is dropped.
 5. Next — wire `ShardWriter.Flush` to `Seal` so a block boundary is one
    durability, sync, and compaction boundary.
 
-Not yet done here: a tiered merge of sealed segments, so the segment
-count is bounded on long chains rather than growing with the seal
-cadence, and reading a value with one `ReadAt` on the value bytes
-rather than through the record header.
+Not yet done here: reading a value with one `ReadAt` on the value bytes
+rather than through the record header, and the cross-shard merge that
+produces globally sorted runs (issue #47).
 
-A merge of *permanent* segments is not just a scheduling question: it
-would destroy the block→segment mapping `ExportBlock` depends on, which
-is the same mapping issue #27 established. Either the merge stays below
-the last exported block, or the manifest carries the mapping
-separately. The Dyna layer has no such constraint — no peer receives
-one of its segments.
+### Merging finalized segments
+
+A block boundary seals one segment per shard that took writes, so the
+file count grows with the chain and is bounded by nothing. Measured at
+512 shards, 5,000 entries a block, that is ~1,016 files per block —
+~88M a day at one block per second, against 240M inodes on the
+filesystem this was measured on. Inodes run out in under three days,
+and the failure is `ENOSPC` with terabytes free.
+
+`MergeBelow(height)` merges the sealed segments belonging to blocks
+below a watermark into one. Measured on a completed 20-block set:
+**~8,980 segments to ~512, i.e. 17,960 files to 1,024**.
+
+The watermark is what makes this safe, and it is why merging was
+blocked before (issue #37). Merging permanent segments destroys the
+block→segment mapping `ExportBlock` depends on — the mapping #27
+established. Only segments *below* the watermark are merged, and the
+caller sets it behind the healing window, so a block a peer might
+still ask for by number is never merged away.
+`TestMergeDoesNotDisturbBlockExport` runs the whole export/import round
+trip across a merge.
+
+The merged segment takes the sequence after the newest it replaces.
+That slot is always free and correctly ordered: everything merged is at
+or below `(H, S)`, and the first segment left standing is in a block
+above `H`, because the run is exactly the segments below the watermark.
+
+Crash safety inverts compaction's rule deliberately. A compacted
+generation is written *above* the manifest's newest height, so an
+uncommitted one is adopted — correct, because it holds every live key.
+A merge is written *below* it, so an uncommitted one is deleted by
+`recoverOrphans` — also correct, because it holds only part of the
+store and the originals it would replace are still named by the
+manifest. Either way the crash costs space and nothing else.
+
+Merging happens **within a shard**, never across. That keeps the
+working set small — a shard holds a few hundred entries per set — and
+keeps the merge under the shard's own lock, so shards merge
+independently and in parallel. `KVShard.MergeFinalized` drives it per
+shard and keeps going past a failure, reporting the first error.
+
+It is not a goroutine this package starts. Only the caller knows its
+block rate and how far back healing may still write, which is what
+sets the watermark. Measured cost is a real constraint on that caller:
+one 20-block set took 12.2 s serially across 512 shards, a ~61% duty
+cycle against 20 seconds of chain time, so the driver wants concurrency
+across shards, a watermark free to lag, and rate limiting (issue #47).
 
 ### File descriptors are borrowed, not held
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -62,6 +62,22 @@ spend descriptors on avoiding reopens; lower it under a tight
 `ulimit -n`. Files being read are never closed, so the limit is a
 target the pool returns to rather than a ceiling at every instant.
 
+### Finalisation Watermark
+
+`KVShard.MergeFinalized(height)` merges each shard's sealed Perm
+segments below a block height into one.  Sealing produces a segment per
+shard per block, so without this the file count grows with the chain
+and nothing bounds it: measured at 512 shards and 5,000 entries a
+block, ~1,016 files per block, which is ~88M a day at one block per
+second against 240M inodes.  Merging a completed 20-block set took
+17,960 files to 1,024.
+
+Set `height` behind whatever window may still be written to -- healing,
+in Accumulate's case -- because segments at or above it are left alone
+so that block export keeps working.  Run it from your own scheduler,
+concurrently across shards: one set measured 12.2 s serially, against
+20 seconds of chain time.
+
 ### Compaction Ratio
 
 `CompactRatio` (default 0.25) is the share of a mutable layer that must


### PR DESCRIPTION
Tier one of #47. The file count currently grows with the chain and nothing bounds it.

## The problem, measured

A block boundary seals one segment per shard that took writes. At 512 shards and 5,000 entries a block that is **~1,016 files per block**:

| entries/block | sealed segments/block | files/block |
|---|---|---|
| 50 | 27 | 53 |
| 500 | 198 | 396 |
| 5,000 | 508 | 1,016 |

Against the 240M free inodes on the filesystem this was measured on, and assuming a block a second, inodes are gone in under three days — and the failure is `ENOSPC` with terabytes free.

(Both the block rate and the entries per block are assumptions, not Accumulate's numbers. The measured part is the per-block file count; the day-count scales linearly with whatever the real rate is.)

## The change

`MergeBelow(height)` merges the sealed segments below a watermark into one. Measured on a completed 20-block set: **~8,980 segments to ~512, i.e. 17,960 files to 1,024 — 17.5×.**

- `SegmentStore.MergeBelow(height)` — merges the contiguous prefix below the watermark
- `KV2.MergeBelow(height)` — Perm only; Dyna has `Compress`, which merges for a different reason
- `KVShard.MergeFinalized(height)` — per shard, continuing past a failure, reporting the first error

### Why the watermark makes it safe

This is what #37 was blocked on: merging permanent segments destroys the block→segment mapping `ExportBlock` depends on, which is the mapping #27 established. Only segments strictly *below* the watermark are merged, and the caller sets it behind whatever window may still be written to, so a block a peer might still ask for by number is never merged away.

`TestMergeDoesNotDisturbBlockExport` runs the whole export/import round trip across a merge — seven blocks to a fresh peer, every record arrives.

### Within a shard, never across

Keeps the working set to a few hundred entries and the merge under the shard's own lock, so shards merge independently and in parallel. Cross-shard merging is what produces globally sorted runs; it is a separate, rarer pass and stays on #47.

### Identity and crash safety

The merged segment takes the sequence after the newest it replaces — always free and correctly ordered, because the run is exactly the segments below the watermark and the first one standing is in a higher block.

Crash safety **inverts** compaction's rule on purpose. A compacted generation is written *above* the manifest's newest height so an uncommitted one is adopted (correct: it holds every live key). A merge is written *below* it so an uncommitted one is deleted by `recoverOrphans` (also correct: it holds only part of the store, and the originals are still named by the manifest). Either way a crash costs space and nothing else.

### Not a goroutine

`MergeFinalized` is a method the caller drives. Only the caller knows its block rate and healing horizon, which is what sets the watermark. The measured cost makes that job real: **one 20-block set took 12.2 s serially across 512 shards** — a ~61% duty cycle against 20 seconds of chain time — so the driver wants concurrency across shards, a watermark free to lag, and rate limiting. Recorded on #47.

## Verification

`compact` gained two extracted helpers, `mergeInputs` and `writeMergedSegment`, so the merge does not duplicate the file writing. That touches the compaction commit path, which is where the crash tests aim their kills, so it was verified rather than assumed:

- **crash contract: 0 failures in 20 runs** of both crash tests
- full `-short` suite green (1341s)
- five new tests, including `TestRepeatedMergesKeepDeepEntriesReachable`, which covers the steady state a single merge does not: eight sets merged in turn so each merge but the first folds in the previous one's output, then every entry read back — the oldest several merges deep — absent keys still absent, and all of it again after a reopen

Refs #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKAh7mFDHChAtKQtJYP3a3