### PR TITLE
Pack a finished block set into one file, and merge by copying

### DIFF
--- a/database/blockset.go
+++ b/database/blockset.go
@@ -1,0 +1,582 @@
+package blockchainDB
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// Block-set files: the second stage of merging finalized Perm data.
+//
+// The first stage (MergeBelow) merges each shard's segments for a
+// finished set of blocks into one segment per shard.  That bounds the
+// file count per block, but the shard count still multiplies it: a
+// 512-shard database produces 1,024 files per set, ~4.4M a day at a
+// block a second (issue #47).  This stage folds the 512 per-shard
+// results for one block set into ONE file, outside any shard:
+//
+//	<db>/sets/set-<first>-<last>.bset
+//
+// with a structure fixed at its head so that everything a lookup needs
+// to decide WHERE to read is one contiguous, up-front region:
+//
+//	header      magic, version, shard count, block range, key count,
+//	            bloom size, where the bodies begin
+//	directory   per shard: body offset and length, index offset, key count
+//	indexes     every shard's sorted 48-byte key records, contiguous
+//	bloom       one filter over every key in the set
+//	bodies      every shard's records, in shard order
+//
+// The directory, the indexes and the bloom are one region whose size is
+// known from the key counts before a byte of it is written, so it is
+// written with ONE call once the bodies are in place, and it can be
+// loaded with one read.  What a lookup keeps in memory is the directory
+// and the bloom; a shard's index slice is read when the bloom says the
+// key may be here, in one read when the slice is small.
+//
+// Keys are sorted WITHIN each shard, not across the file.  A key routes
+// to its shard by ShardIndex before anything is looked up, so a global
+// order would buy nothing and cost a 512-way merge; per-shard order is
+// exactly what the first stage already produced, so the index region is
+// a concatenation of what the shards had.
+//
+// And it is a concatenation byte for byte.  An index entry's offset is
+// relative to the body it indexes (segment.value), so a shard's merged
+// index is copied in unchanged, its body is copied in unchanged, and
+// the directory records where the body landed.  A reader resolves an
+// entry as directory[shard].dataOff + entry.offset.
+//
+// A set is built by copying: header, then the bodies laid end to end
+// past a reserved head region, then the head region filled in.  No
+// record is read individually and, with one segment per shard, no
+// index entry is touched.  Crash safety is the usual shape --
+// written to a .tmp name, fsynced, renamed, the directory fsynced -- and
+// the rename is the commit.  The per-shard segments the set replaces are
+// dropped from their shards only after that commit, and their files are
+// deleted only after the shard's next manifest commit names them no
+// longer, so what a crash costs at any point is space.
+
+const (
+	setDirName    = "sets"
+	setFilePrefix = "set-"
+	setFileSuffix = ".bset"
+	setMagic      = 0x42534554 // "BSET"
+	setVersion    = 1
+	setHdrSize    = 64 // magic(4) version(4) shards(4) bloomK(4) first(8) last(8) keys(8) bloomBytes(8) dataOffset(8) reserved(8)
+	setDirEntSize = 32 // dataOffset(8) dataLength(8) indexOffset(8) count(8)
+
+	// setIndexReadWhole is the largest index slice a lookup reads in one
+	// call and searches in memory, rather than probing record by record.
+	// A shard's slice of a 20-block set is ~10 KB at 5,000 entries a
+	// block, so the usual lookup is one read for the index and one for
+	// the value.
+	setIndexReadWhole = 64 << 10
+)
+
+// SetMeta
+// One block-set file, as the store describes it
+type SetMeta struct {
+	First uint64 // Lowest block whose records the set holds
+	Last  uint64 // Highest
+	File  string // File name within the set directory
+	Keys  uint64 // Keys indexed, over every shard
+}
+
+// setEntry is one shard's directory entry
+type setEntry struct {
+	dataOff  uint64 // Where the shard's records begin
+	dataLen  uint64 // How long they run
+	indexOff uint64 // Where the shard's sorted index records begin
+	count    uint64 // How many
+}
+
+// blockSet
+// An open block-set file: what a lookup keeps in memory to decide
+// whether, and where, to read.  The file itself is borrowed from the
+// shared pool for the length of a read, like a segment's.
+type blockSet struct {
+	meta  SetMeta
+	path  string
+	dir   []setEntry // One per shard
+	bloom *Bloom     // Over every key in the set
+}
+
+// SetStore
+// The block-set files of one sharded database, oldest first.  Methods
+// are safe for concurrent use: every shard consults it.
+type SetStore struct {
+	Mutex     sync.Mutex
+	Directory string
+	sets      []*blockSet
+}
+
+// NewSetStore creates an empty set directory, replacing any existing one
+func NewSetStore(directory string) (store *SetStore, err error) {
+	os.RemoveAll(directory)
+	if err = os.MkdirAll(directory, os.ModePerm); err != nil {
+		return nil, err
+	}
+	return &SetStore{Directory: directory}, nil
+}
+
+// OpenSetStore
+// Open the set directory: every complete set file in it, in block
+// order.  A file is complete by construction if it has its final name,
+// because the rename that gave it that name followed the fsync of its
+// contents; a .tmp is never complete and is deleted.
+//
+// The directory must exist.  A database is created with one, and its
+// absence means the database is not one this build wrote.
+func OpenSetStore(directory string) (store *SetStore, err error) {
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		return nil, err
+	}
+	store = &SetStore{Directory: directory}
+	for _, e := range entries {
+		name := e.Name()
+		if strings.HasSuffix(name, segTmpSuffix) {
+			os.Remove(filepath.Join(directory, name))
+			continue
+		}
+		if !strings.HasPrefix(name, setFilePrefix) || !strings.HasSuffix(name, setFileSuffix) {
+			continue
+		}
+		set, err := openBlockSet(filepath.Join(directory, name))
+		if err != nil {
+			return nil, err
+		}
+		store.sets = append(store.sets, set)
+	}
+	sort.Slice(store.sets, func(i, j int) bool { return store.sets[i].meta.First < store.sets[j].meta.First })
+	for i := 1; i < len(store.sets); i++ {
+		a, b := store.sets[i-1].meta, store.sets[i].meta
+		if b.First <= a.Last {
+			return nil, fmt.Errorf("block sets %s and %s overlap", a.File, b.File)
+		}
+	}
+	return store, nil
+}
+
+// Sets describes every block-set file, oldest first
+func (ss *SetStore) Sets() (metas []SetMeta) {
+	for _, set := range ss.snapshot() {
+		metas = append(metas, set.meta)
+	}
+	return metas
+}
+
+// Newest is the most recent set, if there is one
+func (ss *SetStore) Newest() (meta SetMeta, ok bool) {
+	sets := ss.snapshot()
+	if len(sets) == 0 {
+		return meta, false
+	}
+	return sets[len(sets)-1].meta, true
+}
+
+// snapshot is the set list as it stands.  A set, once opened, never
+// changes, and the list only ever grows, so a caller can walk the
+// snapshot without the lock.
+func (ss *SetStore) snapshot() []*blockSet {
+	ss.Mutex.Lock()
+	defer ss.Mutex.Unlock()
+	return ss.sets
+}
+
+// setFileName is the file name for a set covering blocks first..last
+func setFileName(first, last uint64) string {
+	return fmt.Sprintf("%s%08d-%08d%s", setFilePrefix, first, last, setFileSuffix)
+}
+
+// build
+// Write one block-set file holding the given segments of every shard
+// -- shards[i] is shard i's segments, oldest first, possibly none --
+// and commit it.  first and last are the blocks it covers.
+func (ss *SetStore) build(first, last uint64, shards [][]*segment) (set *blockSet, err error) {
+	if len(shards) != NumShards {
+		return nil, fmt.Errorf("block set needs %d shards, given %d", NumShards, len(shards))
+	}
+	if newest, ok := ss.Newest(); ok && first <= newest.Last {
+		return nil, fmt.Errorf("block set %d..%d overlaps the newest set, %d..%d",
+			first, last, newest.First, newest.Last)
+	}
+
+	// Pass one: each shard's index, and where its body will sit among
+	// the bodies.  A shard's index entries are relative to its own body,
+	// so they are copied as they are -- the usual case, one merged
+	// segment per shard, touches no entry -- and the directory is what
+	// records where the body landed.  Where the bodies begin in the file
+	// depends on the key count, which is known only once every index has
+	// been read, so body positions are laid out from 0 here.
+	dir := make([]setEntry, NumShards)
+	sizes := make([][]int64, NumShards)
+	indexes := make([][]byte, NumShards)
+	var keys, bodies uint64
+	for i, segs := range shards {
+		if len(segs) == 0 {
+			continue
+		}
+		var bases []uint64
+		var size uint64
+		if sizes[i], bases, size, err = layoutBodies(segs); err != nil {
+			return nil, err
+		}
+		if indexes[i], err = shiftedIndex(segs, bases); err != nil {
+			return nil, err
+		}
+		dir[i] = setEntry{dataOff: bodies, dataLen: size, count: uint64(len(indexes[i]) / DBKeyFullSize)}
+		keys += dir[i].count
+		bodies += size
+	}
+	bloom := NewBloomSizedForKeys(keys, 3)
+	dataStart := uint64(setHdrSize) + NumShards*setDirEntSize + keys*DBKeyFullSize + bloom.NumBytes
+
+	// Now the head region can be assembled: the directory, with each
+	// body's position made absolute; the indexes, verbatim; the bloom
+	head := make([]byte, 0, dataStart-setHdrSize)
+	indexOff := uint64(setHdrSize) + NumShards*setDirEntSize
+	for i := range dir {
+		if dir[i].count > 0 {
+			dir[i].dataOff += dataStart
+		}
+		dir[i].indexOff = indexOff
+		indexOff += dir[i].count * DBKeyFullSize
+		head = binary.BigEndian.AppendUint64(head, dir[i].dataOff)
+		head = binary.BigEndian.AppendUint64(head, dir[i].dataLen)
+		head = binary.BigEndian.AppendUint64(head, dir[i].indexOff)
+		head = binary.BigEndian.AppendUint64(head, dir[i].count)
+	}
+	for _, index := range indexes {
+		for pos := 0; pos < len(index); pos += DBKeyFullSize {
+			var key [32]byte
+			copy(key[:], index[pos:])
+			bloom.Set(key)
+		}
+		head = append(head, index...)
+	}
+	head = append(head, bloom.Map...)
+
+	var header [setHdrSize]byte
+	binary.BigEndian.PutUint32(header[0:], setMagic)
+	binary.BigEndian.PutUint32(header[4:], setVersion)
+	binary.BigEndian.PutUint32(header[8:], NumShards)
+	binary.BigEndian.PutUint32(header[12:], uint32(bloom.K))
+	binary.BigEndian.PutUint64(header[16:], first)
+	binary.BigEndian.PutUint64(header[24:], last)
+	binary.BigEndian.PutUint64(header[32:], keys)
+	binary.BigEndian.PutUint64(header[40:], bloom.NumBytes)
+	binary.BigEndian.PutUint64(header[48:], dataStart)
+
+	// Pass two: the file.  Header, then the bodies past the reserved
+	// head region, then the head region in one write.
+	name := setFileName(first, last)
+	path := filepath.Join(ss.Directory, name)
+	tmpPath := path + segTmpSuffix
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if f != nil {
+			f.Close()
+			os.Remove(tmpPath)
+		}
+	}()
+	if _, err = f.WriteAt(header[:], 0); err != nil {
+		return nil, err
+	}
+	if _, err = f.Seek(int64(dataStart), 0); err != nil {
+		return nil, err
+	}
+	bw := bufio.NewWriterSize(f, segWriteBuffer)
+	buf := make([]byte, segWriteBuffer)
+	for i, segs := range shards {
+		for j, seg := range segs {
+			if err = seg.copyBody(bw, sizes[i][j], buf); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if err = bw.Flush(); err != nil {
+		return nil, err
+	}
+	if _, err = f.WriteAt(head, setHdrSize); err != nil {
+		return nil, err
+	}
+	if err = f.Sync(); err != nil {
+		return nil, err
+	}
+	if err = f.Close(); err != nil {
+		f = nil
+		return nil, err
+	}
+	f = nil
+	if err = os.Rename(tmpPath, path); err != nil {
+		return nil, err
+	}
+	if err = syncDir(ss.Directory); err != nil { // Commit
+		return nil, err
+	}
+
+	set = &blockSet{
+		meta:  SetMeta{First: first, Last: last, File: name, Keys: keys},
+		path:  path,
+		dir:   dir,
+		bloom: bloom,
+	}
+	ss.Mutex.Lock()
+	ss.sets = append(ss.sets, set)
+	ss.Mutex.Unlock()
+	return set, nil
+}
+
+// openBlockSet
+// Read what a lookup keeps in memory: the header, the directory, and
+// the bloom.  The indexes stay on disk.
+func openBlockSet(path string) (set *blockSet, err error) {
+	f, release, err := segmentFiles.acquire(path)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	var header [setHdrSize]byte
+	if _, err = f.ReadAt(header[:], 0); err != nil {
+		return nil, err
+	}
+	if magic := binary.BigEndian.Uint32(header[0:]); magic != setMagic {
+		return nil, fmt.Errorf("%s is not a block set (magic %#08x)", path, magic)
+	}
+	if v := binary.BigEndian.Uint32(header[4:]); v != setVersion {
+		return nil, fmt.Errorf("%s is block set format version %d; this build reads version %d", path, v, setVersion)
+	}
+	if shards := binary.BigEndian.Uint32(header[8:]); shards != NumShards {
+		return nil, fmt.Errorf("%s was written for %d shards; this build has %d", path, shards, NumShards)
+	}
+	set = &blockSet{path: path}
+	set.meta.File = filepath.Base(path)
+	set.meta.First = binary.BigEndian.Uint64(header[16:])
+	set.meta.Last = binary.BigEndian.Uint64(header[24:])
+	set.meta.Keys = binary.BigEndian.Uint64(header[32:])
+	bloomBytes := binary.BigEndian.Uint64(header[40:])
+	bloomK := int(binary.BigEndian.Uint32(header[12:]))
+	if bloomBytes == 0 || bloomK < 1 {
+		return nil, fmt.Errorf("%s has no bloom filter", path)
+	}
+
+	raw := make([]byte, NumShards*setDirEntSize)
+	if _, err = f.ReadAt(raw, setHdrSize); err != nil {
+		return nil, err
+	}
+	set.dir = make([]setEntry, NumShards)
+	for i := range set.dir {
+		e := raw[i*setDirEntSize:]
+		set.dir[i] = setEntry{
+			dataOff:  binary.BigEndian.Uint64(e[0:]),
+			dataLen:  binary.BigEndian.Uint64(e[8:]),
+			indexOff: binary.BigEndian.Uint64(e[16:]),
+			count:    binary.BigEndian.Uint64(e[24:]),
+		}
+	}
+
+	bitmap := make([]byte, bloomBytes)
+	bloomOff := int64(setHdrSize) + NumShards*setDirEntSize + int64(set.meta.Keys)*DBKeyFullSize
+	if _, err = f.ReadAt(bitmap, bloomOff); err != nil {
+		return nil, err
+	}
+	set.bloom = &Bloom{
+		SizeOfMap: float64(bloomBytes) / (1024 * 1024),
+		NumBytes:  bloomBytes,
+		Map:       bitmap,
+		K:         bloomK,
+		Capacity:  bloomBytes * 8 / BloomBitsPerKey,
+		Count:     set.meta.Keys,
+	}
+	return set, nil
+}
+
+// lookup
+// Find a key in this set: bloom, then the shard's directory entry, then
+// a binary search of that shard's index slice, then the value.
+func (b *blockSet) lookup(shard int, key [32]byte) (value []byte, found bool, err error) {
+	if !b.bloom.Test(key) {
+		return nil, false, nil // Definitely not here: no file needed
+	}
+	e := b.dir[shard]
+	if e.count == 0 {
+		return nil, false, nil
+	}
+	f, release, err := segmentFiles.acquire(b.path)
+	if err != nil {
+		return nil, false, err
+	}
+	defer release()
+
+	var dbb DBBKey
+	if e.count*DBKeyFullSize <= setIndexReadWhole {
+		// The whole slice in one read, searched in memory
+		slice := make([]byte, e.count*DBKeyFullSize)
+		if _, err = f.ReadAt(slice, int64(e.indexOff)); err != nil {
+			return nil, false, err
+		}
+		n := int(e.count)
+		i := sort.Search(n, func(i int) bool {
+			return bytes.Compare(slice[i*DBKeyFullSize:i*DBKeyFullSize+32], key[:]) >= 0
+		})
+		if i == n || !bytes.Equal(slice[i*DBKeyFullSize:i*DBKeyFullSize+32], key[:]) {
+			return nil, false, nil
+		}
+		if _, err = dbb.Unmarshal(slice[i*DBKeyFullSize:]); err != nil {
+			return nil, false, err
+		}
+	} else {
+		var rec [DBKeyFullSize]byte
+		lo, hi := int64(0), int64(e.count)-1
+		found = false
+		for lo <= hi {
+			mid := (lo + hi) / 2
+			if _, err = f.ReadAt(rec[:], int64(e.indexOff)+mid*DBKeyFullSize); err != nil {
+				return nil, false, err
+			}
+			switch bytes.Compare(key[:], rec[:32]) {
+			case 0:
+				if _, err = dbb.Unmarshal(rec[:]); err != nil {
+					return nil, false, err
+				}
+				found = true
+				lo = hi + 1
+			case -1:
+				hi = mid - 1
+			default:
+				lo = mid + 1
+			}
+		}
+		if !found {
+			return nil, false, nil
+		}
+	}
+	value = make([]byte, dbb.Length)
+	if _, err = f.ReadAt(value, int64(e.dataOff+dbb.Offset)); err != nil {
+		return nil, false, err
+	}
+	return value, true, nil
+}
+
+// forEachKey
+// Call fn with every key one shard holds in this set, read from the
+// shard's index slice in batches.
+func (b *blockSet) forEachKey(shard int, fn func(key [32]byte, dbb *DBBKey) error) (err error) {
+	e := b.dir[shard]
+	if e.count == 0 {
+		return nil
+	}
+	f, release, err := segmentFiles.acquire(b.path)
+	if err != nil {
+		return err
+	}
+	defer release()
+	const batch = 4096
+	buff := make([]byte, batch*DBKeyFullSize)
+	for at := uint64(0); at < e.count; {
+		n := e.count - at
+		if n > batch {
+			n = batch
+		}
+		chunk := buff[:n*DBKeyFullSize]
+		if _, err = f.ReadAt(chunk, int64(e.indexOff+at*DBKeyFullSize)); err != nil {
+			return err
+		}
+		for pos := 0; pos < len(chunk); pos += DBKeyFullSize {
+			key, dbb, err := GetDBBKey(chunk[pos : pos+DBKeyFullSize])
+			if err != nil {
+				return err
+			}
+			if err = fn(key, dbb); err != nil {
+				return err
+			}
+		}
+		at += n
+	}
+	return nil
+}
+
+// value reads one of a shard's values out of the set file.  The entry
+// is relative to the shard's body; the directory says where that is.
+func (b *blockSet) value(shard int, dbb *DBBKey) (value []byte, err error) {
+	f, release, err := segmentFiles.acquire(b.path)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	value = make([]byte, dbb.Length)
+	if _, err = f.ReadAt(value, int64(b.dir[shard].dataOff+dbb.Offset)); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+// shardSets
+// One shard's view of the set store: the coldStore a Perm layer
+// consults for keys that have left its segments.
+type shardSets struct {
+	store *SetStore
+	shard int
+}
+
+// lookup walks the sets newest first
+func (c shardSets) lookup(key [32]byte) (value []byte, found bool, err error) {
+	sets := c.store.snapshot()
+	for i := len(sets) - 1; i >= 0; i-- {
+		if value, found, err = sets[i].lookup(c.shard, key); err != nil || found {
+			return value, found, err
+		}
+	}
+	return nil, false, nil
+}
+
+// forEachKey visits every key the shard holds in any set
+func (c shardSets) forEachKey(fn func(key [32]byte)) (err error) {
+	for _, set := range c.store.snapshot() {
+		err = set.forEachKey(c.shard, func(key [32]byte, _ *DBBKey) error {
+			fn(key)
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// forEach visits every key and value the shard holds in any set, newest
+// set first, the order a lookup uses
+func (c shardSets) forEach(fn func(key [32]byte, value []byte) error) (err error) {
+	sets := c.store.snapshot()
+	for i := len(sets) - 1; i >= 0; i-- {
+		set := sets[i]
+		err = set.forEachKey(c.shard, func(key [32]byte, dbb *DBBKey) error {
+			value, err := set.value(c.shard, dbb)
+			if err != nil {
+				return err
+			}
+			return fn(key, value)
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// watermark is the highest block any set holds
+func (c shardSets) watermark() (last uint64, ok bool) {
+	newest, ok := c.store.Newest()
+	return newest.Last, ok
+}

--- a/database/blockset_test.go
+++ b/database/blockset_test.go
@@ -1,0 +1,466 @@
+package blockchainDB
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The second stage of finalization (issue #47): the per-shard merged
+// segments of one block set are packed into a single block-set file
+// outside any shard, and the shards stop serving them.
+
+// packedFixture builds a sharded database of `blocks` blocks with
+// `perBlock` Perm entries each, sealed at every block, and returns the
+// keys and values written in order.
+func packedFixture(t *testing.T, dir string, seed byte, blocks, perBlock int) (kvs *KVShard, keys [][32]byte, values map[[32]byte][]byte) {
+	t.Helper()
+	os.RemoveAll(dir)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	kvs, err := NewKVShard(dir, 100_000) // High, so only block boundaries seal
+	require.NoError(t, err)
+	kr := NewFastRandom([]byte{seed})
+	vr := NewFastRandom([]byte{seed, seed})
+	values = make(map[[32]byte][]byte)
+	for h := 1; h <= blocks; h++ {
+		for i := 0; i < perBlock; i++ {
+			key := kr.NextHash()
+			val := vr.RandBuff(20, 60)
+			require.NoError(t, kvs.PutPerm(key, val))
+			keys = append(keys, key)
+			values[key] = val
+		}
+		require.NoError(t, kvs.SealBlock(uint64(h)))
+	}
+	return kvs, keys, values
+}
+
+// permSegmentsBelow counts, across every shard, the Perm segments the
+// shards are still serving from blocks below height
+func permSegmentsBelow(kvs *KVShard, height uint64) (n int) {
+	for _, sh := range kvs.Shards {
+		sh.PermKV.Mutex.Lock()
+		for _, seg := range sh.PermKV.segments {
+			if seg.meta.Height < height {
+				n++
+			}
+		}
+		sh.PermKV.Mutex.Unlock()
+	}
+	return n
+}
+
+// permDataFiles counts the sealed segment data files on disk across
+// every shard's Perm directory, and how many of them belong to blocks
+// below height
+func permDataFiles(t *testing.T, kvs *KVShard, height uint64) (n, below int) {
+	t.Helper()
+	for i := range kvs.Shards {
+		entries, err := os.ReadDir(filepath.Join(kvs.ShardDir(i), PermDirName))
+		require.NoError(t, err)
+		for _, e := range entries {
+			if !strings.HasPrefix(e.Name(), segFilePrefix) || filepath.Ext(e.Name()) != segDataSuffix {
+				continue // live.dat, bloom.dat, indexes, the manifest
+			}
+			n++
+			h, _, err := keyFromName(e.Name())
+			require.NoError(t, err)
+			if h < height {
+				below++
+			}
+		}
+	}
+	return n, below
+}
+
+// checkEveryKey reads every key back through both the Perm and the
+// layered lookup
+func checkEveryKey(t *testing.T, kvs *KVShard, keys [][32]byte, values map[[32]byte][]byte, when string) {
+	t.Helper()
+	for i, key := range keys {
+		v, err := kvs.GetPerm(key)
+		require.NoErrorf(t, err, "key %d lost %s", i, when)
+		require.Equalf(t, values[key], v, "key %d wrong %s", i, when)
+		v, err = kvs.Get(key)
+		require.NoErrorf(t, err, "key %d lost via Get %s", i, when)
+		require.Equal(t, values[key], v)
+	}
+}
+
+// TestPackFinalizedLeavesOneFileAndEveryKey
+// One block set, packed: one file in the set directory, no segment
+// below the watermark left in any shard, every key still readable, and
+// the per-shard files gone once the shards next commit.
+func TestPackFinalizedLeavesOneFileAndEveryKey(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	kvs, keys, values := packedFixture(t, dir, 181, 8, 100)
+
+	_, err := kvs.MergeFinalized(7)
+	require.NoError(t, err)
+	filesBefore, belowBefore := permDataFiles(t, kvs, 7)
+	require.Greater(t, permSegmentsBelow(kvs, 7), 0)
+
+	meta, packed, err := kvs.PackFinalized(7)
+	require.NoError(t, err)
+	require.True(t, packed, "six finalized blocks must pack")
+	assert.Equal(t, uint64(0), meta.First, "the first set covers every block there has been")
+	assert.Equal(t, uint64(6), meta.Last)
+	assert.Equal(t, uint64(600), meta.Keys, "every key below the watermark is in the set")
+
+	entries, err := os.ReadDir(kvs.setDir())
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "one block set is one file")
+	assert.Equal(t, meta.File, entries[0].Name())
+
+	assert.Equal(t, 0, permSegmentsBelow(kvs, 7), "the shards must stop serving what the set holds")
+	files, below := permDataFiles(t, kvs, 7)
+	assert.Equal(t, filesBefore, files, "the dropped files stay until the shards next commit a manifest")
+	assert.Equal(t, belowBefore, below)
+
+	checkEveryKey(t, kvs, keys, values, "after packing")
+
+	// An unwritten key is still absent, and settled without an error
+	kr := NewFastRandom([]byte{182})
+	for i := 0; i < 50; i++ {
+		_, err := kvs.GetPerm(kr.NextHash())
+		require.ErrorIsf(t, err, errNotFound, "unwritten key %d", i)
+	}
+
+	// Packing again does nothing: everything below 7 is already packed
+	_, packed, err = kvs.PackFinalized(7)
+	require.NoError(t, err)
+	assert.False(t, packed)
+
+	// The next block boundary commits the manifest of every shard that
+	// took a write, which is when that shard's dropped files are retired
+	for i := 0; i < 200; i++ { // Enough to touch most shards
+		require.NoError(t, kvs.PutPerm(kr.NextHash(), []byte("v")))
+	}
+	require.NoError(t, kvs.SealBlock(9))
+	_, below = permDataFiles(t, kvs, 7)
+	assert.Less(t, below, belowBefore, "the shards' next manifest commit retires the packed files")
+
+	// And a reopen finds it all from the set file
+	require.NoError(t, kvs.Close())
+	reopened, err := OpenKVShard(dir)
+	require.NoError(t, err)
+	require.Len(t, reopened.Sets.Sets(), 1)
+	assert.Equal(t, 0, permSegmentsBelow(reopened, 7))
+	checkEveryKey(t, reopened, keys, values, "after a reopen")
+	require.NoError(t, reopened.Close())
+}
+
+// TestPackFinalizedCountsFiles
+// The point of the second stage, measured at the size a test can
+// afford: one set, before and after.
+func TestPackFinalizedCountsFiles(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	kvs, keys, values := packedFixture(t, dir, 183, 6, 2000)
+
+	segs, _ := permDataFiles(t, kvs, 6)
+	_, err := kvs.MergeFinalized(6)
+	require.NoError(t, err)
+	merged, mergedBelow := permDataFiles(t, kvs, 6)
+	_, packed, err := kvs.PackFinalized(6)
+	require.NoError(t, err)
+	require.True(t, packed)
+	for i := 0; i < 2000; i++ { // Touch every shard, so every drop is committed
+		require.NoError(t, kvs.PutPerm(NewFastRandom([]byte{183, byte(i), byte(i >> 8)}).NextHash(), []byte("v")))
+	}
+	require.NoError(t, kvs.SealBlock(7)) // Commit the drops
+	_, after := permDataFiles(t, kvs, 6)
+	t.Logf("5 blocks x 2000 entries, below the watermark: %d segment files -> %d merged (%d files in all) -> %d left in shards + 1 set file",
+		segs, mergedBelow, merged, after)
+	assert.Equal(t, 0, permSegmentsBelow(kvs, 6))
+	assert.Less(t, after, mergedBelow/10, "nearly every shard sealed, so nearly every packed file is retired")
+	checkEveryKey(t, kvs, keys, values, "after packing")
+	require.NoError(t, kvs.Close())
+}
+
+// TestPackFinalizedSurvivesACrashBeforeTheShardsCommit
+// The set's commit is its rename; the shards drop the packed segments
+// without a manifest of their own.  A crash between the two leaves
+// every shard's manifest naming segments the set already holds.  The
+// next open must drop them again -- nothing served twice, nothing lost
+// -- and the next commit must retire their files.
+func TestPackFinalizedSurvivesACrashBeforeTheShardsCommit(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	kvs, keys, values := packedFixture(t, dir, 184, 5, 80)
+
+	_, err := kvs.MergeFinalized(5)
+	require.NoError(t, err)
+	meta, packed, err := kvs.PackFinalized(5)
+	require.NoError(t, err)
+	require.True(t, packed)
+	_, below := permDataFiles(t, kvs, 5)
+	require.Greater(t, below, 0, "the dropped segments' files are still on disk")
+
+	// "Crash": reopen without closing.  The shards' manifests were not
+	// rewritten, so they still name the packed segments.
+	reopened, err := OpenKVShard(dir)
+	require.NoError(t, err)
+	sets := reopened.Sets.Sets()
+	require.Len(t, sets, 1)
+	assert.Equal(t, meta, sets[0])
+	assert.Equal(t, 0, permSegmentsBelow(reopened, 5), "recovery must drop what the set already holds")
+	checkEveryKey(t, reopened, keys, values, "after the crash")
+
+	// The next commit in each shard retires the files it no longer needs
+	kr := NewFastRandom([]byte{185})
+	for i := 0; i < 200; i++ { // Enough to touch most shards
+		require.NoError(t, reopened.PutPerm(kr.NextHash(), []byte("v")))
+	}
+	require.NoError(t, reopened.SealBlock(6))
+	_, belowAfter := permDataFiles(t, reopened, 5)
+	assert.Less(t, belowAfter, below, "the next manifest commit retires the packed files")
+
+	// A clean close, then a clean open: still all there
+	require.NoError(t, reopened.Close())
+	again, err := OpenKVShard(dir)
+	require.NoError(t, err)
+	checkEveryKey(t, again, keys, values, "after a clean reopen")
+	require.NoError(t, again.Close())
+}
+
+// TestPackedKeysStayImmutable
+// The Perm layer refuses a different value for a key it holds.  That
+// check is answered by the shard's key filter first, so once the keys
+// have left the shard's segments for a set, the filter must still cover
+// them -- including when it is rebuilt from scratch on open, from
+// segments that no longer hold them, which is the case this test
+// exists for.
+func TestPackedKeysStayImmutable(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	kvs, keys, values := packedFixture(t, dir, 186, 4, 60)
+
+	_, err := kvs.MergeFinalized(4)
+	require.NoError(t, err)
+	_, packed, err := kvs.PackFinalized(4)
+	require.NoError(t, err)
+	require.True(t, packed)
+
+	// Close commits every shard's manifest, so the packed segments are
+	// gone from the shards, and saves every filter.  Deleting the saved
+	// filters forces each shard to rebuild on open from what it holds --
+	// which, without the set store, is not the packed keys.
+	require.NoError(t, kvs.Close())
+	for i := range kvs.Shards {
+		saved := filepath.Join(kvs.ShardDir(i), PermDirName, bloomFilename)
+		if err := os.Remove(saved); err != nil {
+			require.True(t, errors.Is(err, os.ErrNotExist), "%v", err)
+		}
+	}
+	reopened, err := OpenKVShard(dir)
+	require.NoError(t, err)
+	shard := reopened.Shards[ShardIndex(keys[0][:])]
+	require.Equal(t, 0, len(shard.PermKV.segments), "the packed key's shard holds it in no segment now")
+
+	packedKey := keys[0]
+	other := append([]byte("changed-"), values[packedKey]...)
+
+	// PutPerm: a different value is refused, the same is a no-op
+	err = reopened.PutPerm(packedKey, other)
+	require.ErrorIs(t, err, ErrImmutable, "a packed key must still be immutable")
+	require.NoError(t, reopened.PutPerm(packedKey, values[packedKey]), "an identical rewrite is a no-op")
+	assert.Equal(t, 0, shard.PermKV.LiveCount(), "a rewrite of a packed key must not append a record")
+
+	// Put: a different value moves the key to Dyna, as it always has
+	require.NoError(t, reopened.Put(packedKey, other))
+	v, err := reopened.Get(packedKey)
+	require.NoError(t, err)
+	assert.Equal(t, other, v, "Get answers with the dynamic copy")
+	v, err = reopened.GetPerm(packedKey)
+	require.NoError(t, err)
+	assert.Equal(t, values[packedKey], v, "the permanent copy is unchanged")
+	require.NoError(t, reopened.Close())
+}
+
+// TestForEachReachesPackedKeys
+// Iteration must see the packed keys once each.
+func TestForEachReachesPackedKeys(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	kvs, keys, values := packedFixture(t, dir, 187, 6, 40)
+
+	// Pack two sets in turn, so the second set is not the first, and
+	// leave block 6 unpacked
+	for _, w := range []uint64{3, 6} {
+		_, err := kvs.MergeFinalized(w)
+		require.NoError(t, err)
+		_, packed, err := kvs.PackFinalized(w)
+		require.NoError(t, err)
+		require.Truef(t, packed, "watermark %d", w)
+	}
+	require.Len(t, kvs.Sets.Sets(), 2)
+
+	seen := make(map[[32]byte]int)
+	err := kvs.ForEach(func(key [32]byte, value []byte) error {
+		seen[key]++
+		assert.Equal(t, values[key], value)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, seen, len(keys), "every key, packed or not, is visited")
+	for i, key := range keys {
+		assert.Equalf(t, 1, seen[key], "key %d visited %d times", i, seen[key])
+	}
+	require.NoError(t, kvs.Close())
+}
+
+// TestRepeatedPacksKeepDeepEntriesReachable
+// The steady state: set after set packed, the oldest entries several
+// sets deep, all reachable, and again after a reopen.
+func TestRepeatedPacksKeepDeepEntriesReachable(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
+	kvs, err := NewKVShard(dir, 100_000)
+	require.NoError(t, err)
+
+	const sets, setSize, perBlock = 6, 3, 30
+	kr := NewFastRandom([]byte{188})
+	vr := NewFastRandom([]byte{188, 188})
+	var keys [][32]byte
+	values := make(map[[32]byte][]byte)
+	block := uint64(0)
+	for set := 0; set < sets; set++ {
+		for b := 0; b < setSize; b++ {
+			block++
+			for i := 0; i < perBlock; i++ {
+				key := kr.NextHash()
+				val := vr.RandBuff(10, 40)
+				require.NoError(t, kvs.PutPerm(key, val))
+				keys = append(keys, key)
+				values[key] = val
+			}
+			require.NoError(t, kvs.SealBlock(block))
+		}
+		watermark := block - setSize + 1
+		if watermark > 1 {
+			_, err = kvs.MergeFinalized(watermark)
+			require.NoError(t, err)
+			_, packed, err := kvs.PackFinalized(watermark)
+			require.NoError(t, err)
+			require.Truef(t, packed, "set %d", set)
+		}
+	}
+	metas := kvs.Sets.Sets()
+	require.Len(t, metas, sets-1)
+	for i := 1; i < len(metas); i++ {
+		assert.Equal(t, metas[i-1].Last+1, metas[i].First, "sets are contiguous")
+	}
+	checkEveryKey(t, kvs, keys, values, "after repeated packs")
+
+	require.NoError(t, kvs.Close())
+	reopened, err := OpenKVShard(dir)
+	require.NoError(t, err)
+	checkEveryKey(t, reopened, keys, values, "after a reopen")
+	for i := 0; i < 50; i++ {
+		_, err := reopened.GetPerm(kr.NextHash())
+		require.ErrorIsf(t, err, errNotFound, "unwritten key %d", i)
+	}
+	require.NoError(t, reopened.Close())
+}
+
+// TestPackedBlocksRefuseAnImport
+// A block in a set is finalized.  A shard that has dropped every
+// segment has no newest segment to measure an import against, so the
+// set's watermark has to be the bound, or a peer could re-import a
+// block the node already holds cold.
+func TestPackedBlocksRefuseAnImport(t *testing.T) {
+	dirA := filepath.Join(os.TempDir(), t.Name()+"_A")
+	dirB := filepath.Join(os.TempDir(), t.Name()+"_B")
+	exportDir := filepath.Join(os.TempDir(), t.Name()+"_export")
+	os.RemoveAll(exportDir)
+	defer os.RemoveAll(exportDir)
+
+	nodeA, _, _ := packedFixture(t, dirA, 189, 1, 0)
+	nodeB, _, _ := packedFixture(t, dirB, 190, 0, 0)
+
+	// A exports blocks 2 and 3; B takes both and packs them
+	kr := NewFastRandom([]byte{191})
+	var prev *Manifest
+	var err error
+	for h := uint64(2); h <= 3; h++ {
+		for i := 0; i < 50; i++ {
+			require.NoError(t, nodeA.PutPerm(kr.NextHash(), []byte("v")))
+		}
+		prev, err = nodeA.ExportBlock(exportDir, h, prev)
+		require.NoError(t, err)
+		_, err = nodeB.ImportBlock(filepath.Join(exportDir, fmt.Sprintf("block-%08d", h)))
+		require.NoError(t, err)
+	}
+	_, err = nodeB.MergeFinalized(4)
+	require.NoError(t, err)
+	_, packed, err := nodeB.PackFinalized(4)
+	require.NoError(t, err)
+	require.True(t, packed)
+
+	// Block 3 again: already packed, must be refused rather than adopted
+	_, err = nodeB.ImportBlock(filepath.Join(exportDir, "block-00000003"))
+	require.Error(t, err, "a block already packed into a set must not be imported again")
+	assert.Contains(t, err.Error(), "block set")
+
+	require.NoError(t, nodeA.Close())
+	require.NoError(t, nodeB.Close())
+}
+
+// TestBlockSetHeaderIsChecked
+// A set file carries its magic, version and shard count, and open
+// refuses one it cannot read rather than guessing.  A .tmp left by an
+// interrupted build is deleted.
+func TestBlockSetHeaderIsChecked(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		offset int64
+		want   string
+	}{
+		{"magic", 0, "not a block set"},
+		{"version", 4, "block set format version"},
+		{"shards", 8, "shards"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := filepath.Join(os.TempDir(), t.Name())
+			kvs, _, _ := packedFixture(t, dir, 192, 3, 20)
+			_, err := kvs.MergeFinalized(3)
+			require.NoError(t, err)
+			meta, packed, err := kvs.PackFinalized(3)
+			require.NoError(t, err)
+			require.True(t, packed)
+			require.NoError(t, kvs.Close())
+
+			path := filepath.Join(kvs.setDir(), meta.File)
+			f, err := os.OpenFile(path, os.O_RDWR, 0644)
+			require.NoError(t, err)
+			var bad [4]byte
+			binary.BigEndian.PutUint32(bad[:], 0xDEADBEEF)
+			_, err = f.WriteAt(bad[:], tc.offset)
+			require.NoError(t, err)
+			require.NoError(t, f.Close())
+
+			_, err = OpenKVShard(dir)
+			require.Error(t, err, "a set file this build cannot read must be refused")
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+
+	t.Run("tmp", func(t *testing.T) {
+		dir := filepath.Join(os.TempDir(), t.Name())
+		kvs, _, _ := packedFixture(t, dir, 193, 1, 5)
+		require.NoError(t, kvs.Close())
+		stray := filepath.Join(kvs.setDir(), setFileName(1, 1)+segTmpSuffix)
+		require.NoError(t, os.WriteFile(stray, []byte("half a set"), 0644))
+		reopened, err := OpenKVShard(dir)
+		require.NoError(t, err)
+		_, err = os.Stat(stray)
+		assert.True(t, errors.Is(err, os.ErrNotExist), "an interrupted build's .tmp is deleted on open")
+		assert.Empty(t, reopened.Sets.Sets())
+		require.NoError(t, reopened.Close())
+	})
+}

--- a/database/iterate.go
+++ b/database/iterate.go
@@ -41,6 +41,7 @@ import (
 func (s *SegmentStore) ForEach(fn func(key [32]byte, value []byte) error) (err error) {
 	s.Mutex.Lock()
 	segs, live, err := s.beginIterate()
+	cold := s.cold
 	s.Mutex.Unlock()
 	if err != nil {
 		return err
@@ -64,6 +65,18 @@ func (s *SegmentStore) ForEach(fn func(key [32]byte, value []byte) error) (err e
 		if err = forEachInSegment(segs[i], buff, batch, seen, fn); err != nil {
 			return err
 		}
+	}
+	// Then what has left the segments for a block set.  The set list is
+	// append-only, so this is a snapshot too; a key that a set and a
+	// not-yet-retired segment both hold is emitted once.
+	if cold != nil {
+		return cold.forEach(func(key [32]byte, value []byte) error {
+			if _, ok := seen[key]; ok {
+				return nil
+			}
+			seen[key] = struct{}{}
+			return fn(key, value)
+		})
 	}
 	return nil
 }

--- a/database/kv_shard.go
+++ b/database/kv_shard.go
@@ -33,6 +33,30 @@ func ShardIndex(key []byte) int {
 type KVShard struct {
 	Directory string
 	Shards    [NumShards]*KV2
+
+	// Sets holds the finalized Perm data that has left the shards: one
+	// block-set file per completed set of blocks, packed from every
+	// shard's merged segment (blockset.go).  Each shard's Perm layer
+	// consults it for keys its own segments no longer hold.
+	Sets *SetStore
+}
+
+// setDir is where the block-set files live
+func (k *KVShard) setDir() string {
+	return filepath.Join(k.Directory, setDirName)
+}
+
+// attachSets points every shard's Perm layer at the set store
+func (k *KVShard) attachSets() (err error) {
+	for i, shard := range k.Shards {
+		if shard == nil || shard.PermKV == nil {
+			continue
+		}
+		if err = shard.PermKV.attachCold(shardSets{k.Sets, i}); err != nil {
+			return fmt.Errorf("shard %d: %w", i, err)
+		}
+	}
+	return nil
 }
 
 func (k *KVShard) ShardDir(index int) string {
@@ -56,6 +80,22 @@ func OpenKVShard(directory string) (kVShard *KVShard, err error) {
 	kVShard.useSharedBlockRecord()
 	if err = kVShard.adoptBlockHeight(); err != nil {
 		return nil, err
+	}
+	if kVShard.Sets, err = OpenSetStore(kVShard.setDir()); err != nil {
+		return nil, err
+	}
+	if err = kVShard.attachSets(); err != nil {
+		return nil, err
+	}
+	// A shard still naming segments a committed set already holds was
+	// interrupted between the set's commit and its own next manifest;
+	// drop them again, and that next manifest retires them
+	if newest, ok := kVShard.Sets.Newest(); ok {
+		for i, shard := range kVShard.Shards {
+			if _, err = shard.PermKV.DropBelow(newest.Last + 1); err != nil {
+				return nil, fmt.Errorf("shard %d: %w", i, err)
+			}
+		}
 	}
 
 	return kVShard, nil
@@ -83,6 +123,12 @@ func NewKVShard(directory string, sealLimit uint64) (kvs *KVShard, err error) {
 		}
 	}
 	kvs.useSharedBlockRecord()
+	if kvs.Sets, err = NewSetStore(kvs.setDir()); err != nil {
+		return nil, err
+	}
+	if err = kvs.attachSets(); err != nil {
+		return nil, err
+	}
 
 	return kvs, nil
 }
@@ -341,6 +387,73 @@ func (k *KVShard) MergeFinalized(height uint64) (mergedShards int, err error) {
 		}
 	}
 	return mergedShards, err
+}
+
+// PackFinalized
+// Pack every shard's Perm segments below a block height into one
+// block-set file, then drop those segments from their shards.  Reports
+// whether anything was packed.  This is the second stage of
+// finalization; MergeFinalized is the first, and this expects to find
+// its output -- one segment per shard -- though it copes with more.
+//
+// The file count is the reason.  The first stage leaves one segment per
+// shard per set, which at 512 shards is still 1,024 files a set; this
+// leaves one file a set, outside any shard, and a lookup that reaches
+// it costs a bloom probe, one read of the shard's index slice, and one
+// read of the value (blockset.go).
+//
+// The set's commit is the rename of its file.  Nothing is dropped from
+// a shard before that, so a crash during the build leaves a .tmp that
+// the next open deletes and every shard as it was.  Dropping after it
+// writes no manifest: the shard's next seal records the drop and only
+// then deletes the files, so a crash in between costs the space of the
+// segments until that seal (DropBelow).
+//
+// Not safe to run concurrently with MergeFinalized at the same
+// watermark: the merge retires the segments this is copying.  Drive
+// both from one scheduler, in order.
+func (k *KVShard) PackFinalized(height uint64) (meta SetMeta, packed bool, err error) {
+	if newest, ok := k.Sets.Newest(); ok && height <= newest.Last+1 {
+		return meta, false, nil // Everything below is already packed
+	}
+	shards := make([][]*segment, NumShards)
+	last, any := uint64(0), false
+	for i, shard := range k.Shards {
+		if err = shard.Open(); err != nil {
+			return meta, false, fmt.Errorf("shard %d: %w", i, err)
+		}
+		if shards[i], err = shard.PermKV.segmentsBelow(height); err != nil {
+			return meta, false, fmt.Errorf("shard %d: %w", i, err)
+		}
+		for _, seg := range shards[i] {
+			if h := seg.meta.Height; !any || h > last {
+				last = h
+			}
+			any = true
+		}
+	}
+	if !any {
+		return meta, false, nil
+	}
+	// A set covers every block since the previous set, and the first
+	// set covers every block there has been.  The segments cannot say
+	// which those are: a merged segment carries the height of the
+	// newest block it holds, not the oldest.
+	first := uint64(0)
+	if newest, ok := k.Sets.Newest(); ok {
+		first = newest.Last + 1
+	}
+	set, err := k.Sets.build(first, last, shards)
+	if err != nil {
+		return meta, false, err
+	}
+	// Committed.  The shards can stop serving what the set now holds.
+	for i, shard := range k.Shards {
+		if _, dropErr := shard.PermKV.DropBelow(height); dropErr != nil && err == nil {
+			err = fmt.Errorf("shard %d: %w", i, dropErr)
+		}
+	}
+	return set.meta, true, err
 }
 
 // Compress

--- a/database/merge_test.go
+++ b/database/merge_test.go
@@ -202,10 +202,14 @@ func TestMergeDoesNotDisturbBlockExport(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Now finalise the blocks a peer has already taken
+	// Now finalise the blocks a peer has already taken: both stages, so
+	// blocks 1-4 leave the shards altogether for a block-set file
 	mergedShards, err := nodeA.MergeFinalized(5)
 	require.NoError(t, err)
 	require.Greater(t, mergedShards, 0, "the merge must have done something for this to test anything")
+	_, packed, err := nodeA.PackFinalized(5)
+	require.NoError(t, err)
+	require.True(t, packed, "the pack must have done something for this to test anything")
 
 	// A later block still exports correctly after the merge
 	for i := 0; i < 50; i++ {

--- a/database/segstore.go
+++ b/database/segstore.go
@@ -29,6 +29,11 @@ import (
 //	seg-<height>.idx    its key index: sorted 48-byte records + a bloom
 //	segments.json       the manifest: the segments, counts, and hashes
 //
+// An index record is key(32) offset(8) length(8), and the offset is
+// relative to the segment's BODY -- its records, after the header --
+// so that a body and its index can be copied into a larger file
+// unchanged (blockset.go); see segment.value.
+//
 // What this buys over the v1 kfile/history/values arrangement it
 // replaced (removed; see docs/design/segment-store.md):
 //
@@ -75,7 +80,14 @@ const (
 	// zero value that degrades safely, but nothing enforced that and
 	// the next field need not be so lucky.  Refusing to open says so
 	// immediately, at the one moment a person can act on it.
-	StoreFormatVersion = 1
+	//
+	// Version 2 added the block-set directory beside the shards
+	// (blockset.go) and made index offsets relative to the segment body
+	// rather than the file.  A build reading version 1 would open a
+	// version 2 database without complaint and answer "not found" for
+	// every key that had been packed into a set, which is exactly the
+	// silent failure the check exists to refuse.
+	StoreFormatVersion = 2
 	segIndexHdrSize    = 32 // magic(4) version(4) count(8) bloomBytes(8) bloomK(4) reserved(4)
 	segDataHdrSize     = 24 // magic(4) version(4) sinceOffset(8) count(8) -- segment.go's stream header
 	segRecHdrSize      = 40 // key(32) valueLen(8) precede each value in a .dat
@@ -228,7 +240,15 @@ func (s *segment) lookup(key [32]byte) (dbb *DBBKey, found bool, err error) {
 	return nil, false, nil
 }
 
-// value reads a value out of the segment's data file
+// value reads a value out of the segment's data file.
+//
+// An index entry's offset is RELATIVE to the segment's body -- the
+// records after the header -- not to the file.  In a segment file the
+// body starts at segDataHdrSize, so that is the base here.  The
+// convention exists for the files that contain many bodies: a block
+// set copies a segment's body and its index in verbatim and records
+// where the body landed, and a reader adds that base instead of this
+// one.  Nothing in an index is rewritten when it is moved.
 func (s *segment) value(dbb *DBBKey) (value []byte, err error) {
 	data, release, err := s.data()
 	if err != nil {
@@ -236,7 +256,7 @@ func (s *segment) value(dbb *DBBKey) (value []byte, err error) {
 	}
 	defer release()
 	value = make([]byte, dbb.Length)
-	if _, err = data.ReadAt(value, int64(dbb.Offset)); err != nil {
+	if _, err = data.ReadAt(value, segDataHdrSize+int64(dbb.Offset)); err != nil {
 		return nil, err
 	}
 	return value, nil
@@ -286,6 +306,30 @@ type SegmentStore struct {
 	liveRecords uint64               // Physical records in liveFile (>= len(live) if keys repeat)
 	liveDirty   bool                 // Records written to the tail since the last fsync of it
 	closed      bool                 // Set by Close; cleared by Open
+
+	// cold is where this store's keys go once they leave its segments:
+	// the block-set files a sharded database packs its finalized Perm
+	// segments into (blockset.go).  Nil for a store that has nowhere
+	// else to look, which is every Dyna layer and every store outside a
+	// KVShard.
+	//
+	// It sits inside the store rather than beside it because of the key
+	// filter.  Every lookup -- and so every write, which asks whether
+	// its key is new -- is settled by the filter when it says "absent",
+	// and that answer is only definitive if the filter covers the cold
+	// keys too.  A layer above the store cannot keep that promise; the
+	// store can, by adding the cold keys whenever it rebuilds the filter
+	// and consulting cold only when the filter has already said "maybe".
+	cold coldStore
+
+	// retireOnCommit holds segments dropped from the list -- their keys
+	// now held cold -- whose files the manifest still names.  They are
+	// deleted after the next manifest commit, whatever causes it, so
+	// that dropping a segment costs no barrier of its own: a shard
+	// commits a manifest every block it seals in anyway, and this rides
+	// on that one.  Until then the files stay, and a crash leaves them
+	// named by a manifest that still points at whole segments.
+	retireOnCommit []*segment
 
 	// iterating counts the iterations in flight, and pendingDelete
 	// holds the files a compaction wanted to delete while one was.
@@ -355,7 +399,47 @@ type SegmentStore struct {
 	bloomAt       SegmentMeta
 	bloomSegments uint64
 
+	// keysLackCold says the filter was rebuilt from the segments with no
+	// cold store attached, so the cold keys still have to be added
+	// (attachCold).  A filter loaded from disk was saved complete.
+	keysLackCold bool
+
 	stats StoreStats // Counted under the Mutex, like everything else here
+}
+
+// coldStore
+// Somewhere a store's keys can live once its own segments no longer
+// hold them.  Every method is scoped to the one store it is attached
+// to: a sharded database attaches a view onto its set store that
+// answers for that shard alone.
+type coldStore interface {
+	// lookup finds a key, or reports that it is not held cold
+	lookup(key [32]byte) (value []byte, found bool, err error)
+	// forEachKey visits every key held cold, for rebuilding the filter
+	forEachKey(fn func(key [32]byte)) error
+	// forEach visits every key and its value, for iteration
+	forEach(fn func(key [32]byte, value []byte) error) error
+	// watermark is the highest block held cold, if any is
+	watermark() (last uint64, ok bool)
+}
+
+// attachCold
+// Give the store somewhere to look for keys its segments no longer
+// hold.  If the key filter was rebuilt from the segments alone -- which
+// it is on the first open, before anything could be attached -- the
+// cold keys are added to it now, so that "absent" stays definitive.
+func (s *SegmentStore) attachCold(cold coldStore) (err error) {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+	s.cold = cold
+	if s.keys != nil && s.keysLackCold {
+		if err = cold.forEachKey(s.keys.Set); err != nil {
+			s.keys = nil // Never under-report: walk instead
+			return err
+		}
+	}
+	s.keysLackCold = false
+	return nil
 }
 
 // StoreStats
@@ -497,6 +581,7 @@ func (s *SegmentStore) Open() (err error) {
 func (s *SegmentStore) load() (err error) {
 	s.live = make(map[[32]byte]*DBBKey)
 	s.segments = nil
+	s.retireOnCommit = nil // The manifest being read is the truth again
 	s.liveRecords = 0
 
 	m, err := s.readManifest()
@@ -561,6 +646,7 @@ func (s *SegmentStore) loadKeyFilter(m *StoreManifest) (err error) {
 			(ok && newest.Height == m.BloomHeight && newest.Seq == m.BloomSeq))
 	if covered {
 		if s.keys, err = LoadBloomSet(s.Directory); err == nil {
+			s.keysLackCold = false // Saved from a filter that had them
 			return nil
 		}
 		s.keys = nil // Unreadable or truncated; rebuild instead
@@ -592,6 +678,15 @@ func (s *SegmentStore) rebuildKeyFilter() (err error) {
 	for key := range s.live { // The tail is part of what the store holds
 		s.keys.Set(key)
 	}
+	// And so are the keys held cold: a filter without them would answer
+	// "absent" for a key that is right there in a block set
+	if s.cold != nil {
+		if err = s.cold.forEachKey(s.keys.Set); err != nil {
+			s.keys = nil
+			return err
+		}
+	}
+	s.keysLackCold = s.cold == nil
 	return nil
 }
 
@@ -946,7 +1041,18 @@ func (s *SegmentStore) writeManifest() (err error) {
 	if err = os.Rename(tmp, filepath.Join(s.Directory, segManifestName)); err != nil {
 		return err
 	}
-	return syncDir(s.Directory)
+	if err = syncDir(s.Directory); err != nil {
+		return err
+	}
+	// Committed: the manifest no longer names what DropBelow dropped, so
+	// the files can go
+	for _, seg := range s.retireOnCommit {
+		seg.close()
+		s.retire(seg.dataPath)
+		s.retire(seg.indexPath)
+	}
+	s.retireOnCommit = nil
+	return nil
 }
 
 // errStoreClosed is returned by every operation that would read or
@@ -1026,6 +1132,15 @@ func (s *SegmentStore) get(key [32]byte) (value []byte, err error) {
 		}
 		if found {
 			return s.segments[i].value(dbb)
+		}
+	}
+	if s.cold != nil { // Then whatever left the segments for a block set
+		value, found, err := s.cold.lookup(key)
+		if err != nil {
+			return nil, err
+		}
+		if found {
+			return value, nil
 		}
 	}
 	if s.keys != nil {
@@ -1721,6 +1836,235 @@ func (s *SegmentStore) writeMergedSegment(
 	return meta, seg, nil
 }
 
+// bodySize
+// The length of a segment's records: everything after the header.
+func (s *segment) bodySize() (size int64, err error) {
+	data, release, err := s.data()
+	if err != nil {
+		return 0, err
+	}
+	defer release()
+	info, err := data.Stat()
+	if err != nil {
+		return 0, err
+	}
+	if info.Size() < segDataHdrSize {
+		return 0, fmt.Errorf("%s is shorter than its header", s.dataPath)
+	}
+	return info.Size() - segDataHdrSize, nil
+}
+
+// copyBody
+// Copy a segment's records -- its body, without the header -- to out
+// as one sequential read.  size is what bodySize reported, and is
+// checked against what actually arrived.
+func (s *segment) copyBody(out io.Writer, size int64, buf []byte) (err error) {
+	data, release, err := s.data()
+	if err != nil {
+		return err
+	}
+	defer release()
+	n, err := io.CopyBuffer(out, io.NewSectionReader(data, segDataHdrSize, size), buf)
+	if err != nil {
+		return err
+	}
+	if n != size {
+		return fmt.Errorf("%s: copied %d of %d bytes", s.dataPath, n, size)
+	}
+	return nil
+}
+
+// layoutBodies
+// Where each segment's body will land when the bodies are laid end to
+// end to form one body: each body's size, and its offset within the
+// combined body.  The first is at 0; where the combined body itself
+// sits in a file is the file's business.
+func layoutBodies(segs []*segment) (sizes []int64, bases []uint64, total uint64, err error) {
+	sizes = make([]int64, len(segs))
+	bases = make([]uint64, len(segs))
+	for i, seg := range segs {
+		if sizes[i], err = seg.bodySize(); err != nil {
+			return nil, nil, 0, err
+		}
+		bases[i] = total
+		total += uint64(sizes[i])
+	}
+	return sizes, bases, total, nil
+}
+
+// shiftedIndex
+// The index records of several segments as they read once their bodies
+// are laid end to end: each entry's offset moved by where its segment's
+// body landed, one entry per key, sorted.  Returns raw 48-byte records,
+// relative to the combined body, which is the form an index file and a
+// block-set file both store.
+//
+// This is the whole per-key cost of merging: the index is 48 bytes a
+// key and already sorted within each source, so the work is a read of
+// each index, an add per entry, and a sort of a few hundred records.
+// No value is touched.  With ONE source there is not even the add: its
+// index is already relative to its body, and its body is the whole
+// result, so the records are copied verbatim.
+//
+// A key that appears in two sources -- possible in the Perm layer only
+// through an import, which permits an identical value and rejects a
+// differing one -- keeps the NEWEST source's entry.  The sources are
+// taken newest first so that a stable sort leaves that entry first
+// among equals, and the older ones are dropped.
+func shiftedIndex(segs []*segment, bases []uint64) (records []byte, err error) {
+	var total int64
+	for _, seg := range segs {
+		total += seg.count
+	}
+	records = make([]byte, 0, total*DBKeyFullSize)
+	for i := len(segs) - 1; i >= 0; i-- {
+		seg := segs[i]
+		shift := bases[i]
+		start := len(records)
+		records = records[:start+int(seg.count)*DBKeyFullSize]
+		index, release, err := seg.index()
+		if err != nil {
+			return nil, err
+		}
+		_, err = index.ReadAt(records[start:], segIndexHdrSize)
+		release()
+		if err != nil {
+			return nil, err
+		}
+		if shift == 0 {
+			continue // Verbatim: the body sits where the index says
+		}
+		for pos := start; pos < len(records); pos += DBKeyFullSize {
+			off := binary.BigEndian.Uint64(records[pos+32:])
+			binary.BigEndian.PutUint64(records[pos+32:], off+shift)
+		}
+	}
+	if len(segs) == 1 {
+		return records, nil // One source: already sorted and unique
+	}
+	sort.Stable(recordSort(records))
+	w := 0
+	for r := 0; r < len(records); r += DBKeyFullSize {
+		if w > 0 && bytes.Equal(records[w-DBKeyFullSize:w-DBKeyFullSize+32], records[r:r+32]) {
+			continue // An older copy of the key just kept
+		}
+		if w != r {
+			copy(records[w:w+DBKeyFullSize], records[r:r+DBKeyFullSize])
+		}
+		w += DBKeyFullSize
+	}
+	return records[:w], nil
+}
+
+// concatSegments
+// Build one segment from several by COPYING their bodies end to end
+// and shifting their index offsets, rather than reading every value
+// back and re-encoding it.
+//
+// This is the difference between the two reasons to combine segments,
+// and they want different work.  Compaction exists to RECLAIM: the Dyna
+// layer's segments are full of records a later write superseded, so it
+// must decide what survives and rewrite only that.  A merge of the Perm
+// layer exists to reduce the FILE COUNT: its keys are unique and
+// immutable, so there is nothing dead to drop, and re-encoding every
+// record to produce a byte-identical result is pure cost.
+//
+// So the data file is a concatenation.  Each source contributes its
+// body -- everything after its 24-byte header -- as one sequential
+// copy, and an entry that pointed at offset O in source i points at
+// base[i] + O in the result, base[i] being where that body landed
+// within the combined body.  Nothing is read per record; the only
+// per-key work is the index (shiftedIndex).
+//
+// A key that appears in two sources leaves both copies in the data file
+// and one entry in the index, pointing at the newest.  The older copy
+// becomes dead bytes.  That is the trade: a little space in exchange
+// for never touching a value.
+//
+// The caller must hold the Mutex.
+func (s *SegmentStore) concatSegments(segs []*segment, height, seq uint64) (meta SegmentMeta, merged *segment, err error) {
+	// The index first: it needs only the sizes, and it is where a
+	// damaged source would be found, before anything is written
+	sizes, bases, _, err := layoutBodies(segs)
+	if err != nil {
+		return meta, nil, err
+	}
+	records, err := shiftedIndex(segs, bases)
+	if err != nil {
+		return meta, nil, err
+	}
+
+	dataName := segmentFileName(height, seq)
+	dataPath := filepath.Join(s.Directory, dataName)
+	tmpPath := dataPath + segTmpSuffix
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return meta, nil, err
+	}
+	defer func() {
+		if f != nil {
+			f.Close()
+			os.Remove(tmpPath)
+		}
+	}()
+
+	bw := bufio.NewWriterSize(f, segWriteBuffer)
+	var h hash.Hash
+	var out io.Writer = bw
+	if !s.Mutable { // Immutable segments are transported; a peer verifies this
+		h = sha256.New()
+		out = io.MultiWriter(bw, h)
+	}
+
+	var header [segDataHdrSize]byte
+	binary.BigEndian.PutUint32(header[:], segmentMagic)
+	binary.BigEndian.PutUint32(header[4:], segmentVersion)
+	var physical uint64
+	for _, seg := range segs {
+		physical += uint64(seg.records)
+	}
+	binary.BigEndian.PutUint64(header[16:], physical)
+	if _, err = out.Write(header[:]); err != nil {
+		return meta, nil, err
+	}
+	buf := make([]byte, segWriteBuffer)
+	for i, seg := range segs {
+		if err = seg.copyBody(out, sizes[i], buf); err != nil {
+			return meta, nil, err
+		}
+	}
+	if err = bw.Flush(); err != nil {
+		return meta, nil, err
+	}
+	if err = f.Sync(); err != nil {
+		return meta, nil, err
+	}
+	if err = f.Close(); err != nil {
+		f = nil
+		return meta, nil, err
+	}
+	f = nil
+	if err = os.Rename(tmpPath, dataPath); err != nil {
+		return meta, nil, err
+	}
+	// The manifest commit's directory fsync covers this rename
+
+	indexPath := strings.TrimSuffix(dataPath, segDataSuffix) + segIndexSuffix
+	if err = writeIndexRecords(indexPath, records); err != nil {
+		return meta, nil, err
+	}
+
+	meta = SegmentMeta{Height: height, Seq: seq, File: dataName, Count: uint64(len(records) / DBKeyFullSize)}
+	if h != nil {
+		meta.Hash = fmt.Sprintf("%x", h.Sum(nil))
+	}
+	seg, err := s.openSegment(meta)
+	if err != nil {
+		return meta, nil, err
+	}
+	return meta, seg, nil
+}
+
 // MergeBelow
 // Merge every sealed segment belonging to a block below `height` into
 // one, leaving the rest untouched.  Reports whether it merged anything.
@@ -1780,12 +2124,7 @@ func (s *SegmentStore) MergeBelow(height uint64) (meta SegmentMeta, merged bool,
 	last := run[n-1].meta
 	outHeight, outSeq := last.Height, last.Seq+1
 
-	winners, keys, err := s.mergeInputs(run)
-	if err != nil {
-		return meta, false, err
-	}
-
-	meta, seg, err := s.writeMergedSegment(winners, keys, outHeight, outSeq)
+	meta, seg, err := s.concatSegments(run, outHeight, outSeq)
 	if err != nil {
 		return meta, false, err
 	}
@@ -1807,6 +2146,61 @@ func (s *SegmentStore) MergeBelow(height uint64) (meta SegmentMeta, merged bool,
 		s.retire(o.indexPath)
 	}
 	return meta, true, nil
+}
+
+// segmentsBelow
+// The sealed segments belonging to blocks below `height`, oldest
+// first.  Segments are kept in order, so it is a prefix of the list.
+func (s *SegmentStore) segmentsBelow(height uint64) (segs []*segment, err error) {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+	if err = s.checkOpen(); err != nil {
+		return nil, err
+	}
+	n := 0
+	for _, seg := range s.segments {
+		if seg.meta.Height >= height {
+			break
+		}
+		n++
+	}
+	return append([]*segment(nil), s.segments[:n]...), nil
+}
+
+// DropBelow
+// Stop serving the sealed segments belonging to blocks below `height`
+// from this store, because their keys are now held cold.  Reports how
+// many were dropped.
+//
+// No manifest is written.  Dropping is a consequence of a commit that
+// has already happened -- the block set holding these keys is durable
+// before anyone calls this -- so nothing is lost by recording it late,
+// and recording it now would cost two barriers per shard for a fact the
+// shard's next seal records for free.  The files stay until then
+// (retireOnCommit), still named by the manifest and still whole, so a
+// crash in between leaves a store that opens exactly as before and
+// simply drops them again.
+//
+// The caller asserts the keys are held cold; the store cannot check.
+func (s *SegmentStore) DropBelow(height uint64) (dropped int, err error) {
+	s.Mutex.Lock()
+	defer s.Mutex.Unlock()
+	if err = s.checkOpen(); err != nil {
+		return 0, err
+	}
+	n := 0
+	for _, seg := range s.segments {
+		if seg.meta.Height >= height {
+			break
+		}
+		n++
+	}
+	if n == 0 {
+		return 0, nil
+	}
+	s.retireOnCommit = append(s.retireOnCommit, s.segments[:n]...)
+	s.segments = append([]*segment(nil), s.segments[n:]...)
+	return n, nil
 }
 
 // mergeInput names where a key's surviving value lives
@@ -1970,6 +2364,15 @@ func (s *SegmentStore) ImportSegmentFile(path string, meta SegmentMeta) (err err
 	if newest, ok := s.newestMeta(); ok && !meta.after(newest) {
 		return fmt.Errorf("segment (block %d, seq %d) is not above the newest segment (block %d, seq %d)",
 			meta.Height, meta.Seq, newest.Height, newest.Seq)
+	}
+	// A block already packed into a set is finalized: the set is what
+	// answers for it, and a store that has dropped every segment has no
+	// newest to be measured against, so the set's watermark is the bound
+	if s.cold != nil {
+		if last, ok := s.cold.watermark(); ok && meta.Height <= last {
+			return fmt.Errorf("segment (block %d, seq %d) is not above the newest block set, which ends at block %d",
+				meta.Height, meta.Seq, last)
+		}
 	}
 	if err = VerifySegmentFile(path, meta.Hash); err != nil {
 		return err
@@ -2181,14 +2584,35 @@ func (r recordSort) Swap(i, j int) {
 // where each one's value sits in the data file.  Sealing and
 // compaction both know that as they write, so neither has to read the
 // segment back to index it.
+//
+// entries carry offsets into the data FILE, which is what every writer
+// has in hand -- the live tail's map, or the position it just wrote a
+// record at.  The index stores them relative to the body instead (see
+// segment.value), so the header's length comes off here, once, rather
+// than in every writer.
 func writeIndexFile(indexPath string, order [][32]byte, entries map[[32]byte]*DBBKey) (err error) {
 	buff := make([]byte, 0, len(order)*DBKeyFullSize)
-	bloom := NewBloomSizedForKeys(uint64(len(order)), 3)
 	for _, key := range order {
-		buff = append(buff, entries[key].Bytes(key)...)
-		bloom.Set(key)
+		e := entries[key]
+		rel := DBBKey{Offset: e.Offset - segDataHdrSize, Length: e.Length}
+		buff = append(buff, rel.Bytes(key)...)
 	}
 	sort.Sort(recordSort(buff)) // Sorted by key, for binary search
+	return writeIndexRecords(indexPath, buff)
+}
+
+// writeIndexRecords
+// Write a segment's index from its records already sorted, encoded and
+// body-relative: what a merge has in hand, since the sources' indexes
+// are already in this form and combining them never leaves the form.
+func writeIndexRecords(indexPath string, buff []byte) (err error) {
+	count := uint64(len(buff) / DBKeyFullSize)
+	bloom := NewBloomSizedForKeys(count, 3)
+	for pos := 0; pos < len(buff); pos += DBKeyFullSize {
+		var key [32]byte
+		copy(key[:], buff[pos:])
+		bloom.Set(key)
+	}
 
 	tmpPath := indexPath + segTmpSuffix
 	out, err := os.Create(tmpPath)
@@ -2205,7 +2629,7 @@ func writeIndexFile(indexPath string, order [][32]byte, entries map[[32]byte]*DB
 	var idxHdr [segIndexHdrSize]byte
 	binary.BigEndian.PutUint32(idxHdr[:], segIndexMagic)
 	binary.BigEndian.PutUint32(idxHdr[4:], segIndexVersion)
-	binary.BigEndian.PutUint64(idxHdr[8:], uint64(len(order)))
+	binary.BigEndian.PutUint64(idxHdr[8:], count)
 	binary.BigEndian.PutUint64(idxHdr[16:], bloom.NumBytes)
 	binary.BigEndian.PutUint32(idxHdr[24:], uint32(bloom.K))
 	if _, err = out.Write(idxHdr[:]); err != nil {

--- a/docs/design/durability.md
+++ b/docs/design/durability.md
@@ -94,6 +94,8 @@ state survives until the new state is durable:
 | torn live-tail record | the live tail is replayed record by record on open; a record whose value bytes run past end-of-data is dropped **and the file is truncated to the last complete record**, so the next append lands on a record boundary |
 | live file with no header | `seal` creates the new `live.dat` and leaves its 24-byte header in the `BFile` buffer, so a crash before the first flush leaves the file at 0 bytes; open rewrites the header rather than trusting it to be there |
 | the block a shard is in | recorded once for the whole shard set (`block.json`, one fsync), not once per shard.  A shard with no writes advances in memory and commits nothing.  On open the set tells every shard the block it is in, which is what a shard needs it for: `SealNext` tags an auto-sealed segment with its block height, so a shard that came back believing it was in an older block would label segments with a block they do not belong to and `ExportBlock`, which selects by block, would never export them.  A missing file reads as 0 and constrains nothing, so an existing database opens unchanged (issue #32) |
+| merge of finalized segments | the merged segment is written, fsynced and renamed before the manifest names it, at an identity *below* the manifest's newest, so an uncommitted one is deleted by `recoverOrphans` while the originals it would replace are still named (issue #47) |
+| block-set file | written to `sets/set-….bset.tmp`, fsynced, renamed, and the set directory fsynced: the rename is the commit.  A `.tmp` left by a crash is deleted on open.  Only after that commit do the shards drop the segments the set holds -- **without a manifest of their own**.  The shard's next manifest commit (its next seal, or its close) is what stops naming them, and the files are deleted only after it.  A crash in between leaves every shard's manifest naming whole, intact segments that the set also holds; on open the shard set drops them again (`TestPackFinalizedSurvivesACrashBeforeTheShardsCommit`).  Nothing is ever in only one place until the second place is durable |
 | one barrier per operation | a seal renames up to three files into the same directory -- the sealed data file, its index, then the manifest -- and fsyncs that directory once, at the manifest commit. One directory fsync commits every name change made in it, and the renames are issued in order, so the manifest can never become durable ahead of the data file it names. Each file's own fsync is still taken before its rename: that is what makes a published name always point at durable contents. Six barriers a seal became four, measured 36 ms to 24.6 ms (issue #33) |
 | operations on a closed store | `Close` drops the sealed segment list but keeps the live map, so reads and writes refuse with `errStoreClosed` rather than running against half a store |
 
@@ -172,3 +174,12 @@ The first three have a regression test in `segstore_test.go`
 - A key written to Dyna keeps a stale copy in Perm. `Get` resolves the
   layer order, so the copy is dead weight rather than a wrong answer,
   but compaction does not reclaim it.
+- `recoverOrphans` adopts any complete data file *above* the manifest's
+  newest segment.  Two paths can leave such a file that duplicates
+  data the manifest already names: a merge of a shard whose every
+  segment was below the watermark (the merged file is then above
+  everything), and a shard that dropped its last segment for a block
+  set, committed, and crashed before the unlink.  Either way the
+  adopted file holds keys with identical values elsewhere; lookups are
+  right, the next merge or drop folds it away, and the cost is space
+  until then.

--- a/docs/design/segment-store.md
+++ b/docs/design/segment-store.md
@@ -15,6 +15,14 @@ v2 makes the segment format the *storage* itself.
     seg-<block>-<seq>.idx     its index: sorted 48-byte key records + a bloom
     segments.json             the manifest: segments, counts, hashes
 
+An index record is `key(32) offset(8) length(8)`. The offset is
+**relative to the segment's body** — its records, after the 24-byte
+header — not to the file. That is what lets a body and its index be
+copied into a larger file byte for byte, with the container recording
+where the body landed and a reader adding that base (see *Block-set
+files*, below). For a segment file on its own the base is the header
+length.
+
 Writes append to the live tail. `Seal(height)` turns the tail into an
 immutable segment; nothing already written is ever moved or rewritten.
 
@@ -197,8 +205,9 @@ record from a crash mid-write is dropped.
    durability, sync, and compaction boundary.
 
 Not yet done here: reading a value with one `ReadAt` on the value bytes
-rather than through the record header, and the cross-shard merge that
-produces globally sorted runs (issue #47).
+rather than through the record header, and merging block sets into
+larger ones — the levelled runs of issue #47 beyond the first two
+stages below.
 
 ### Merging finalized segments
 
@@ -243,10 +252,113 @@ shard and keeps going past a failure, reporting the first error.
 
 It is not a goroutine this package starts. Only the caller knows its
 block rate and how far back healing may still write, which is what
-sets the watermark. Measured cost is a real constraint on that caller:
-one 20-block set took 12.2 s serially across 512 shards, a ~61% duty
-cycle against 20 seconds of chain time, so the driver wants concurrency
-across shards, a watermark free to lag, and rate limiting (issue #47).
+sets the watermark.
+
+The merge is a **copy, not a rewrite**. Perm keys are unique and
+immutable, so there is nothing to reclaim and nothing to resolve: each
+source segment's body is copied in as one sequential read, and its
+index entries are shifted by where that body landed. No value is read
+individually. The per-key work is the index — 48 bytes a key, already
+sorted per source — merged and sorted per shard. (The first version
+read every value back and re-encoded it, which is what compaction has
+to do and a merge does not.)
+
+Measured on the same fixture as before, a 20-block set of 2,000
+entries a block across 512 shards:
+
+| | time |
+|---|---|
+| serial, read-and-rewrite (previous) | 12.2 s |
+| serial, copy (this) | 12.1 s |
+| 16 goroutines, copy | **1.3 s** |
+
+The serial figure barely moves because the merge is **fsync-bound, not
+read-bound**: each shard pays four barriers — data, index, manifest,
+directory — at ~5.5 ms each on this NVMe, which is ~11 s of the 12
+across 512 shards. What the copy buys is the CPU and the read I/O,
+which do not show at this size. What buys the wall time is running
+shards concurrently, as the barriers overlap: 16 goroutines take the
+set to 1.3 s, against 20 seconds of chain time. The driver wants
+that concurrency, a watermark free to lag, and rate limiting (issue
+#47).
+
+### Block-set files
+
+Stage one leaves one segment per shard per set. At 512 shards that is
+still 1,024 files a set — ~4.4M a day at a block a second — so the
+second stage packs the 512 per-shard results for one block set into
+**one file** outside any shard:
+
+    <db>/sets/set-<first>-<last>.bset
+
+    header      magic "BSET", version, shard count, bloom K,
+                first block, last block, key count, bloom bytes,
+                offset where the bodies begin              (64 bytes)
+    directory   per shard: body offset, body length,
+                index offset, key count                    (512 × 32)
+    indexes     every shard's sorted 48-byte key records, contiguous
+    bloom       one filter over every key in the set
+    bodies      every shard's records, in shard order
+
+The head — directory, indexes, bloom — is one contiguous region whose
+size is known from the key counts before anything is written, so it is
+written with one call after the bodies are in place, and can be loaded
+with one read. What a lookup keeps in memory is the directory (16 KB)
+and the bloom (~1.5 bytes a key); the indexes stay on disk.
+
+Keys are sorted **within each shard**, not across the file. A key
+routes to its shard by `ShardIndex` before anything is looked up, so a
+global order would cost a 512-way merge and buy nothing. And because
+index offsets are body-relative, building the set is a byte-for-byte
+concatenation: each shard's merged index is copied in unchanged, its
+body is copied in unchanged, and the directory records where the body
+landed. No index entry is touched.
+
+A lookup that reaches a set costs a bloom probe, one read of the
+shard's index slice (~10 KB at 5,000 entries a block, searched in
+memory; slices over 64 KB are binary-searched on disk), and one read of
+the value. Sets are walked newest to oldest; a key the shard's own
+filter says is absent never reaches them.
+
+`KVShard.PackFinalized(height)` builds it: every shard's segments below
+the watermark — expected to be stage one's single merged segment each,
+though it copes with more — into one set, committed by the rename of
+the file and one fsync of the set directory. Then each shard **drops**
+those segments (`SegmentStore.DropBelow`) without writing a manifest:
+the shard's next seal records the drop, and only then are the files
+deleted. That is deliberate. Recording it immediately would cost two
+barriers per shard — ~5.6 s a set, the same cost issue #32 removed from
+the block boundary — for a fact the next seal records for free. A crash
+in between leaves a shard whose manifest still names segments the set
+also holds; on open it drops them again
+(`TestPackFinalizedSurvivesACrashBeforeTheShardsCommit`).
+
+Measured, the same 20-block set of 40,000 keys: **~30 ms** for the
+pack, one file of 7.6 MB, and the set's files go from 1,024 after
+stage one to 1. Reading every packed key back took 2.5 µs a key from
+the page cache; an absent key, settled by the shard's filter, 0.45 µs. A lookup of a packed key,
+a rebuilt filter, an import, iteration, and block export are all
+covered in `blockset_test.go` and `TestMergeDoesNotDisturbBlockExport`.
+
+**The shard's key filter covers its packed keys.** Every write asks
+whether its key is new, and the store-level filter is what answers
+"no" without a disk read; that answer is only definitive if the filter
+holds the keys that have left the segments. So the set store is
+attached *inside* each shard's Perm layer rather than beside it: the
+filter adds the cold keys whenever it is rebuilt, `get` consults the
+sets only after the filter has said "maybe" and the segments have
+said no, and a packed key rewritten with a different value is still
+refused (`TestPackedKeysStayImmutable` — which fails against a filter
+rebuilt from the segments alone).
+
+Sets are the finalized record, so a block in one cannot be imported
+again: a shard that has dropped every segment has no newest segment to
+measure an import against, and the set's watermark is the bound.
+
+Memory per set is the directory plus the bloom, so it grows with the
+key count at ~1.5 bytes a key — the same order as the per-segment
+filters it replaces. The next stage of #47, merging sets into larger
+ones, is what bounds the number of sets a lookup walks.
 
 ### File descriptors are borrowed, not held
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -64,19 +64,47 @@ target the pool returns to rather than a ceiling at every instant.
 
 ### Finalisation Watermark
 
-`KVShard.MergeFinalized(height)` merges each shard's sealed Perm
-segments below a block height into one.  Sealing produces a segment per
-shard per block, so without this the file count grows with the chain
-and nothing bounds it: measured at 512 shards and 5,000 entries a
-block, ~1,016 files per block, which is ~88M a day at one block per
-second against 240M inodes.  Merging a completed 20-block set took
-17,960 files to 1,024.
+Finalisation is two stages, both driven by the caller from its own
+scheduler, both below a watermark `height` that must sit behind
+whatever window may still be written to -- healing, in Accumulate's
+case -- because segments at or above it are left alone so that block
+export keeps working.
 
-Set `height` behind whatever window may still be written to -- healing,
-in Accumulate's case -- because segments at or above it are left alone
-so that block export keeps working.  Run it from your own scheduler,
-concurrently across shards: one set measured 12.2 s serially, against
-20 seconds of chain time.
+1. `KVShard.MergeFinalized(height)` merges each shard's sealed Perm
+   segments below the watermark into one.  Sealing produces a segment
+   per shard per block, so without this the file count grows with the
+   chain and nothing bounds it: measured at 512 shards and 5,000
+   entries a block, ~1,016 files per block, ~88M a day at one block per
+   second against 240M inodes.  A completed 20-block set goes from
+   17,960 files to 1,024.
+
+   The merge copies bodies and shifts index entries; no value is read
+   individually.  Its cost is fsync -- four barriers per shard -- so
+   run it **concurrently across shards**: the same 20-block set of
+   2,000 entries a block measured 12.1 s serially and 1.3 s with
+   16 goroutines, against 20 seconds of chain time.
+
+2. `KVShard.PackFinalized(height)` packs every shard's merged segment
+   for the set into **one block-set file** under `<db>/sets/`, then
+   drops those segments from the shards.  The 1,024 files become 1.
+   Measured on the same set: ~30 ms, one file of 7.6 MB for 40,000
+   keys.
+
+   The drop writes no manifest.  Each shard records it at its next
+   seal, and only then deletes the files, so the pack costs two
+   barriers in all rather than two per shard.  Until a shard next
+   seals -- or closes -- its packed files linger on disk, harmlessly:
+   a shard that takes no writes for a long time keeps them that long.
+
+A lookup that reaches a set costs a bloom probe, one read of the
+shard's index slice, and one read of the value; a key the shard's own
+filter says is absent never reaches the sets.  Measured over the packed
+20-block set: 2.5 µs per hit from the page cache, and 0.45 µs per
+absent key.  Memory
+per set is 16 KB of directory plus a bloom at ~1.5 bytes a key.
+
+Run stage two after stage one for the same watermark, never
+concurrently with it: the merge retires the files the pack is copying.
 
 ### Compaction Ratio
 


### PR DESCRIPTION
Tier two of #47, plus a rework of tier one. A finished block set becomes **one file** instead of one segment per shard, and the per-shard merge that precedes it copies bodies instead of rewriting values.

## Stage 1 — merge by copying, measured honestly

`MergeBelow` (PR #48) read every value back and re-encoded it. That is what compaction must do and a Perm merge need not: Perm keys are unique and immutable, so there is nothing to reclaim. `concatSegments` copies each source body in as one sequential read and shifts its index entries; no value is read individually.

Same fixture as #48 — a 20-block set, 2,000 entries/block, 512 shards:

| | time |
|---|---|
| serial, read-and-rewrite (before) | 12.2 s |
| serial, copy (now) | 12.1 s |
| 16 goroutines, copy | **1.3 s** |

The serial number barely moves, and that is the finding: the merge is **fsync-bound** — four barriers per shard at ~5.5 ms is ~11 s of the 12. The copy removes CPU and read I/O, which do not show at this size. Concurrency across shards is what buys wall time, because the barriers overlap. Recorded on #47.

## Stage 2 — one file per block set

`KVShard.PackFinalized(height)` packs every shard's merged segment into `<db>/sets/set-<first>-<last>.bset`:

```
header      magic, version, shard count, block range, key count, bloom size, data offset   (64 B)
directory   per shard: body offset, body length, index offset, key count               (512 × 32 B)
indexes     every shard's sorted 48-byte key records, contiguous
bloom       one filter over the set
bodies      every shard's records, in shard order
```

The head is one contiguous region whose size is known before anything is written: header, reserve, copy bodies, **one write** for directory + indexes + bloom. Loadable with one read. Lookup: key → `ShardIndex` → directory entry → the shard's index slice in one read (searched in memory; >64 KB slices binary-search on disk) → the value.

Measured on the same set: **~30 ms**, one 7.6 MB file for 40,000 keys; **1,024 files → 1**. Packed-key reads 2.5 µs each from the page cache; absent keys 0.45 µs, settled by the shard's filter.

### Index offsets are body-relative (owner's refinement)

Both stages. A segment's `.idx` now holds offsets into its **records**, not its file; `segment.value` adds the header. So the set file is a byte-for-byte concatenation: each shard's merged index and body are copied in unchanged and the directory records where the body landed. No index entry is touched at stage two. One convention for every index the store writes. Format change → `StoreFormatVersion = 2`, free because no database predates the check.

### The set store lives inside each shard's Perm layer

Because of the key filter. Every write asks "is this key new?", and the store-level filter is what answers "absent" without a disk read — only definitive if it covers the keys that have left the segments. So the cold store is attached to the `SegmentStore`: the filter adds cold keys on rebuild, `get` consults sets only after filter-maybe and segments-miss, `ForEach` walks them, and an import at or below a set's watermark is refused.

`TestPackedKeysStayImmutable` rebuilds a shard's filter from segments that no longer hold a packed key, then rewrites it with a different value. Against a filter built without the cold keys it fails with `a packed key must still be immutable`.

### Dropping the per-shard segments costs no barrier

Recording the drop immediately would be two fsyncs per shard — ~5.6 s a set, the cost #32 removed from the block boundary — for a fact each shard's next seal records for free. `DropBelow` removes the segments from the list and defers their files until the next `writeManifest`. The set is durable before any shard drops, so a crash in between leaves shards naming whole segments the set also holds; `OpenKVShard` drops them again (`TestPackFinalizedSurvivesACrashBeforeTheShardsCommit`, which reopens without closing). A shard that takes no writes keeps its packed files until its next seal or close — documented.

## Verification

- crash contract: **0 failures in 20 runs** of both crash tests (this touches `writeManifest` and every seal's index)
- full `-short` suite green
- eight new tests in `blockset_test.go`; `TestMergeDoesNotDisturbBlockExport` now runs both stages before exporting the next block
- `gofmt` clean, `go vet` clean

## Filed rather than folded in

- #52 — `recoverOrphans` adopts a merge output or a dropped file that duplicates data the manifest names (pre-existing shape; space only)
- Merging sets into larger ones — what bounds the number of sets a lookup walks — stays on #47

Refs #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKAh7mFDHChAtKQtJYP3a3
