### PR TITLE
Let readers share the lock, and shard the file pool they were queueing on

### DIFF
--- a/database/bfile.go
+++ b/database/bfile.go
@@ -204,15 +204,20 @@ func (b *BFile) ReadAt(offset uint64, data []byte) (err error) {
 
 	switch {
 	case DataLastOffset <= b.EOD:
-		if err = b.Open(); err != nil {
-			return err
+		// pread, not seek-then-read.  Readers of the live tail hold only
+		// a shared lock (issue #50), so two of them can be here at once;
+		// a seek followed by a read is two syscalls sharing one file
+		// offset, and interleaved they hand each reader the other's
+		// bytes.  ReadAt takes the offset as an argument and touches no
+		// shared state.
+		//
+		// Nor does this open the file: Open mutates b.File, which is not
+		// safe under a shared lock either.  A nil File means the store
+		// is closed, which checkOpen reports before any read gets here.
+		if b.File == nil {
+			return fmt.Errorf("%s is not open", b.Filename)
 		}
-		// Question: Why not call File.ReadAt and avoid the call to Seek and
-		// avoid clobbering the file offset?
-		if _, err = b.File.Seek(int64(offset), io.SeekStart); err != nil {
-			return err
-		}
-		if _, err = b.File.Read(data); err != nil {
+		if _, err = b.File.ReadAt(data, int64(offset)); err != nil {
 			return err
 		}
 	case DataLastOffset > b.EOB+b.EOD:

--- a/database/filecache.go
+++ b/database/filecache.go
@@ -69,15 +69,94 @@ type cachedFile struct {
 }
 
 func newFileCache(limit int) *fileCache {
-	if limit < 1 {
-		limit = 1
+	if limit < 0 {
+		limit = 0 // Cache nothing; every release closes
 	}
 	return &fileCache{limit: limit, open: make(map[string]*cachedFile), lru: list.New()}
 }
 
+// filePoolShards is how many independent caches the process-wide pool
+// is split into, by a hash of the path.
+//
+// One cache under one mutex was the read path's serialisation point
+// once the store's own lock went shared (issue #50): every lookup
+// borrows an index file and a data file, so every read took that mutex
+// twice, and a mutex profile at eight readers put 100% of the wait on
+// it -- acquire 69%, release 31%.  Sixty-four shards make the
+// contention per shard a sixty-fourth of what it was, and a path's
+// shard is fixed, so a file is only ever in one cache.
+//
+// Each shard enforces a sixty-fourth of the limit.  That is an
+// approximation of a global bound -- a skewed working set can hold one
+// shard at its limit while others sit empty -- but the limit was
+// always a target rather than a ceiling, and this keeps eviction a
+// per-shard decision that needs no cross-shard lock.
+const filePoolShards = 64
+
+// filePool is the process-wide pool: filePoolShards caches, each with
+// its own lock, LRU, and share of the limit.
+type filePool struct {
+	shards [filePoolShards]*fileCache
+}
+
+func newFilePool(limit int) *filePool {
+	p := &filePool{}
+	for i := range p.shards {
+		p.shards[i] = newFileCache(perShardLimit(limit))
+	}
+	return p
+}
+
+// perShardLimit divides the pool's limit among its shards.  A share of
+// zero is legitimate and means the shard caches nothing: a file it
+// hands out is closed as soon as its last borrow ends.  No floor is
+// needed to serve a file -- a file in use is never an eviction
+// candidate, whatever the limit -- and a floor of one would make the
+// pool's real minimum filePoolShards, not what the caller asked for.
+func perShardLimit(limit int) int {
+	if limit < 0 {
+		return 0
+	}
+	return limit / filePoolShards
+}
+
+// shard picks the cache for a path.  FNV-1a over the bytes: cheap, and
+// what matters is only that the same path always lands in the same
+// shard.
+func (p *filePool) shard(path string) *fileCache {
+	var h uint32 = 2166136261
+	for i := 0; i < len(path); i++ {
+		h ^= uint32(path[i])
+		h *= 16777619
+	}
+	return p.shards[h%filePoolShards]
+}
+
+func (p *filePool) acquire(path string) (*os.File, func(), error) {
+	return p.shard(path).acquire(path)
+}
+
+func (p *filePool) forget(path string) { p.shard(path).forget(path) }
+
+func (p *filePool) setLimit(limit int) {
+	for _, c := range p.shards {
+		c.setLimit(perShardLimit(limit))
+	}
+}
+
+// stats sums the shards.  Not a consistent snapshot -- each shard is
+// read under its own lock -- which is fine for what it is used for.
+func (p *filePool) stats() (open, idle, limit int) {
+	for _, c := range p.shards {
+		o, i, l := c.stats()
+		open, idle, limit = open+o, idle+i, limit+l
+	}
+	return open, idle, limit
+}
+
 // segmentFiles is the pool every store borrows from.  It is process
 // wide on purpose; see defaultOpenFiles.
-var segmentFiles = newFileCache(defaultOpenFiles)
+var segmentFiles = newFilePool(defaultOpenFiles)
 
 // SetOpenFileLimit
 // Bound how many segment files the process keeps open.  Files
@@ -90,8 +169,8 @@ func SetOpenFileLimit(limit int) {
 }
 
 func (c *fileCache) setLimit(limit int) {
-	if limit < 1 {
-		limit = 1
+	if limit < 0 {
+		limit = 0
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/database/kv_2.go
+++ b/database/kv_2.go
@@ -42,7 +42,7 @@ const DynaDirName = "dyna"
 // key/values are kept in one store.
 
 type KV2 struct {
-	Mutex     sync.Mutex    // Serializes access; KV2 methods are safe for concurrent use
+	Mutex     sync.RWMutex  // Writers exclusive, readers shared; KV2 methods are safe for concurrent use
 	Directory string        // Directory where the PermKV and DynaKV directories are
 	PermKV    *SegmentStore // The Perm layer: sealed, immutable segments
 	DynaKV    *SegmentStore // The Dyna layer: sealed, mutable segments
@@ -159,8 +159,8 @@ func (k *KV2) Close() error {
 // GetDyna
 // Get a k/v from the DynaKV db.  Doesn't check the PermKV.
 func (k *KV2) GetDyna(key [32]byte) (value []byte, err error) {
-	k.Mutex.Lock()
-	defer k.Mutex.Unlock()
+	k.Mutex.RLock()
+	defer k.Mutex.RUnlock()
 
 	if value, err = k.DynaKV.Get(key); err != nil { // Not in DynaKV, then return whatever
 		return nil, err
@@ -171,8 +171,8 @@ func (k *KV2) GetDyna(key [32]byte) (value []byte, err error) {
 // GetPerm
 // Get a k/v from the PermKV db.  Doesn't check the DynaKV.
 func (k *KV2) GetPerm(key [32]byte) (value []byte, err error) {
-	k.Mutex.Lock()
-	defer k.Mutex.Unlock()
+	k.Mutex.RLock()
+	defer k.Mutex.RUnlock()
 
 	if value, err = k.PermKV.Get(key); err != nil { // Not in PermKV, then return whatever
 		return nil, err
@@ -183,8 +183,8 @@ func (k *KV2) GetPerm(key [32]byte) (value []byte, err error) {
 // Get
 // Get a value from the KV2.  Checks the DynaKV first, then the PermKV
 func (k *KV2) Get(key [32]byte) (value []byte, err error) {
-	k.Mutex.Lock()
-	defer k.Mutex.Unlock()
+	k.Mutex.RLock()
+	defer k.Mutex.RUnlock()
 
 	// Check and see if this is a key that has been changed
 	if value, err = k.DynaKV.Get(key); err == nil { // Not in DynaKV, then return whatever

--- a/database/readlock_test.go
+++ b/database/readlock_test.go
@@ -1,0 +1,159 @@
+package blockchainDB
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Reads take the store's lock SHARED (issue #50).
+//
+// The test for that is deterministic rather than a timing: hold the
+// lock shared from outside, then call Get.  Under the exclusive mutex
+// the reads used to take, Get blocks forever -- the harness's timeout
+// is the failure.  Under a shared lock it proceeds.
+
+func TestSegmentStoreReadsShareTheLock(t *testing.T) {
+	dir := storeDir(t, "rlock")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+	defer store.Close()
+
+	kr := NewFastRandom([]byte{65})
+	sealed := kr.NextHash()
+	require.NoError(t, store.Put(sealed, []byte("sealed")))
+	_, err = store.Seal(1)
+	require.NoError(t, err)
+	live := kr.NextHash()
+	require.NoError(t, store.Put(live, []byte("live")))
+
+	store.Mutex.RLock() // Another reader is in the store
+	defer store.Mutex.RUnlock()
+
+	done := make(chan error, 1)
+	go func() {
+		for _, key := range [][32]byte{sealed, live} {
+			if _, err := store.Get(key); err != nil {
+				done <- err
+				return
+			}
+		}
+		_, err := store.Get(kr.NextHash()) // And an absent key
+		if err != errNotFound {
+			done <- fmt.Errorf("absent key: %v", err)
+			return
+		}
+		done <- nil
+	}()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Get blocked behind another reader: reads are not sharing the lock")
+	}
+}
+
+func TestKV2ReadsShareTheLock(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
+	kv, err := NewKV2(dir, 1000)
+	require.NoError(t, err)
+	defer kv.Close()
+
+	kr := NewFastRandom([]byte{66})
+	perm, dyna := kr.NextHash(), kr.NextHash()
+	_, err = kv.PutPerm(perm, []byte("p"))
+	require.NoError(t, err)
+	_, err = kv.PutDyna(dyna, []byte("d"))
+	require.NoError(t, err)
+
+	kv.Mutex.RLock()
+	defer kv.Mutex.RUnlock()
+
+	done := make(chan error, 1)
+	go func() {
+		if _, err := kv.Get(perm); err != nil {
+			done <- err
+			return
+		}
+		if _, err := kv.GetPerm(perm); err != nil {
+			done <- err
+			return
+		}
+		_, err := kv.GetDyna(dyna)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("KV2.Get blocked behind another reader")
+	}
+}
+
+// TestConcurrentReadersAndAWriter
+// Many readers against sealed data and the live tail while one writer
+// appends and seals.  Run under -race: the point is that the shared
+// lock, the atomic counters, and pread on the live tail are enough.
+func TestConcurrentReadersAndAWriter(t *testing.T) {
+	dir := storeDir(t, "race")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+	defer store.Close()
+
+	kr := NewFastRandom([]byte{67})
+	keys := make([][32]byte, 2000)
+	for i := range keys {
+		keys[i] = kr.NextHash()
+		require.NoError(t, store.Put(keys[i], []byte(fmt.Sprintf("v%d", i))))
+		if i%250 == 249 {
+			_, err = store.Seal(uint64(i/250 + 1))
+			require.NoError(t, err)
+		}
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for r := 0; r < 8; r++ {
+		wg.Add(1)
+		go func(r int) {
+			defer wg.Done()
+			rr := NewFastRandom([]byte{byte(r), 68})
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				i := int(rr.UintN(uint(len(keys))))
+				v, err := store.Get(keys[i])
+				if err != nil {
+					t.Errorf("reader %d: key %d: %v", r, i, err)
+					return
+				}
+				if string(v) != fmt.Sprintf("v%d", i) {
+					t.Errorf("reader %d: key %d: wrong value %q", r, i, v)
+					return
+				}
+			}
+		}(r)
+	}
+	// The writer keeps appending and sealing underneath them
+	for i := 0; i < 500; i++ {
+		require.NoError(t, store.Put(kr.NextHash(), []byte("w")))
+		if i%100 == 99 {
+			_, err = store.Seal(uint64(9 + i/100))
+			require.NoError(t, err)
+		}
+	}
+	close(stop)
+	wg.Wait()
+	st := store.Stats()
+	require.Greater(t, st.LookupTotal, uint64(0), "the counters must have counted under the shared lock")
+}

--- a/database/segstore.go
+++ b/database/segstore.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 )
 
 // Sealed segments as storage.
@@ -266,7 +267,20 @@ func (s *segment) value(dbb *DBBKey) (value []byte, err error) {
 // A key/value store built from sealed segments and a live tail.
 // Methods are safe for concurrent use.
 type SegmentStore struct {
-	Mutex     sync.Mutex
+	// Mutex guards the store.  Writers -- anything that appends to the
+	// live tail, seals, compacts, merges, imports, or closes -- take it
+	// exclusively.  Readers take it SHARED: a sealed segment is
+	// immutable and the pool hands out descriptors for pread, so
+	// lookups against sealed data need no lock at all; the shared lock
+	// exists only to keep the live map and the segment list stable
+	// while a reader is looking at them.
+	//
+	// It was an exclusive mutex for reads too, and that serialised
+	// every read in the process on one lock whose hold time grew with
+	// the segment walk.  Measured on an 8-node Accumulate network at
+	// 500 tx/s: the busiest node ran at ~110% CPU -- one core, seven
+	// idle -- while block time climbed from 3.0 s to 5.2 s (issue #50).
+	Mutex     sync.RWMutex
 	Directory string
 	Mutable   bool // Mutable: newer segments shadow older; immutable: conflicts error
 
@@ -404,7 +418,7 @@ type SegmentStore struct {
 	// (attachCold).  A filter loaded from disk was saved complete.
 	keysLackCold bool
 
-	stats StoreStats // Counted under the Mutex, like everything else here
+	stats storeCounters // Atomic: the read path holds only a shared lock
 }
 
 // coldStore
@@ -470,12 +484,31 @@ type StoreStats struct {
 	LiveHit      uint64 // Answered from the live tail, before any filter
 }
 
+// storeCounters is StoreStats as the store keeps it: atomics, because
+// the counters on the read path are bumped under a SHARED lock, and a
+// plain increment there is a data race.
+type storeCounters struct {
+	putTotal, putNew, putDuplicate, putConflict           atomic.Uint64
+	lookupTotal, filterAbsent, filterWalked, filterMisled atomic.Uint64
+	liveHit                                               atomic.Uint64
+}
+
 // Stats
-// A snapshot of the store's counters.
+// A snapshot of the store's counters.  Taken without any lock: each
+// counter is read atomically, and a snapshot that straddles a
+// concurrent operation is off by one, which is what a counter is for.
 func (s *SegmentStore) Stats() StoreStats {
-	s.Mutex.Lock()
-	defer s.Mutex.Unlock()
-	return s.stats
+	return StoreStats{
+		PutTotal:     s.stats.putTotal.Load(),
+		PutNew:       s.stats.putNew.Load(),
+		PutDuplicate: s.stats.putDuplicate.Load(),
+		PutConflict:  s.stats.putConflict.Load(),
+		LookupTotal:  s.stats.lookupTotal.Load(),
+		FilterAbsent: s.stats.filterAbsent.Load(),
+		FilterWalked: s.stats.filterWalked.Load(),
+		FilterMisled: s.stats.filterMisled.Load(),
+		LiveHit:      s.stats.liveHit.Load(),
+	}
 }
 
 // NewSegmentStore
@@ -1105,8 +1138,8 @@ func (s *SegmentStore) checkOpen() error {
 // Return the value for a key.  Checks the live tail, then the sealed
 // segments newest to oldest.
 func (s *SegmentStore) Get(key [32]byte) (value []byte, err error) {
-	s.Mutex.Lock()
-	defer s.Mutex.Unlock()
+	s.Mutex.RLock()
+	defer s.Mutex.RUnlock()
 	return s.get(key)
 }
 
@@ -1115,23 +1148,23 @@ func (s *SegmentStore) get(key [32]byte) (value []byte, err error) {
 	if err = s.checkOpen(); err != nil {
 		return nil, err
 	}
-	s.stats.LookupTotal++
+	s.stats.lookupTotal.Add(1)
 	if dbb, ok := s.live[key]; ok {
 		value = make([]byte, dbb.Length)
 		if err = s.liveFile.ReadAt(dbb.Offset, value); err != nil {
 			return nil, err
 		}
-		s.stats.LiveHit++
+		s.stats.liveHit.Add(1)
 		return value, nil
 	}
 	// One probe settles the common case.  The filter covers every key
 	// in the store, so a "no" here is definitive and the walk below --
 	// which is what grows with the seal count -- is skipped entirely.
 	if s.keys != nil && !s.keys.Test(key) {
-		s.stats.FilterAbsent++
+		s.stats.filterAbsent.Add(1)
 		return nil, errNotFound
 	}
-	s.stats.FilterWalked++
+	s.stats.filterWalked.Add(1)
 	for i := len(s.segments) - 1; i >= 0; i-- { // Newest segment wins
 		dbb, found, err := s.segments[i].lookup(key)
 		if err != nil {
@@ -1151,7 +1184,7 @@ func (s *SegmentStore) get(key [32]byte) (value []byte, err error) {
 		}
 	}
 	if s.keys != nil {
-		s.stats.FilterMisled++ // The walk was the filter's fault
+		s.stats.filterMisled.Add(1) // The walk was the filter's fault
 	}
 	return nil, errNotFound
 }
@@ -1173,18 +1206,18 @@ func (s *SegmentStore) put(key [32]byte, value []byte) (err error) {
 	if err = s.checkOpen(); err != nil {
 		return err
 	}
-	s.stats.PutTotal++
+	s.stats.putTotal.Add(1)
 	if !s.Mutable {
 		if existing, err := s.get(key); err == nil {
 			if bytes.Equal(existing, value) {
-				s.stats.PutDuplicate++
+				s.stats.putDuplicate.Add(1)
 				return nil // Same value: no-op
 			}
-			s.stats.PutConflict++
+			s.stats.putConflict.Add(1)
 			return ErrImmutable
 		}
 	}
-	s.stats.PutNew++
+	s.stats.putNew.Add(1)
 	return s.writeRecord(key, value)
 }
 
@@ -1239,30 +1272,30 @@ func (s *SegmentStore) PutIfAbsent(key [32]byte, value []byte) (existing []byte,
 	if err = s.checkOpen(); err != nil {
 		return nil, false, err
 	}
-	s.stats.PutTotal++
+	s.stats.putTotal.Add(1)
 	switch existing, err = s.get(key); {
 	case err == nil:
 		// Split the two ways a key can already be here, because they
 		// mean opposite things: an identical rewrite is a write this
 		// check avoided, a differing one is a write it caught.
 		if bytes.Equal(existing, value) {
-			s.stats.PutDuplicate++
+			s.stats.putDuplicate.Add(1)
 		} else {
-			s.stats.PutConflict++
+			s.stats.putConflict.Add(1)
 		}
 		return existing, true, nil
 	case !errors.Is(err, errNotFound):
 		return nil, false, err
 	}
-	s.stats.PutNew++
+	s.stats.putNew.Add(1)
 	return nil, false, s.writeRecord(key, value)
 }
 
 // LiveCount
 // The number of keys in the live tail (not yet sealed)
 func (s *SegmentStore) LiveCount() int {
-	s.Mutex.Lock()
-	defer s.Mutex.Unlock()
+	s.Mutex.RLock()
+	defer s.Mutex.RUnlock()
 	return len(s.live)
 }
 
@@ -1272,8 +1305,8 @@ func (s *SegmentStore) LiveCount() int {
 // records: this, not LiveCount, is what bounds the tail's size on disk
 // and its replay cost on open.
 func (s *SegmentStore) LiveRecords() uint64 {
-	s.Mutex.Lock()
-	defer s.Mutex.Unlock()
+	s.Mutex.RLock()
+	defer s.Mutex.RUnlock()
 	return s.liveRecords
 }
 
@@ -1336,8 +1369,8 @@ func (s *SegmentStore) endIterate() {
 // not need this, but one resuming after a crash does -- the block it
 // was about to seal may already be sealed and recorded.
 func (s *SegmentStore) BlockHeight() uint64 {
-	s.Mutex.Lock()
-	defer s.Mutex.Unlock()
+	s.Mutex.RLock()
+	defer s.Mutex.RUnlock()
 	return s.blockHeight
 }
 

--- a/docs/design/segment-store.md
+++ b/docs/design/segment-store.md
@@ -382,6 +382,58 @@ keeps reading after the path is unlinked. A reader can therefore hold
 a segment open across a compaction that retires and deletes it, which
 is what lets iteration run without the store's lock.
 
+### Reads share the lock; the file pool is sharded
+
+Every read used to take the store's mutex exclusively, and `KV2.Get`
+took its own exclusively above that. Sealed segments are immutable and
+the pool hands out descriptors for `pread`, so a lookup against sealed
+data needs no lock at all; the exclusive one existed only by default.
+Measured on an 8-node Accumulate network at 500 tx/s: the busiest node
+ran at ~110% CPU — one core, seven idle — while every shard's reads
+queued on that lock and its hold time grew with the segment walk
+(issue #50).
+
+Readers now take both locks shared. Writers — anything that appends,
+seals, compacts, merges, imports, or closes — still take them
+exclusively, so a reader never sees the live map or the segment list
+mid-change. Three things had to follow:
+
+- **The counters are atomic.** A plain increment under a shared lock
+  is a data race.
+- **The live tail is read with `pread`.** `BFile.ReadAt` was seek then
+  read: two syscalls sharing one file offset, which interleaved between
+  two readers hand each the other's bytes.
+- **The file pool is sharded 64 ways** by a hash of the path. Once the
+  store lock went shared, a mutex profile at eight readers put 100% of
+  the remaining wait on the pool's single mutex — every lookup borrows
+  an index file and a data file through it. Each shard enforces a
+  sixty-fourth of the limit; a share of zero means the shard caches
+  nothing, which is what a very small limit should mean.
+
+Measured, one store with 1,000 sealed segments and 100,000 keys, random
+`Get` from N goroutines:
+
+| readers | exclusive lock | shared lock, one pool | shared lock, sharded pool |
+|---|---|---|---|
+| 1 | 107,000/s | 120,000/s | 112,000/s |
+| 2 | 50,000/s | 207,000/s | 205,000/s |
+| 4 | 50,000/s | 142,000/s | 392,000/s |
+| 8 | 53,000/s | 125,000/s | 668,000/s |
+| 16 | 48,000/s | 131,000/s | **976,000/s** |
+
+The first column is the finding: under the exclusive lock, adding a
+second reader *halved* throughput and it never recovered — a lock
+convoy. The middle column shows the store lock was only the first wall.
+
+Two deterministic tests pin the property rather than the timing: hold
+the lock shared from outside and call `Get`; under an exclusive lock it
+blocks forever, so the harness timeout is the failure.
+
+What remains on the read path is the walk itself: at 1,000 segments a
+hit probes 1,000 per-segment blooms (`Bloom.Test` was 25% of CPU in the
+profile). That is the segment count, which block-set packing collapses
+— a packed set is one bloom, not one per block.
+
 ### Iteration takes a snapshot and holds no lock
 
 `ForEach` used to hold the store's mutex for the whole iteration, so a

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -20,9 +20,13 @@ the trade-offs behind them.
    plus one manifest commit -- not a re-insertion of every record.
    The cost does not grow with what the receiving node already holds.
 
-4. **Shards give you cores.**  Keys route to one of 512 shards by
-   `ShardIndex`, and each shard has its own lock, so writes to
-   different shards proceed in parallel.
+4. **Shards give you cores, and so do readers.**  Keys route to one
+   of 512 shards by `ShardIndex`, and each shard has its own lock, so
+   writes to different shards proceed in parallel.  Reads take every
+   lock shared, so readers of the *same* shard proceed in parallel
+   too: measured 107,000 gets/s with one reader and 976,000 with
+   sixteen on a store of 1,000 sealed segments.  Under the exclusive
+   lock reads used to take, a second reader halved throughput.
 
 Measured on the running database (see
 [Segments as storage](design/segment-store.md) for methodology):


### PR DESCRIPTION
Issue #50, from an 8-node Accumulate soak at 500 tx/s: the busiest node ran at ~110% CPU — one core, seven idle — while block time climbed from 3.0 s to 5.2 s, because every read in the process queued on one exclusive mutex whose hold time grew with the segment walk.

## What changed

Three things, because the lock was only the first wall:

1. **`SegmentStore.Mutex` and `KV2.Mutex` are `RWMutex`; readers take them shared.** Sealed segments are immutable and the pool hands out descriptors for `pread`, so a lookup against sealed data needs no lock at all; the shared lock exists only to keep the live map and segment list stable while a reader looks. Writers — append, seal, compact, merge, import, close — still take it exclusively. Two things had to follow: the stats counters are now atomics (a plain increment under a shared lock is a data race), and `BFile.ReadAt` uses `pread` — it was seek-then-read, two syscalls sharing one file offset, which interleaved between two readers hand each the other's bytes.

2. **The file pool is sharded 64 ways by path hash.** Once the store lock went shared, a mutex profile at eight readers put **100% of the remaining wait on the pool's single mutex** (acquire 69%, release 31%) — every lookup borrows an index and a data file through it. Each shard enforces a sixty-fourth of the limit.

3. **A share of zero caches nothing.** My first cut floored each shard at one file, which made the pool's real minimum 64 whatever `SetOpenFileLimit` asked for; `TestSegmentFDsStayBounded` caught it. A file in use is never evicted regardless of the limit, so no floor is needed to serve one.

## Measured

One store, 1,000 sealed segments (the soak's count), 100,000 keys, random `Get` from N goroutines:

| readers | exclusive lock (before) | shared lock, one pool | shared lock, sharded pool |
|---|---|---|---|
| 1 | 107,000/s | 120,000/s | 112,000/s |
| 2 | 50,000/s | 207,000/s | 205,000/s |
| 4 | 50,000/s | 142,000/s | 392,000/s |
| 8 | 53,000/s | 125,000/s | 668,000/s |
| 16 | 48,000/s | 131,000/s | **976,000/s** |

The first column is the soak in miniature: under the exclusive lock a second reader **halved** throughput and it never recovered — a lock convoy. The middle column is why the pool had to change too.

What remains on the read path is the walk itself: at 1,000 segments a hit probes 1,000 per-segment blooms (`Bloom.Test` was 25% of CPU). That is the segment count, which #53's packing collapses to one bloom per set — so the soak should already look different at `main`, and #44 addresses the rest.

## Verification

- `TestSegmentStoreReadsShareTheLock` / `TestKV2ReadsShareTheLock`: deterministic, not a timing — hold the lock shared from outside and call `Get`; under the old exclusive lock it blocks forever, so the harness timeout is the failure.
- `TestConcurrentReadersAndAWriter` under `-race`: eight readers against sealed data and the live tail while a writer appends and seals.
- Existing pool, iteration, FD-bound, and concurrency tests under `-race`: green.
- **Crash contract: 0 failures in 20 runs** (the `pread` change touches live-tail replay).
- Full `-short` suite green.

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKAh7mFDHChAtKQtJYP3a3