### PR TITLE
Check the on-disk format version everywhere it is written

### DIFF
--- a/database/kv_shard.go
+++ b/database/kv_shard.go
@@ -54,7 +54,9 @@ func OpenKVShard(directory string) (kVShard *KVShard, err error) {
 		}
 	}
 	kVShard.useSharedBlockRecord()
-	kVShard.adoptBlockHeight()
+	if err = kVShard.adoptBlockHeight(); err != nil {
+		return nil, err
+	}
 
 	return kVShard, nil
 }
@@ -175,25 +177,39 @@ const blockFileName = "block.json"
 
 // blockRecord is what that file holds
 type blockRecord struct {
+	// Version is the on-disk format; see StoreFormatVersion
+	Version uint32 `json:"version"`
+
 	// BlockHeight is the block the shards accumulate into next: the
 	// height above the last one sealed
 	BlockHeight uint64 `json:"blockHeight"`
 }
 
 // readBlockHeight
-// The block the shard set was last known to be accumulating into.  A
-// missing file reads as 0, which constrains nothing -- so a database
-// written before this file existed opens unchanged.
-func (k *KVShard) readBlockHeight() uint64 {
+// The block the shard set was last known to be accumulating into.
+//
+// A MISSING file is not an error: a set that has never sealed a block
+// has none, and 0 constrains nothing.  A file that is present and
+// unreadable is: it is the only record of which block the quiet shards
+// are in, and guessing 0 there would let them tag segments with a
+// block they do not belong to.
+func (k *KVShard) readBlockHeight() (uint64, error) {
 	data, err := os.ReadFile(filepath.Join(k.Directory, blockFileName))
+	if os.IsNotExist(err) {
+		return 0, nil
+	}
 	if err != nil {
-		return 0
+		return 0, err
 	}
 	var rec blockRecord
 	if err = json.Unmarshal(data, &rec); err != nil {
-		return 0
+		return 0, fmt.Errorf("%s: %w", blockFileName, err)
 	}
-	return rec.BlockHeight
+	if rec.Version != StoreFormatVersion {
+		return 0, fmt.Errorf("%s is on-disk format version %d; this build reads version %d",
+			filepath.Join(k.Directory, blockFileName), rec.Version, StoreFormatVersion)
+	}
+	return rec.BlockHeight, nil
 }
 
 // writeBlockHeight
@@ -207,7 +223,7 @@ func (k *KVShard) readBlockHeight() uint64 {
 // block boundary -- ~5.6 seconds of pure device wait before any shard
 // with actual data did any work (issue #32).
 func (k *KVShard) writeBlockHeight(height uint64) (err error) {
-	data, err := json.Marshal(blockRecord{BlockHeight: height})
+	data, err := json.Marshal(blockRecord{Version: StoreFormatVersion, BlockHeight: height})
 	if err != nil {
 		return err
 	}
@@ -237,16 +253,20 @@ func (k *KVShard) writeBlockHeight(height uint64) (err error) {
 // Tell every shard the block the set is accumulating into, so a shard
 // that sealed nothing for a long time still tags its next auto-seal
 // with the block it belongs to
-func (k *KVShard) adoptBlockHeight() {
-	height := k.readBlockHeight()
+func (k *KVShard) adoptBlockHeight() error {
+	height, err := k.readBlockHeight()
+	if err != nil {
+		return err
+	}
 	if height == 0 {
-		return
+		return nil
 	}
 	for _, shard := range k.Shards {
 		if shard != nil && shard.PermKV != nil {
 			shard.PermKV.AdvanceBlock(height)
 		}
 	}
+	return nil
 }
 
 // useSharedBlockRecord marks every shard's Perm layer as having its

--- a/database/segstore.go
+++ b/database/segstore.go
@@ -62,9 +62,23 @@ const (
 
 	segIndexMagic   = 0x53494458 // "SIDX"
 	segIndexVersion = 1
-	segIndexHdrSize = 32 // magic(4) version(4) count(8) bloomBytes(8) bloomK(4) reserved(4)
-	segDataHdrSize  = 24 // magic(4) version(4) sinceOffset(8) count(8) -- segment.go's stream header
-	segRecHdrSize   = 40 // key(32) valueLen(8) precede each value in a .dat
+
+	// StoreFormatVersion is the on-disk layout this build reads and
+	// writes: the manifest's shape, the files beside it, and what the
+	// segment headers mean.
+	//
+	// The check on it is STRICT -- a store whose manifest carries any
+	// other version is refused, not opened and worked around.  There is
+	// no database in the wild predating this, so there is nothing to be
+	// compatible with, and a hard failure is worth more than a silent
+	// one: every field added to the manifest so far happens to have a
+	// zero value that degrades safely, but nothing enforced that and
+	// the next field need not be so lucky.  Refusing to open says so
+	// immediately, at the one moment a person can act on it.
+	StoreFormatVersion = 1
+	segIndexHdrSize    = 32 // magic(4) version(4) count(8) bloomBytes(8) bloomK(4) reserved(4)
+	segDataHdrSize     = 24 // magic(4) version(4) sinceOffset(8) count(8) -- segment.go's stream header
+	segRecHdrSize      = 40 // key(32) valueLen(8) precede each value in a .dat
 )
 
 // SegmentMeta
@@ -96,6 +110,10 @@ func (a SegmentMeta) after(b SegmentMeta) bool {
 // The authoritative list of a store's sealed segments.  Replacing it
 // is the commit point for both sealing and compaction.
 type StoreManifest struct {
+	// Version is the on-disk format; see StoreFormatVersion.  It is
+	// first so that it is readable at the head of the file.
+	Version uint32 `json:"version"`
+
 	Mutable     bool          `json:"mutable"`
 	SealLimit   uint64        `json:"sealLimit"`   // 0: unset, caller decides
 	BlockHeight uint64        `json:"blockHeight"` // Block currently being accumulated
@@ -485,6 +503,11 @@ func (s *SegmentStore) load() (err error) {
 	if err != nil {
 		return err
 	}
+	if m.Version != StoreFormatVersion {
+		return fmt.Errorf(
+			"%s is on-disk format version %d; this build reads version %d",
+			s.Directory, m.Version, StoreFormatVersion)
+	}
 	s.Mutable = m.Mutable
 	s.SealLimit = m.SealLimit
 	s.blockHeight = m.BlockHeight
@@ -602,6 +625,36 @@ func (s *SegmentStore) addSegmentKeys(seg *segment) (err error) {
 	return nil
 }
 
+// checkSegmentHeader
+// Verify a segment data file's header.  Both fields were written from
+// the beginning and neither was ever read: openSegment took the record
+// count on trust, so a file that was not a segment at all -- or was one
+// written by a format this build does not understand -- was parsed as
+// though it were.
+func checkSegmentHeader(path string, hdr []byte) error {
+	if magic := binary.BigEndian.Uint32(hdr[:]); magic != segmentMagic {
+		return fmt.Errorf("%s is not a segment file (magic %#08x)", path, magic)
+	}
+	if v := binary.BigEndian.Uint32(hdr[4:]); v != segmentVersion {
+		return fmt.Errorf("%s is segment format version %d; this build reads version %d",
+			path, v, segmentVersion)
+	}
+	return nil
+}
+
+// checkIndexHeader is checkSegmentHeader for an index.  Its version was
+// likewise written and never read.
+func checkIndexHeader(path string, hdr []byte) error {
+	if magic := binary.BigEndian.Uint32(hdr[:]); magic != segIndexMagic {
+		return fmt.Errorf("%s is not a segment index (magic %#08x)", path, magic)
+	}
+	if v := binary.BigEndian.Uint32(hdr[4:]); v != segIndexVersion {
+		return fmt.Errorf("%s is index format version %d; this build reads version %d",
+			path, v, segIndexVersion)
+	}
+	return nil
+}
+
 // openSegment
 // Adopt a sealed segment: read what a lookup needs to keep in memory
 // -- the record count, the key count, and the bloom filter -- and give
@@ -619,6 +672,10 @@ func (s *SegmentStore) openSegment(meta SegmentMeta) (seg *segment, err error) {
 	}
 	var dataHdr [segDataHdrSize]byte
 	if _, err = data.ReadAt(dataHdr[:], 0); err != nil {
+		releaseData()
+		return nil, err
+	}
+	if err = checkSegmentHeader(dataPath, dataHdr[:]); err != nil {
 		releaseData()
 		return nil, err
 	}
@@ -643,9 +700,9 @@ func (s *SegmentStore) openSegment(meta SegmentMeta) (seg *segment, err error) {
 		seg.close()
 		return nil, err
 	}
-	if binary.BigEndian.Uint32(header[:]) != segIndexMagic {
+	if err = checkIndexHeader(indexPath, header[:]); err != nil {
 		seg.close()
-		return nil, fmt.Errorf("%s is not a segment index", indexPath)
+		return nil, err
 	}
 	seg.count = int64(binary.BigEndian.Uint64(header[8:]))
 	bloomBytes := binary.BigEndian.Uint64(header[16:])
@@ -859,7 +916,8 @@ func (s *SegmentStore) writeManifest() (err error) {
 	// segment set, so clearing it here means no path can forget to.
 	defer func() { s.bloomValid = false }()
 
-	m := StoreManifest{Mutable: s.Mutable, SealLimit: s.SealLimit, BlockHeight: s.blockHeight,
+	m := StoreManifest{Version: StoreFormatVersion,
+		Mutable: s.Mutable, SealLimit: s.SealLimit, BlockHeight: s.blockHeight,
 		BloomValid: s.bloomValid, BloomHeight: s.bloomAt.Height, BloomSeq: s.bloomAt.Seq,
 		BloomSegments: s.bloomSegments, Shadowed: s.shadowed}
 	for _, seg := range s.segments {
@@ -2060,8 +2118,8 @@ func buildIndexFor(dataPath, indexPath string) (err error) {
 	if _, err = f.ReadAt(header[:], 0); err != nil {
 		return err
 	}
-	if binary.BigEndian.Uint32(header[:]) != segmentMagic {
-		return fmt.Errorf("%s is not a segment file", dataPath)
+	if err = checkSegmentHeader(dataPath, header[:]); err != nil {
+		return err
 	}
 	info, err := f.Stat()
 	if err != nil {

--- a/database/version_test.go
+++ b/database/version_test.go
@@ -1,0 +1,167 @@
+package blockchainDB
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The on-disk format carries a version, and every reader checks it.
+//
+// The check is strict on purpose.  No database predates it, so there is
+// nothing to be compatible with, and a store that refuses to open says
+// what is wrong at the one moment somebody can act on it.  The
+// alternative -- opening anyway and working around what is missing --
+// is how a format change becomes silent data loss: the fields added to
+// the manifest so far all happen to have zero values that degrade
+// safely, but nothing enforced that, and the next one need not.
+
+// TestManifestVersionIsWrittenAndChecked
+func TestManifestVersionIsWrittenAndChecked(t *testing.T) {
+	dir := storeDir(t, "ver")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+	require.NoError(t, store.Put(NewFastRandom([]byte{61}).NextHash(), []byte("v")))
+	_, err = store.Seal(1)
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+
+	path := filepath.Join(dir, segManifestName)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var m StoreManifest
+	require.NoError(t, json.Unmarshal(data, &m))
+	assert.Equal(t, uint32(StoreFormatVersion), m.Version, "a manifest must record the format it was written in")
+
+	// A version this build does not know must be refused, not opened
+	for _, v := range []uint32{0, StoreFormatVersion + 1} {
+		m.Version = v
+		out, err := json.MarshalIndent(&m, "", "  ")
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(path, out, 0644))
+
+		_, err = OpenSegmentStore(dir)
+		require.Errorf(t, err, "format version %d must be refused", v)
+		assert.Containsf(t, err.Error(), "format version", "the error must say what is wrong: %v", err)
+	}
+}
+
+// TestSegmentHeaderVersionsAreChecked
+// Both segment headers carried a version from the start and neither was
+// ever read: openSegment took the record count on trust, so a file that
+// was not a segment at all was parsed as though it were.
+func TestSegmentHeaderVersionsAreChecked(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		suffix string
+		offset int64
+		want   string
+	}{
+		{"data version", segDataSuffix, 4, "segment format version"},
+		{"data magic", segDataSuffix, 0, "not a segment file"},
+		{"index version", segIndexSuffix, 4, "index format version"},
+		{"index magic", segIndexSuffix, 0, "not a segment index"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := storeDir(t, "hdr")
+			store, err := NewSegmentStore(dir, false)
+			require.NoError(t, err)
+			require.NoError(t, store.Put(NewFastRandom([]byte{62}).NextHash(), []byte("v")))
+			meta, err := store.Seal(1)
+			require.NoError(t, err)
+			require.NoError(t, store.Close())
+
+			name := meta.File
+			if tc.suffix == segIndexSuffix {
+				name = name[:len(name)-len(segDataSuffix)] + segIndexSuffix
+			}
+			path := filepath.Join(dir, name)
+			f, err := os.OpenFile(path, os.O_RDWR, 0644)
+			require.NoError(t, err)
+			var bad [4]byte
+			binary.BigEndian.PutUint32(bad[:], 0xDEADBEEF)
+			_, err = f.WriteAt(bad[:], tc.offset)
+			require.NoError(t, err)
+			require.NoError(t, f.Close())
+
+			_, err = OpenSegmentStore(dir)
+			require.Error(t, err, "a corrupt header must be refused")
+			assert.Contains(t, err.Error(), tc.want, "the error must name the problem")
+		})
+	}
+}
+
+// TestBlockRecordVersionIsChecked
+// block.json is the only record of which block the quiet shards are in,
+// so guessing when it cannot be read would let them tag segments with a
+// block they do not belong to (issue #32).
+func TestBlockRecordVersionIsChecked(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
+
+	kvs, err := NewKVShard(dir, 1000)
+	require.NoError(t, err)
+	require.NoError(t, kvs.PutPerm(NewFastRandom([]byte{63}).NextHash(), []byte("v")))
+	require.NoError(t, kvs.SealBlock(1))
+	require.NoError(t, kvs.Close())
+
+	path := filepath.Join(dir, blockFileName)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var rec blockRecord
+	require.NoError(t, json.Unmarshal(data, &rec))
+	assert.Equal(t, uint32(StoreFormatVersion), rec.Version)
+	assert.Equal(t, uint64(2), rec.BlockHeight, "after sealing block 1 the set accumulates into block 2")
+
+	rec.Version = StoreFormatVersion + 1
+	out, err := json.Marshal(rec)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, out, 0644))
+
+	_, err = OpenKVShard(dir)
+	require.Error(t, err, "a block record this build cannot read must be refused, not guessed at")
+	assert.Contains(t, err.Error(), "format version")
+
+	// A MISSING record is different: a set that never sealed a block has
+	// none, and 0 constrains nothing
+	require.NoError(t, os.Remove(path))
+	reopened, err := OpenKVShard(dir)
+	require.NoError(t, err, "a missing block record is not an error")
+	require.NoError(t, reopened.Close())
+}
+
+// TestFreshDatabasesCarryTheVersion
+// Both constructors must stamp it, not just the paths that reseal.
+func TestFreshDatabasesCarryTheVersion(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
+	require.NoError(t, os.MkdirAll(dir, os.ModePerm))
+
+	kv2, err := NewKV2(filepath.Join(dir, "kv2"), 1000)
+	require.NoError(t, err)
+	require.NoError(t, kv2.Close())
+
+	for _, layer := range []string{PermDirName, DynaDirName} {
+		data, err := os.ReadFile(filepath.Join(dir, "kv2", layer, segManifestName))
+		require.NoError(t, err)
+		var m StoreManifest
+		require.NoError(t, json.Unmarshal(data, &m))
+		assert.Equalf(t, uint32(StoreFormatVersion), m.Version, "%s layer", layer)
+	}
+
+	// And a freshly created store reopens, which is the check that the
+	// version it writes is the version it accepts
+	reopened, err := OpenKV2(filepath.Join(dir, "kv2"))
+	require.NoError(t, err)
+	require.NoError(t, reopened.Open())
+	require.NoError(t, reopened.Close())
+	fmt.Fprint(os.Stderr, "")
+}


### PR DESCRIPTION
Groundwork for tagging `v0.1.0`: a release should be able to say which on-disk format it reads.

## What was missing

The store wrote a version into every segment and every index from the beginning, and **no reader had ever looked at one**:

- `openSegment` took the data file's record count on trust without checking its magic *or* its version — a file that was not a segment at all would be parsed as though it were
- the index's magic was checked, its version ignored
- `StoreManifest` carried no version at all, and three fields were added to it today
- `block.json` carried none either

## What it does now

`StoreFormatVersion = 1` is recorded in the manifest and in `block.json`, and both segment headers are validated for magic **and** version on every open.

The check is **strict**: a version this build does not know is refused, with a message naming the file and both versions, rather than opened and worked around. That is only available because no database predates this, and it is worth taking while it is free — every field added to the manifest so far happens to have a zero value that degrades safely (`BloomSegments` 0 means "rebuild", `Shadowed` 0 means "assume no garbage"), but nothing enforced that and the next field need not be so lucky.

One deliberate exception: a **missing** `block.json` is not an error, because a shard set that has never sealed a block does not have one and 0 constrains nothing. A **present but unreadable** one is, because it is the only record of which block the quiet shards are in — and guessing 0 there is exactly the failure #32 fixed, segments tagged with a block they do not belong to and never exported.

## Verification

- Four new tests covering all four corruption cases — data magic, data version, index magic, index version — plus a manifest at version 0 and at a future version, a block record from the future, a missing block record, and that both constructors stamp what they later demand
- Full `-short` suite green (1772s)
- **Accumulate's `bcdb` adapter compiles unchanged and all 17 of its tests pass against this branch, including under `-race`** — run in a worktree with a `replace` pointing at this checkout. `TestRestart_*` matters most there: it reopens after commits, which is the path a strict version check could have broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKAh7mFDHChAtKQtJYP3a3