### PR TITLE
Split each store into an active tier and history, with a lock for each

### DIFF
--- a/database/blockset_test.go
+++ b/database/blockset_test.go
@@ -26,6 +26,7 @@ func packedFixture(t *testing.T, dir string, seed byte, blocks, perBlock int) (k
 	t.Cleanup(func() { os.RemoveAll(dir) })
 	kvs, err := NewKVShard(dir, 100_000) // High, so only block boundaries seal
 	require.NoError(t, err)
+	require.NoError(t, kvs.SetFilterBlocks(MinFilterBlocks))
 	kr := NewFastRandom([]byte{seed})
 	vr := NewFastRandom([]byte{seed, seed})
 	values = make(map[[32]byte][]byte)
@@ -46,13 +47,11 @@ func packedFixture(t *testing.T, dir string, seed byte, blocks, perBlock int) (k
 // shards are still serving from blocks below height
 func permSegmentsBelow(kvs *KVShard, height uint64) (n int) {
 	for _, sh := range kvs.Shards {
-		sh.PermKV.Mutex.Lock()
-		for _, seg := range sh.PermKV.segments {
+		for _, seg := range sh.PermKV.sealedSegments() {
 			if seg.meta.Height < height {
 				n++
 			}
 		}
-		sh.PermKV.Mutex.Unlock()
 	}
 	return n
 }
@@ -62,6 +61,9 @@ func permSegmentsBelow(kvs *KVShard, height uint64) (n int) {
 // below height
 func permDataFiles(t *testing.T, kvs *KVShard, height uint64) (n, below int) {
 	t.Helper()
+	for _, sh := range kvs.Shards { // Deletion is a goroutine's; let it finish first
+		sh.PermKV.awaitUnlinks()
+	}
 	for i := range kvs.Shards {
 		entries, err := os.ReadDir(filepath.Join(kvs.ShardDir(i), PermDirName))
 		require.NoError(t, err)
@@ -101,6 +103,7 @@ func checkEveryKey(t *testing.T, kvs *KVShard, keys [][32]byte, values map[[32]b
 func TestPackFinalizedLeavesOneFileAndEveryKey(t *testing.T) {
 	dir := filepath.Join(os.TempDir(), t.Name())
 	kvs, keys, values := packedFixture(t, dir, 181, 8, 100)
+	next := ageOutShards(t, kvs, 8) // Finalisation works on history
 
 	_, err := kvs.MergeFinalized(7)
 	require.NoError(t, err)
@@ -120,9 +123,14 @@ func TestPackFinalizedLeavesOneFileAndEveryKey(t *testing.T) {
 	assert.Equal(t, meta.File, entries[0].Name())
 
 	assert.Equal(t, 0, permSegmentsBelow(kvs, 7), "the shards must stop serving what the set holds")
+	// The drop is a history commit per shard, so the merged segments'
+	// files are gone; what stays is the merge inputs, which the active
+	// manifest still named when the merge replaced them, until each
+	// shard's next active commit
 	files, below := permDataFiles(t, kvs, 7)
-	assert.Equal(t, filesBefore, files, "the dropped files stay until the shards next commit a manifest")
-	assert.Equal(t, belowBefore, below)
+	assert.Less(t, files, filesBefore, "the drop retires the merged segments' files")
+	assert.Less(t, below, belowBefore)
+	assert.Greater(t, below, 0, "the merge inputs wait for the shards' next active commit")
 
 	checkEveryKey(t, kvs, keys, values, "after packing")
 
@@ -138,14 +146,15 @@ func TestPackFinalizedLeavesOneFileAndEveryKey(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, packed)
 
-	// The next block boundary commits the manifest of every shard that
-	// took a write, which is when that shard's dropped files are retired
+	// The next block boundary commits the active manifest of every
+	// shard that took a write, which is when that shard's merge inputs
+	// are retired
 	for i := 0; i < 200; i++ { // Enough to touch most shards
 		require.NoError(t, kvs.PutPerm(kr.NextHash(), []byte("v")))
 	}
-	require.NoError(t, kvs.SealBlock(9))
-	_, below = permDataFiles(t, kvs, 7)
-	assert.Less(t, below, belowBefore, "the shards' next manifest commit retires the packed files")
+	require.NoError(t, kvs.SealBlock(next))
+	_, belowAfter := permDataFiles(t, kvs, 7)
+	assert.Less(t, belowAfter, below, "the shards' next active commit retires the merge inputs")
 
 	// And a reopen finds it all from the set file
 	require.NoError(t, kvs.Close())
@@ -163,6 +172,7 @@ func TestPackFinalizedLeavesOneFileAndEveryKey(t *testing.T) {
 func TestPackFinalizedCountsFiles(t *testing.T) {
 	dir := filepath.Join(os.TempDir(), t.Name())
 	kvs, keys, values := packedFixture(t, dir, 183, 6, 2000)
+	next := ageOutShards(t, kvs, 6)
 
 	segs, _ := permDataFiles(t, kvs, 6)
 	_, err := kvs.MergeFinalized(6)
@@ -174,7 +184,7 @@ func TestPackFinalizedCountsFiles(t *testing.T) {
 	for i := 0; i < 2000; i++ { // Touch every shard, so every drop is committed
 		require.NoError(t, kvs.PutPerm(NewFastRandom([]byte{183, byte(i), byte(i >> 8)}).NextHash(), []byte("v")))
 	}
-	require.NoError(t, kvs.SealBlock(7)) // Commit the drops
+	require.NoError(t, kvs.SealBlock(next)) // Retire the merge inputs
 	_, after := permDataFiles(t, kvs, 6)
 	t.Logf("5 blocks x 2000 entries, below the watermark: %d segment files -> %d merged (%d files in all) -> %d left in shards + 1 set file",
 		segs, mergedBelow, merged, after)
@@ -193,6 +203,7 @@ func TestPackFinalizedCountsFiles(t *testing.T) {
 func TestPackFinalizedSurvivesACrashBeforeTheShardsCommit(t *testing.T) {
 	dir := filepath.Join(os.TempDir(), t.Name())
 	kvs, keys, values := packedFixture(t, dir, 184, 5, 80)
+	next := ageOutShards(t, kvs, 5)
 
 	_, err := kvs.MergeFinalized(5)
 	require.NoError(t, err)
@@ -200,10 +211,11 @@ func TestPackFinalizedSurvivesACrashBeforeTheShardsCommit(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, packed)
 	_, below := permDataFiles(t, kvs, 5)
-	require.Greater(t, below, 0, "the dropped segments' files are still on disk")
+	require.Greater(t, below, 0, "the merge inputs' files are still on disk: the active manifest names them")
 
-	// "Crash": reopen without closing.  The shards' manifests were not
-	// rewritten, so they still name the packed segments.
+	// "Crash": reopen without closing.  The shards' active manifests
+	// were not rewritten since before the merge, so they still name
+	// the merge inputs, whose keys the set also holds.
 	reopened, err := OpenKVShard(dir)
 	require.NoError(t, err)
 	sets := reopened.Sets.Sets()
@@ -217,9 +229,9 @@ func TestPackFinalizedSurvivesACrashBeforeTheShardsCommit(t *testing.T) {
 	for i := 0; i < 200; i++ { // Enough to touch most shards
 		require.NoError(t, reopened.PutPerm(kr.NextHash(), []byte("v")))
 	}
-	require.NoError(t, reopened.SealBlock(6))
+	require.NoError(t, reopened.SealBlock(next))
 	_, belowAfter := permDataFiles(t, reopened, 5)
-	assert.Less(t, belowAfter, below, "the next manifest commit retires the packed files")
+	assert.Less(t, belowAfter, below, "the next active commit retires the packed files")
 
 	// A clean close, then a clean open: still all there
 	require.NoError(t, reopened.Close())
@@ -230,16 +242,23 @@ func TestPackFinalizedSurvivesACrashBeforeTheShardsCommit(t *testing.T) {
 }
 
 // TestPackedKeysStayImmutable
-// The Perm layer refuses a different value for a key it holds.  That
-// check is answered by the shard's key filters first, and they do not
-// cover the keys that have left the segments for a set, so a write the
-// filters cannot place must go on to the sets before it is allowed --
-// including on a store whose filters were rebuilt from scratch on
-// open, from segments that no longer hold the key, which is the case
-// this test exists for.
+// The Perm layer refuses a different value for a key it holds inside
+// the window.  That check is answered by the shard's key filters
+// first, and they do not cover the keys that have left the segments
+// for a set, so a filter whose window reaches a set must be built
+// with the set's keys -- including on a store whose filters were
+// rebuilt from scratch on open, from segments that no longer hold the
+// key, which is the case this test exists for.
+//
+// Only history is packed, so a set lies below the window by
+// construction and a rebuilt filter normally has no set to add.  The
+// window reaches a set when it widens: a shard reopened with a block
+// behind the set's, or SetFilterBlocks raising N, which is what this
+// test uses.
 func TestPackedKeysStayImmutable(t *testing.T) {
 	dir := filepath.Join(os.TempDir(), t.Name())
 	kvs, keys, values := packedFixture(t, dir, 186, 4, 60)
+	ageOutShards(t, kvs, 4)
 
 	_, err := kvs.MergeFinalized(4)
 	require.NoError(t, err)
@@ -261,10 +280,25 @@ func TestPackedKeysStayImmutable(t *testing.T) {
 	reopened, err := OpenKVShard(dir)
 	require.NoError(t, err)
 	shard := reopened.Shards[ShardIndex(keys[0][:])]
-	require.Equal(t, 0, len(shard.PermKV.segments), "the packed key's shard holds it in no segment now")
+	require.Equal(t, 0, len(shard.PermKV.sealedSegments()), "the packed key's shard holds it in no segment now")
 
 	packedKey := keys[0]
 	other := append([]byte("changed-"), values[packedKey]...)
+
+	// As reopened, the window starts above the set: the packed key is
+	// older than the window, not consulted on write (issue #44), and
+	// the filters do not claim it
+	shard.PermKV.Mutex.RLock()
+	start, ok := shard.PermKV.windowStart()
+	claimed := shard.PermKV.filterTest(packedKey)
+	shard.PermKV.Mutex.RUnlock()
+	require.True(t, ok)
+	require.Greater(t, start, uint64(4), "the set lies below the window")
+	require.False(t, claimed, "a filter must not claim a key below its window")
+
+	// Widen the window until it reaches the set: the rebuilt filters
+	// must take the set's keys, or the packed key could be rewritten
+	require.NoError(t, shard.PermKV.SetFilterBlocks(100))
 
 	// PutPerm: a different value is refused, the same is a no-op
 	err = reopened.PutPerm(packedKey, other)
@@ -288,6 +322,7 @@ func TestPackedKeysStayImmutable(t *testing.T) {
 func TestForEachReachesPackedKeys(t *testing.T) {
 	dir := filepath.Join(os.TempDir(), t.Name())
 	kvs, keys, values := packedFixture(t, dir, 187, 6, 40)
+	ageOutShards(t, kvs, 6)
 
 	// Pack two sets in turn, so the second set is not the first, and
 	// leave block 6 unpacked
@@ -323,8 +358,11 @@ func TestRepeatedPacksKeepDeepEntriesReachable(t *testing.T) {
 	defer os.RemoveAll(dir)
 	kvs, err := NewKVShard(dir, 100_000)
 	require.NoError(t, err)
+	require.NoError(t, kvs.SetFilterBlocks(MinFilterBlocks))
 
-	const sets, setSize, perBlock = 6, 3, 30
+	// A set is N blocks, so that every set rolls the window once and
+	// the set before the window is what each pack finalises
+	const sets, setSize, perBlock = 6, MinFilterBlocks, 30
 	kr := NewFastRandom([]byte{188})
 	vr := NewFastRandom([]byte{188, 188})
 	var keys [][32]byte
@@ -348,7 +386,10 @@ func TestRepeatedPacksKeepDeepEntriesReachable(t *testing.T) {
 			require.NoError(t, err)
 			_, packed, err := kvs.PackFinalized(watermark)
 			require.NoError(t, err)
-			require.Truef(t, packed, "set %d", set)
+			// The first set is still inside the window at the end of
+			// the second; from the third on, each pack finalises the
+			// set the window has just rolled past
+			require.Equalf(t, set >= 1, packed, "set %d: packed=%v", set, packed)
 		}
 	}
 	metas := kvs.Sets.Sets()
@@ -397,6 +438,7 @@ func TestPackedBlocksRefuseAnImport(t *testing.T) {
 		_, err = nodeB.ImportBlock(filepath.Join(exportDir, fmt.Sprintf("block-%08d", h)))
 		require.NoError(t, err)
 	}
+	ageOutShards(t, nodeB, 3)
 	_, err = nodeB.MergeFinalized(4)
 	require.NoError(t, err)
 	_, packed, err := nodeB.PackFinalized(4)
@@ -429,6 +471,7 @@ func TestBlockSetHeaderIsChecked(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := filepath.Join(os.TempDir(), t.Name())
 			kvs, _, _ := packedFixture(t, dir, 192, 3, 20)
+			ageOutShards(t, kvs, 3)
 			_, err := kvs.MergeFinalized(3)
 			require.NoError(t, err)
 			meta, packed, err := kvs.PackFinalized(3)

--- a/database/crash_test.go
+++ b/database/crash_test.go
@@ -127,6 +127,13 @@ func TestCrashChildProcess(t *testing.T) {
 	for i := start; i < start+100_000; i++ {
 		require.NoError(t, crashPut(kv, i, kr.NextHash(), vr.RandBuff(10, 50)), "child: put")
 		if (i+1)%crashCompressEvery == 0 {
+			// Compaction works on history -- what the window of the last
+			// N to 2N blocks has rolled past -- and a child that lives
+			// for a few hundred puts never seals that many blocks, so
+			// the blocks are made to pass: everything the Dyna layer
+			// has sealed so far becomes history, and the compaction
+			// that follows is under the kill (issue #57)
+			kv.DynaKV.AdvanceBlock(kv.DynaKV.BlockHeight() + 3*MinFilterBlocks)
 			require.NoError(t, kv.Compress(), "child: compress")
 		}
 		if (i+1)%batch != 0 {
@@ -184,6 +191,7 @@ func runCrashRounds(t *testing.T, mode string) {
 	// design notes.)
 	kv, err := NewKV2(dir, crashSealLimit)
 	require.NoError(t, err)
+	require.NoError(t, kv.SetFilterBlocks(MinFilterBlocks)) // So the child can age the Dyna layer
 	require.NoError(t, kv.Close())
 
 	durable := 0
@@ -285,13 +293,15 @@ func crashDiagnose(kv *KV2, dir string, i int, key [32]byte) string {
 		store *SegmentStore
 	}{{"Perm", kv.PermKV}, {"Dyna", kv.DynaKV}} {
 		s := l.store
+		segs := s.sealedSegments()
 		s.Mutex.Lock()
 		_, inLive := s.live[key]
 		inFilter := s.filterTest(key)
-		fmt.Fprintf(&b, "%s: %d segments, live keys %d, records %d, blockHeight %d, filters=%d inLive=%v filterSays=%v\n",
-			l.name, len(s.segments), len(s.live), s.liveRecords, s.blockHeight,
+		fmt.Fprintf(&b, "%s: %d segments (%d active), live keys %d, records %d, blockHeight %d, filters=%d inLive=%v filterSays=%v\n",
+			l.name, len(segs), len(s.active), len(s.live), s.liveRecords, s.blockHeight,
 			len(s.filters), inLive, inFilter)
-		for _, seg := range s.segments {
+		s.Mutex.Unlock()
+		for _, seg := range segs {
 			dbb, found, err := seg.lookup(key)
 			mark := ""
 			if found {
@@ -303,7 +313,6 @@ func crashDiagnose(kv *KV2, dir string, i int, key [32]byte) string {
 			fmt.Fprintf(&b, "   seg (%d,%d) count=%d records=%d file=%s%s\n",
 				seg.meta.Height, seg.meta.Seq, seg.count, seg.records, seg.meta.File, mark)
 		}
-		s.Mutex.Unlock()
 	}
 
 	for _, sub := range []string{PermDirName, DynaDirName} {

--- a/database/degradation_test.go
+++ b/database/degradation_test.go
@@ -349,9 +349,7 @@ func degWriteCSV(t *testing.T, path string, samples []degSample) {
 
 // degSegCount is the number of sealed segments in a layer
 func degSegCount(s *SegmentStore) int {
-	s.Mutex.Lock()
-	defer s.Mutex.Unlock()
-	return len(s.segments)
+	return len(s.sealedSegments())
 }
 
 // degDirSize totals a directory tree, since a KV2 has a directory per layer

--- a/database/dyna_test.go
+++ b/database/dyna_test.go
@@ -1,6 +1,7 @@
 package blockchainDB
 
 import (
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -13,15 +14,31 @@ import (
 // dynaDir is the Dyna layer's directory within a KV2
 func dynaDir(kv2 *KV2) string { return filepath.Join(kv2.Directory, DynaDirName) }
 
+// ageOut
+// Advance a store's block far enough that every segment it has sealed
+// so far falls below the window and is handed to history: what a
+// mutable layer needs before CompactHistory has anything to compact,
+// since a record last written inside the window is the protocol's and
+// compaction never touches it (issue #57).
+func ageOut(t *testing.T, s *SegmentStore) {
+	t.Helper()
+	s.AdvanceBlock(s.BlockHeight() + 3*s.FilterBlocks)
+	s.Mutex.RLock()
+	defer s.Mutex.RUnlock()
+	require.Empty(t, s.active, "every sealed segment should now be history")
+}
+
 // TestDynaCompressReclaims
 // The Dyna layer accumulates trash as keys are overwritten, and
 // Compress reclaims it -- the property KV.Compress used to provide,
 // now by writing a new sealed generation instead of swapping the
-// values file in place.
+// values file in place.  What it reclaims is history: the segments
+// the window has rolled past.
 func TestDynaCompressReclaims(t *testing.T) {
 	dir := storeDir(t, "kv2")
 	kv2, err := NewKV2(dir, 500) // SealLimit 500 records
 	require.NoError(t, err)
+	require.NoError(t, kv2.SetFilterBlocks(MinFilterBlocks))
 
 	kr := NewFastRandom([]byte{201})
 	vr := NewFastRandom([]byte{201, 201})
@@ -39,13 +56,23 @@ func TestDynaCompressReclaims(t *testing.T) {
 			require.NoError(t, err)
 		}
 	}
-	require.Greater(t, len(kv2.DynaKV.segments), 1, "overwrites should have sealed several generations")
+	_, err = kv2.DynaKV.SealNext()
+	require.NoError(t, err)
+	require.Greater(t, len(kv2.DynaKV.sealedSegments()), 1, "overwrites should have sealed several generations")
 
+	// Nothing to reclaim while every generation is inside the window
 	sizeBefore := dirSize(t, dynaDir(kv2))
+	require.NoError(t, kv2.Compress())
+	require.Equal(t, sizeBefore, dirSize(t, dynaDir(kv2)), "a record inside the window is not compaction's to touch")
+
+	// Sealing blocks ages the Dyna layer: past 2N blocks the generations
+	// are history, and Compress folds them into one
+	for h := uint64(1); h <= 3*MinFilterBlocks; h++ {
+		_, err = kv2.Seal(h)
+		require.NoError(t, err)
+	}
 	require.NoError(t, kv2.Compress(), "compress")
-	sizeAfter := dirSize(t, dynaDir(kv2))
-	assert.Lessf(t, sizeAfter, sizeBefore/3, "space not reclaimed (%d -> %d)", sizeBefore, sizeAfter)
-	assert.Len(t, kv2.DynaKV.segments, 1, "compaction should leave one generation")
+	assert.Len(t, kv2.DynaKV.sealedSegments(), 1, "compaction should leave one generation")
 
 	for i := range keys {
 		v, err := kv2.Get(keys[i])
@@ -53,8 +80,14 @@ func TestDynaCompressReclaims(t *testing.T) {
 		assert.Equalf(t, latest[i], v, "key %d after compress", i)
 	}
 
-	// And across a reopen
+	// The generations it replaced were still named by the active
+	// manifest, as handoffs in flight, so their files wait for the
+	// next active commit; the close is one
 	require.NoError(t, kv2.Close())
+	sizeAfter := dirSize(t, dynaDir(kv2))
+	assert.Lessf(t, sizeAfter, sizeBefore/3, "space not reclaimed (%d -> %d)", sizeBefore, sizeAfter)
+
+	// And across a reopen
 	reopened, err := OpenKV2(dir)
 	require.NoError(t, err)
 	require.NoError(t, reopened.Open())
@@ -71,15 +104,13 @@ func TestDynaCompressReclaims(t *testing.T) {
 // must not lose anything either way.  KVShard compresses on a write
 // count, so a shard whose keys rarely repeat hits this path often.
 //
-// "Nothing to reclaim" now means Compress does nothing at all, rather
-// than sealing the tail and rewriting the single generation that
-// produced.  The seal was the reason it could not opt out: it added a
-// second segment, so the single-generation early-out never applied and
-// every call paid for a full rewrite of the layer (issue #31).
+// "Nothing to reclaim" means Compress does nothing at all: it never
+// seals the tail, and a single history segment is left as it is.
 func TestDynaCompressIsIdempotent(t *testing.T) {
 	dir := storeDir(t, "kv2")
 	kv2, err := NewKV2(dir, 1000)
 	require.NoError(t, err)
+	require.NoError(t, kv2.SetFilterBlocks(MinFilterBlocks))
 
 	kr := NewFastRandom([]byte{202})
 	vr := NewFastRandom([]byte{202, 202})
@@ -93,7 +124,7 @@ func TestDynaCompressIsIdempotent(t *testing.T) {
 
 	// Distinct keys, so not one record is superseded
 	require.NoError(t, kv2.Compress())
-	assert.Empty(t, kv2.DynaKV.segments,
+	assert.Empty(t, kv2.DynaKV.sealedSegments(),
 		"nothing was overwritten: Compress must not seal a generation in order to rewrite it")
 	for i := range keys {
 		v, err := kv2.Get(keys[i])
@@ -101,22 +132,26 @@ func TestDynaCompressIsIdempotent(t *testing.T) {
 		assert.Equal(t, values[i], v)
 	}
 
-	// Now overwrite every key enough times to be worth reclaiming
+	// Now overwrite every key enough times to be worth reclaiming, a
+	// generation per round, and age them out of the window
 	for round := 0; round < 3; round++ {
 		for i := range keys {
 			values[i] = vr.RandBuff(20, 100)
 			_, err = kv2.PutDyna(keys[i], values[i])
 			require.NoError(t, err)
 		}
+		_, err = kv2.DynaKV.SealNext()
+		require.NoError(t, err)
 	}
+	ageOut(t, kv2.DynaKV)
 	require.NoError(t, kv2.Compress())
-	require.Len(t, kv2.DynaKV.segments, 1, "three quarters of the layer is garbage: it must compact")
-	first := kv2.DynaKV.segments[0].meta
+	require.Len(t, kv2.DynaKV.sealedSegments(), 1, "three quarters of the layer is garbage: it must compact")
+	first := kv2.DynaKV.sealedSegments()[0].meta
 
 	// The generation just written has nothing superseded in it
 	require.NoError(t, kv2.Compress(), "second compress")
-	require.Len(t, kv2.DynaKV.segments, 1)
-	assert.Equal(t, first, kv2.DynaKV.segments[0].meta, "nothing to reclaim: the generation should stand as it is")
+	require.Len(t, kv2.DynaKV.sealedSegments(), 1)
+	assert.Equal(t, first, kv2.DynaKV.sealedSegments()[0].meta, "nothing to reclaim: the generation should stand as it is")
 
 	for i := range keys {
 		v, err := kv2.Get(keys[i])
@@ -173,6 +208,7 @@ func TestDynaCompressCrashMidway(t *testing.T) {
 	crashed := storeDir(t, "crashed")
 	kv2, err := NewKV2(dir, 200)
 	require.NoError(t, err)
+	require.NoError(t, kv2.SetFilterBlocks(MinFilterBlocks))
 
 	kr := NewFastRandom([]byte{204})
 	vr := NewFastRandom([]byte{204, 204})
@@ -190,7 +226,15 @@ func TestDynaCompressCrashMidway(t *testing.T) {
 	}
 	_, err = kv2.DynaKV.SealNext() // Everything reclaimable is sealed
 	require.NoError(t, err)
-	require.Greater(t, len(kv2.DynaKV.segments), 1)
+	ageOut(t, kv2.DynaKV) // ... and out of the window
+	require.Greater(t, len(kv2.DynaKV.sealedSegments()), 1)
+	// One more record, sealed inside the window, so the store has an
+	// active segment above everything the compaction will replace
+	_, err = kv2.PutDyna(keys[0], latest[0])
+	require.NoError(t, err)
+	_, err = kv2.DynaKV.SealNext()
+	require.NoError(t, err)
+	before := len(kv2.DynaKV.sealedSegments())
 
 	// Snapshot the pre-commit state, then compact for real.  Copying
 	// the compacted data file back over the snapshot reproduces
@@ -198,21 +242,32 @@ func TestDynaCompressCrashMidway(t *testing.T) {
 	// leaves behind: the new generation on disk, the manifest still
 	// naming the old one.
 	copyDir(t, dynaDir(kv2), crashed)
-	meta, err := kv2.DynaKV.CompactNext()
+	compacted, err := kv2.DynaKV.CompactHistory()
 	require.NoError(t, err)
-	copyFile(t, filepath.Join(dynaDir(kv2), meta.File), filepath.Join(crashed, meta.File))
+	require.True(t, compacted)
 	require.NoError(t, kv2.Close())
+	kv2.DynaKV.History.RLock()
+	require.Empty(t, kv2.DynaKV.history) // Closed; find the output on disk instead
+	kv2.DynaKV.History.RUnlock()
+	reopened, err := OpenSegmentStore(dynaDir(kv2))
+	require.NoError(t, err)
+	reopened.History.RLock()
+	require.Len(t, reopened.history, 1)
+	out := reopened.history[0].meta
+	reopened.History.RUnlock()
+	require.NoError(t, reopened.Close())
+	copyFile(t, filepath.Join(dynaDir(kv2), out.File), filepath.Join(crashed, out.File))
 
 	store, err := OpenSegmentStore(crashed)
 	require.NoError(t, err, "open after a crash mid-compaction")
 
-	// The compacted segment sits above every height the manifest names,
-	// so recovery adopts it rather than discarding it: it joins the old
-	// generation as the newest segment, and newest wins.  Nothing is
-	// lost either way -- what a crash here costs is the space the old
-	// generation still occupies, until the next compaction.
-	require.Len(t, store.segments, 4, "old generation plus the adopted compaction")
-	assert.Equal(t, meta.Height, store.segments[len(store.segments)-1].meta.Height)
+	// The compacted segment sits below the newest segment the manifests
+	// name -- the one sealed inside the window -- so recovery deletes
+	// it: the inputs it would have replaced are still named and still
+	// whole, and nothing is lost.  What the crash costs is the copy.
+	require.Len(t, store.sealedSegments(), before, "the old generations, and only those, after recovery")
+	_, err = os.Stat(filepath.Join(crashed, out.File))
+	assert.True(t, errors.Is(err, os.ErrNotExist), "an uncommitted compaction below the newest segment is swept")
 
 	for i := range keys {
 		v, err := store.Get(keys[i])
@@ -221,9 +276,10 @@ func TestDynaCompressCrashMidway(t *testing.T) {
 	}
 
 	// And compaction still converges from the recovered state
-	_, err = store.CompactNext()
+	compacted, err = store.CompactHistory()
 	require.NoError(t, err)
-	require.Len(t, store.segments, 1)
+	require.True(t, compacted)
+	require.Len(t, store.sealedSegments(), 2, "one compacted history segment plus the active one")
 	for i := range keys {
 		v, err := store.Get(keys[i])
 		require.NoErrorf(t, err, "key %d after recompaction", i)
@@ -303,57 +359,90 @@ func copyFile(t *testing.T, src, dst string) {
 	require.NoError(t, out.Sync())
 }
 
-// TestCompressEstimateSurvivesReopen
-// The estimate that decides whether Compress is worth running is
-// maintained as writes arrive.  It used to be process state, so a
-// reopened store believed it held no garbage whatever it actually
-// held, and would not compact until it had accumulated a threshold
-// fraction of the whole layer again in fresh overwrites (issue #40).
-func TestCompressEstimateSurvivesReopen(t *testing.T) {
+// TestCompressNeverTouchesTheWindow
+// A record last written inside the window -- the last N to 2N blocks
+// -- is the protocol's, and compaction never reads or rewrites it.
+// Only what has rolled out of the window is reclaimed, and a record in
+// history superseded by one still in the window waits until that one
+// has rolled out too.  This is the rule that bounds what a compaction
+// can cost a commit (issue #57).
+func TestCompressNeverTouchesTheWindow(t *testing.T) {
 	dir := storeDir(t, "kv2")
 	kv2, err := NewKV2(dir, 1000)
 	require.NoError(t, err)
+	require.NoError(t, kv2.SetFilterBlocks(MinFilterBlocks))
 
-	kr := NewFastRandom([]byte{204})
-	vr := NewFastRandom([]byte{204, 204})
+	kr := NewFastRandom([]byte{206})
+	vr := NewFastRandom([]byte{206, 206})
 	keys := make([][32]byte, 40)
+	values := make([][]byte, len(keys))
 	for i := range keys {
 		keys[i] = kr.NextHash()
-		_, err = kv2.PutDyna(keys[i], vr.RandBuff(20, 100))
-		require.NoError(t, err)
 	}
-	// Overwrite every one of them, so most of the layer is garbage
-	values := make([][]byte, len(keys))
+	// Three generations of every key, all sealed, then aged out
 	for round := 0; round < 3; round++ {
 		for i := range keys {
 			values[i] = vr.RandBuff(20, 100)
 			_, err = kv2.PutDyna(keys[i], values[i])
 			require.NoError(t, err)
 		}
+		_, err = kv2.DynaKV.SealNext()
+		require.NoError(t, err)
+	}
+	ageOut(t, kv2.DynaKV)
+	// Then half the keys rewritten inside the window, in two generations
+	for round := 0; round < 2; round++ {
+		for i := 0; i < len(keys)/2; i++ {
+			values[i] = vr.RandBuff(20, 100)
+			_, err = kv2.PutDyna(keys[i], values[i])
+			require.NoError(t, err)
+		}
+		_, err = kv2.DynaKV.SealNext()
+		require.NoError(t, err)
+	}
+	kv2.DynaKV.Mutex.RLock()
+	var active []SegmentMeta
+	for _, seg := range kv2.DynaKV.active {
+		active = append(active, seg.meta)
+	}
+	kv2.DynaKV.Mutex.RUnlock()
+	require.Len(t, active, 2, "two generations inside the window")
+
+	require.NoError(t, kv2.Compress())
+
+	kv2.DynaKV.Mutex.RLock()
+	for i, seg := range kv2.DynaKV.active {
+		assert.Equal(t, active[i], seg.meta, "a segment inside the window was rewritten")
+	}
+	kv2.DynaKV.Mutex.RUnlock()
+	kv2.DynaKV.History.RLock()
+	require.Len(t, kv2.DynaKV.history, 1, "the three aged-out generations compact to one")
+	hist := kv2.DynaKV.history[0]
+	kv2.DynaKV.History.RUnlock()
+	// Every key is still in history -- the rewrites inside the window
+	// shadow it but cannot reclaim it until they age out themselves
+	assert.Equal(t, int64(len(keys)), hist.count, "history keeps one record per key")
+
+	for i := range keys {
+		v, err := kv2.Get(keys[i])
+		require.NoErrorf(t, err, "key %d", i)
+		assert.Equal(t, values[i], v, "key %d resolved to the wrong generation", i)
 	}
 
-	// Seal, so the estimate reaches the manifest, then reopen
-	_, err = kv2.DynaKV.SealNext()
-	require.NoError(t, err)
-	before := kv2.DynaKV.shadowed
-	require.Greater(t, before, uint64(0), "the writes must have been counted as superseded")
-	require.NoError(t, kv2.Close())
-
-	reopened, err := OpenKV2(dir)
-	require.NoError(t, err)
-	require.NoError(t, reopened.Open())
-	assert.Equal(t, before, reopened.DynaKV.shadowed,
-		"the reopened store must know the garbage it holds")
-
-	// And it acts on it: a Compress right after reopening compacts,
-	// rather than waiting to re-accumulate the same garbage
-	require.NoError(t, reopened.Compress())
-	assert.Len(t, reopened.DynaKV.segments, 1, "a reopened store must still compact what it holds")
-
-	for i, key := range keys {
-		v, err := reopened.Get(key)
+	// Once the window has rolled past the rewrites, they reach history
+	// and the next compaction reclaims the copies they superseded
+	ageOut(t, kv2.DynaKV)
+	require.NoError(t, kv2.Compress())
+	kv2.DynaKV.History.RLock()
+	require.Len(t, kv2.DynaKV.history, 1)
+	hist = kv2.DynaKV.history[0]
+	kv2.DynaKV.History.RUnlock()
+	assert.Equal(t, int64(len(keys)), hist.count)
+	assert.Equal(t, hist.count, hist.records, "one record per key: the superseded copies are gone")
+	for i := range keys {
+		v, err := kv2.Get(keys[i])
 		require.NoErrorf(t, err, "key %d", i)
 		assert.Equal(t, values[i], v)
 	}
-	require.NoError(t, reopened.Close())
+	require.NoError(t, kv2.Close())
 }

--- a/database/filecache_test.go
+++ b/database/filecache_test.go
@@ -52,7 +52,7 @@ func TestSegmentFDsStayBounded(t *testing.T) {
 		_, err = store.Seal(uint64(i + 1))
 		require.NoError(t, err)
 	}
-	require.Len(t, store.segments, seals, "every seal must have produced a segment")
+	require.Len(t, store.sealedSegments(), seals, "every seal must have produced a segment")
 
 	after := openFDs(t)
 	growth := after - before

--- a/database/iterate.go
+++ b/database/iterate.go
@@ -37,16 +37,15 @@ import (
 // it is iterating.  It used to run under the store's lock for the
 // whole iteration, which made a callback that called Get deadlock and
 // made any callback block every other reader and writer for as long as
-// it ran (issue #31).
+// it ran (issue #31).  The snapshot itself reads each tier under its
+// own lock, one after the other, and pins the files first so that
+// nothing either tier retires meanwhile is deleted under the walk.
 func (s *SegmentStore) ForEach(fn func(key [32]byte, value []byte) error) (err error) {
-	s.Mutex.Lock()
-	segs, live, err := s.beginIterate()
-	cold := s.cold
-	s.Mutex.Unlock()
+	segs, live, cold, err := s.beginIterate()
 	if err != nil {
 		return err
 	}
-	defer s.endIterate()
+	defer s.unpin()
 
 	seen := make(map[[32]byte]struct{}, len(live))
 

--- a/database/iterate_test.go
+++ b/database/iterate_test.go
@@ -203,6 +203,7 @@ func TestForEachSurvivesConcurrentCompaction(t *testing.T) {
 	store, err := NewSegmentStore(dir, true)
 	require.NoError(t, err)
 	defer store.Close()
+	require.NoError(t, store.SetFilterBlocks(MinFilterBlocks))
 
 	kr := NewFastRandom([]byte{48})
 	keys := make([][32]byte, 400)
@@ -214,7 +215,8 @@ func TestForEachSurvivesConcurrentCompaction(t *testing.T) {
 			require.NoError(t, err)
 		}
 	}
-	require.Greater(t, len(store.segments), 1, "need several generations to compact away")
+	ageOut(t, store) // Compaction works on history: roll the window past them
+	require.Greater(t, len(store.sealedSegments()), 1, "need several generations to compact away")
 
 	compacted := make(chan error, 1)
 	var once sync.Once
@@ -224,7 +226,7 @@ func TestForEachSurvivesConcurrentCompaction(t *testing.T) {
 		if seen == 10 { // Well into the sealed segments
 			once.Do(func() {
 				go func() {
-					_, err := store.CompactNext()
+					_, err := store.CompactHistory()
 					compacted <- err
 				}()
 			})

--- a/database/keyfilter.go
+++ b/database/keyfilter.go
@@ -46,7 +46,7 @@ import (
 // is a windowed guarantee, a key written in the last N to 2N blocks
 // cannot be overwritten and older history is not consulted, because
 // the check is there for replay safety and a Perm key is the hash of
-// its value (SegmentStore.lookup).  A READ goes on below the window
+// its value (SegmentStore.Put).  A READ goes on below the window
 // and into the packed sets, each of which carries a filter of its own.
 //
 // The failure modes are still not symmetric.  A filter claiming a key it
@@ -113,9 +113,8 @@ func (m SegmentMeta) first() uint64 {
 // The starts of the filters live at block height t with roll period n:
 // the filter that began at the last multiple of n, and the one before
 // it, oldest first.  There is no "before" until the first roll, so a
-// store's first n blocks have one filter -- and a store whose block
-// never advances (the Dyna layer) keeps that one filter forever, over
-// everything, bounded by its own compaction.
+// store's first n blocks have one filter.  The oldest start is also
+// where the active tier ends and history begins (tierStart).
 func filterStarts(t, n uint64) (starts []uint64) {
 	current := t / n * n
 	if current >= n {
@@ -164,18 +163,18 @@ func (s *SegmentStore) windowStart() (start uint64, ok bool) {
 	return s.filters[0].start, true
 }
 
-// covered reports whether every block a segment holds lies inside the
-// window, so that the filters answer for it.  The caller must hold the
-// Mutex.
-func (s *SegmentStore) covered(seg *segment) bool {
-	start, ok := s.windowStart()
-	return ok && seg.meta.first() >= start
-}
-
 // SetFilterBlocks
 // Set the roll period N and record it in the manifest.  The live
 // filters are rebuilt for the new schedule, so this is meant to be
 // called when the store is created, before it holds much.
+//
+// N is also where the tiers divide (tierStart), so the segments are
+// re-tiered for it: a larger N pulls the newest history back into the
+// active tier, where the rebuilt filters must cover it -- a filter
+// claiming a block range while a segment inside that range sat in
+// history, uncovered, would answer "absent" for keys it never saw --
+// and a smaller N hands the oldest active segments to history as a
+// roll would.  Not the protocol path: it takes both locks.
 func (s *SegmentStore) SetFilterBlocks(n uint64) (err error) {
 	s.Mutex.Lock()
 	defer s.Mutex.Unlock()
@@ -189,6 +188,44 @@ func (s *SegmentStore) SetFilterBlocks(n uint64) (err error) {
 		return nil
 	}
 	s.FilterBlocks = n
+	start := s.tierStart()
+	s.History.Lock()
+	back := len(s.history)
+	for back > 0 && s.history[back-1].meta.first() >= start {
+		back--
+	}
+	if back < len(s.history) {
+		pulled := s.history[back:]
+		s.active = append(append([]*segment(nil), pulled...), s.active...)
+		s.history = append([]*segment(nil), s.history[:back]...)
+		if back > 0 {
+			s.historyNewest = s.history[back-1].meta
+		} else {
+			s.historyNewest, s.historyAny = SegmentMeta{}, false
+		}
+		// A segment pulled back is active again and the active manifest
+		// names it as such; any handoff entry it still had would name
+		// it a second time now and, once it is handed off again, leave
+		// a stale entry behind
+		s.handoffMu.Lock()
+		kept := s.handoffs[:0]
+		for _, h := range s.handoffs {
+			back := false
+			for _, seg := range pulled {
+				if h.seg == seg {
+					back = true
+				}
+			}
+			if !back {
+				kept = append(kept, h)
+			}
+		}
+		s.handoffs = kept
+		s.handoffMu.Unlock()
+		s.epoch++
+	}
+	s.History.Unlock()
+	s.handoffBelowWindow()
 	if err = s.rebuildKeyFilters(); err != nil {
 		return err
 	}
@@ -204,16 +241,18 @@ func checkFilterBlocks(n uint64) error {
 }
 
 // advanceBlock
-// Move the live tail on to a later block, and roll the filters to match.
-// Every change to blockHeight goes through here so that no path can
-// advance the block and leave the window behind.  The caller must hold
-// the Mutex.
+// Move the live tail on to a later block, roll the filters to match,
+// and hand the segments the window has left behind to history.  Every
+// change to blockHeight goes through here so that no path can advance
+// the block and leave the window -- or the tiers -- behind.  The
+// caller must hold the Mutex.
 func (s *SegmentStore) advanceBlock(height uint64) {
 	if height <= s.blockHeight {
 		return
 	}
 	s.blockHeight = height
 	s.rollKeyFilters()
+	s.handoffBelowWindow()
 }
 
 // rollKeyFilters
@@ -299,7 +338,7 @@ func (s *SegmentStore) rollKeyFilters() {
 // attachCold adds them.
 func (s *SegmentStore) buildKeyFilter(start, expected uint64) (f *keyFilter, err error) {
 	var held uint64
-	for _, seg := range s.segments {
+	for _, seg := range s.active {
 		if seg.meta.first() >= start {
 			held += uint64(seg.count)
 		}
@@ -309,7 +348,7 @@ func (s *SegmentStore) buildKeyFilter(start, expected uint64) (f *keyFilter, err
 		expected = held
 	}
 	f = &keyFilter{start: start, keys: s.newKeyFilter(expected)}
-	for _, seg := range s.segments {
+	for _, seg := range s.active { // Only the active tier can lie at or above a filter's start
 		if seg.meta.first() >= start {
 			if err = s.addSegmentKeys(f.keys, seg); err != nil {
 				return nil, err
@@ -377,7 +416,7 @@ func (s *SegmentStore) currentFilterClaim() (c filterClaim, ok bool) {
 		return c, false
 	}
 	c.Start = start
-	for _, seg := range s.segments {
+	for _, seg := range s.active {
 		if seg.meta.first() < start {
 			continue
 		}

--- a/database/keyfilter_test.go
+++ b/database/keyfilter_test.go
@@ -65,7 +65,7 @@ func TestKeyFilterNeverMissesAKey(t *testing.T) {
 		require.NoError(t, err)
 		mustFindAll(store, "after seal")
 	}
-	require.Greater(t, len(store.segments), 1, "the walk being skipped must be worth skipping")
+	require.Greater(t, len(store.sealedSegments()), 1, "the walk being skipped must be worth skipping")
 
 	// A tail on top of the sealed segments
 	write(20)
@@ -130,6 +130,7 @@ func TestKeyFilterSurvivesCompaction(t *testing.T) {
 	dir := storeDir(t, "s")
 	store, err := NewSegmentStore(dir, true)
 	require.NoError(t, err)
+	require.NoError(t, store.SetFilterBlocks(MinFilterBlocks))
 
 	kr := NewFastRandom([]byte{33})
 	keys := make([][32]byte, 100)
@@ -143,8 +144,10 @@ func TestKeyFilterSurvivesCompaction(t *testing.T) {
 		_, err = store.SealNext()
 		require.NoError(t, err)
 	}
-	_, err = store.CompactNext()
+	ageOut(t, store)
+	compacted, err := store.CompactHistory()
 	require.NoError(t, err)
+	require.True(t, compacted)
 
 	for i, key := range keys {
 		got, err := store.Get(key)
@@ -327,9 +330,9 @@ func TestKeyFilterEmptyDoesNotCoverSegmentZero(t *testing.T) {
 	}
 	_, err = store.SealNext()
 	require.NoError(t, err)
-	require.Len(t, store.segments, 1)
-	require.Equal(t, uint64(0), store.segments[0].meta.Height)
-	require.Equal(t, uint64(0), store.segments[0].meta.Seq, "the case only arises for segment (0,0)")
+	require.Len(t, store.sealedSegments(), 1)
+	require.Equal(t, uint64(0), store.sealedSegments()[0].meta.Height)
+	require.Equal(t, uint64(0), store.sealedSegments()[0].meta.Seq, "the case only arises for segment (0,0)")
 
 	// Now put the manifest back as it was before the seal: this is a
 	// crash after the segment file reached disk but before the manifest
@@ -338,7 +341,7 @@ func TestKeyFilterEmptyDoesNotCoverSegmentZero(t *testing.T) {
 
 	reopened, err := OpenSegmentStore(dir)
 	require.NoError(t, err)
-	require.Len(t, reopened.segments, 1, "the orphan segment must have been adopted")
+	require.Len(t, reopened.sealedSegments(), 1, "the orphan segment must have been adopted")
 
 	for i, key := range keys {
 		v, err := reopened.Get(key)
@@ -450,12 +453,16 @@ func filterStartsOf(s *SegmentStore) (starts []uint64) {
 // filters must not claim it unless they saw its oldest keys.
 //
 // After sealing 60 blocks with N=20 the filters cover blocks 40 on.
-// Merging the blocks below 50 makes one segment at height 49 reaching
-// back to block 1.  A filter that judged the segment by its height
-// alone would call it covered, answer "absent" for a key from block
-// 10, and skip the one segment that holds it: a false negative, with
-// nothing downstream to catch it.  Without SegmentMeta.Span this fails
-// with "key from block 1 went missing after the merge".
+// Merging the blocks below 50 merges the history below the window --
+// blocks 1-39 -- into one segment at height 39 reaching back to block
+// 1.  A filter that judged the segment by its height alone would
+// call it covered, answer "absent" for a key from block 10, and skip
+// the one segment that holds it: a false negative, with nothing
+// downstream to catch it.  Without SegmentMeta.Span this fails with
+// "key from block 1 went missing after the merge".  (With the tiers
+// of issue #57 a merged segment is history and never covered; the
+// span is still what says so on a reopen, when the tiers are placed
+// by each segment's oldest block.)
 func TestKeyFilterCoversAMergedSegmentByItsOldestBlock(t *testing.T) {
 	dir := storeDir(t, "span")
 	store, keys := rollingStore(t, dir, 63, 60, 5)
@@ -464,8 +471,8 @@ func TestKeyFilterCoversAMergedSegmentByItsOldestBlock(t *testing.T) {
 	_, merged, err := store.MergeBelow(50)
 	require.NoError(t, err)
 	require.True(t, merged)
-	require.Equal(t, uint64(49), store.segments[0].meta.Height)
-	require.Equal(t, uint64(1), store.segments[0].meta.first(), "the merged segment reaches back to block 1")
+	require.Equal(t, uint64(39), store.sealedSegments()[0].meta.Height)
+	require.Equal(t, uint64(1), store.sealedSegments()[0].meta.first(), "the merged segment reaches back to block 1")
 
 	find := func(s *SegmentStore, when string) {
 		t.Helper()

--- a/database/kv_2.go
+++ b/database/kv_2.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 )
 
 const PermDirName = "perm"
@@ -42,13 +43,24 @@ const DynaDirName = "dyna"
 // key/values are kept in one store.
 
 type KV2 struct {
-	Mutex     sync.RWMutex  // Writers exclusive, readers shared; KV2 methods are safe for concurrent use
+	// Mutex is the protocol's lock at this level: Put, PutPerm, PutDyna
+	// and Seal take it exclusively, Get and its variants shared.  The
+	// history maintenance -- MergeBelow and Compress -- does NOT take
+	// it: each layer has a lock of its own for history (SegmentStore.
+	// History), and holding this one for a merge or a compaction held
+	// every commit and read of the shard for the whole copy (issue #57).
+	Mutex     sync.RWMutex
 	Directory string        // Directory where the PermKV and DynaKV directories are
 	PermKV    *SegmentStore // The Perm layer: sealed, immutable segments
 	DynaKV    *SegmentStore // The Dyna layer: sealed, mutable segments
 	DWrites   int           // Number of writes to the DynaKV since the last compress
 	PWrites   int           // Number of writes to the PermKV since the last compress
 	SealLimit int           // Seal a layer when its live tail reaches this many records
+
+	// opened says both layers are open and SealLimit is set, so that
+	// Open -- which every operation calls first -- can say so without
+	// the lock.  Set at the end of Open and cleared by Close, under it.
+	opened atomic.Bool
 }
 
 // NewKV2
@@ -105,19 +117,25 @@ func NewKV2(directory string, sealLimit uint64) (kv2 *KV2, err error) {
 }
 
 // SetFilterBlocks
-// Set the roll period of the Perm layer's key filter -- the window,
-// N to 2N blocks, over which a permanent key cannot be overwritten
-// (keyfilter.go) -- and record it in the layer's manifest.  Meant for
-// the moment a database is created, since it rebuilds the layer's
-// filters and commits a manifest.  Below MinFilterBlocks is refused.
+// Set N for both layers: the roll period of the key filters -- the
+// window, N to 2N blocks, over which a permanent key cannot be
+// overwritten (keyfilter.go) -- and the line between the active tier
+// and history, which is what bounds the pause a commit can suffer from
+// maintenance (issue #57).  Recorded in each layer's manifest.  Meant
+// for the moment a database is created, since it rebuilds the filters
+// and commits a manifest per layer.  Below MinFilterBlocks is refused.
 //
-// Only the Perm layer.  The Dyna layer's block never advances, so its
-// filter never rolls whatever the period, and its reach is bounded by
-// compaction instead.
+// The Dyna layer takes the same N.  Its block advances with every
+// Seal, so its window rolls like Perm's, and a dynamic record that
+// left the window more than N to 2N blocks ago is history -- which is
+// what makes it reclaimable without touching the protocol's tier.
 func (k *KV2) SetFilterBlocks(n uint64) (err error) {
 	k.Mutex.Lock()
 	defer k.Mutex.Unlock()
-	return k.PermKV.SetFilterBlocks(n)
+	if err = k.PermKV.SetFilterBlocks(n); err != nil {
+		return err
+	}
+	return k.DynaKV.SetFilterBlocks(n)
 }
 
 func OpenKV2(directory string) (kv2 *KV2, err error) {
@@ -135,6 +153,12 @@ func OpenKV2(directory string) (kv2 *KV2, err error) {
 }
 
 func (k *KV2) Open() error {
+	// Every operation on a shard calls this first, the maintenance
+	// included, so an open database answers without the lock: a merge
+	// waiting here behind a seal would be waiting on the protocol
+	if k.opened.Load() {
+		return nil
+	}
 	k.Mutex.Lock()
 	defer k.Mutex.Unlock()
 	if err := k.PermKV.Open(); err != nil {
@@ -149,7 +173,11 @@ func (k *KV2) Open() error {
 			k.SealLimit = int(DefaultBloomCapacity)
 		}
 	}
-	return k.DynaKV.Open()
+	if err := k.DynaKV.Open(); err != nil {
+		return err
+	}
+	k.opened.Store(true)
+	return nil
 }
 
 // Close
@@ -165,6 +193,7 @@ func (k *KV2) Open() error {
 func (k *KV2) Close() error {
 	k.Mutex.Lock()
 	defer k.Mutex.Unlock()
+	k.opened.Store(false)
 	err := k.PermKV.Close()
 	if dynaErr := k.DynaKV.Close(); err == nil {
 		err = dynaErr
@@ -281,6 +310,15 @@ func (k *KV2) sealDynaIfFull() (err error) {
 // Both layers are advanced before either error is returned, so a
 // failure to sync Dyna does not leave Perm unsealed and the block
 // unrepeatable.
+//
+// The Dyna layer is also told the block, so that it ages.  Its
+// segments are tagged with the block they were sealed in and its
+// window rolls with Perm's, which is what puts a dynamic record that
+// has not been rewritten for 2N blocks into history, where
+// CompactHistory can reclaim what superseded it without touching the
+// tier a commit writes (issue #57).  No manifest is written for it:
+// the next Dyna seal records the block, and a reopened layer that is
+// a few blocks behind simply hands the same segments off again.
 func (k *KV2) Seal(height uint64) (meta SegmentMeta, err error) {
 	k.Mutex.Lock()
 	defer k.Mutex.Unlock()
@@ -288,20 +326,23 @@ func (k *KV2) Seal(height uint64) (meta SegmentMeta, err error) {
 	if syncErr := k.DynaKV.Sync(); err == nil {
 		err = syncErr
 	}
+	k.DynaKV.AdvanceBlock(height + 1)
 	return meta, err
 }
 
 // MergeBelow
-// Merge the Perm layer's sealed segments below a block height into one.
-// Reports whether anything was merged.
+// Merge the Perm layer's history segments below a block height into
+// one.  Reports whether anything was merged.
 //
-// Only the Perm layer.  The Dyna layer already has Compress, which
-// merges for a different reason -- to reclaim what overwriting left
-// behind -- and its segments are local, so their count is bounded by
-// how often it compacts rather than by the chain's length.
+// Only the Perm layer.  The Dyna layer has Compress, which merges for
+// a different reason -- to reclaim what overwriting left behind.
+//
+// The KV2 lock is NOT taken.  A merge is a history operation: it reads
+// immutable segments with no lock, writes the merged segment aside,
+// and takes the Perm layer's history lock to swap them.  Holding the
+// KV2 lock here held every Put, Get and Seal of the shard for the
+// whole copy, which is the pause issue #57 measures.
 func (k *KV2) MergeBelow(height uint64) (meta SegmentMeta, merged bool, err error) {
-	k.Mutex.Lock()
-	defer k.Mutex.Unlock()
 	return k.PermKV.MergeBelow(height)
 }
 
@@ -352,19 +393,32 @@ func (k *KV2) Put(key [32]byte, value []byte) (writes int, err error) {
 }
 
 // Compress
-// Reclaim the space the Dyna layer's overwrites left behind: seal its
-// live tail, then replace every sealed generation with one segment
-// holding only the keys still reachable.  The Perm layer is not
-// compacted -- its values are immutable, so none of them are trash.
+// Reclaim the space the Dyna layer's overwrites left behind, in the
+// part of the layer the protocol no longer touches: compact the run of
+// history segments that is worth compacting (SegmentStore.CompactHistory)
+// into one holding only the newest record per key.  The Perm layer is
+// not compacted -- its values are immutable, so none of them are trash.
 //
-// This is crash-atomic.  The compacted generation is fully durable
-// before the manifest names it, so there is no window in which keys
-// and values disagree (issue #19); a crash before the commit costs
-// only the space the old generation still occupies, which the next
-// compaction reclaims.  The v1 kfile Compress this replaced swapped
-// the values file and rewrote the key offsets as two separate steps,
-// and a crash between them left keys pointing into the wrong layout --
-// reads returned wrong bytes with no error.
+// Neither the KV2 lock nor the Dyna layer's store lock is taken.  The
+// records compaction touches are the ones that left the window of the
+// last N to 2N blocks; what the window holds -- the live tail and the
+// active segments -- is the protocol's, and a record last written
+// there is never read or rewritten here.  So a commit runs during a
+// compaction as it does at any other time, and the pause a compaction
+// can cause is the history swap, bounded by nothing that grows with
+// the chain.  It used to seal the tail and rewrite every generation
+// under both locks once a garbage ratio was crossed, and that stopped
+// every commit and read on the node for 12 s at block 400 and up to
+// 32 s at block 1,040 (issue #57).
+//
+// This is crash-atomic.  The compacted segment is fully durable
+// before the history manifest names it, so there is no window in
+// which keys and values disagree (issue #19); a crash before the
+// commit costs only the space of a file recoverOrphans deletes.  The
+// v1 kfile Compress this replaced swapped the values file and rewrote
+// the key offsets as two separate steps, and a crash between them
+// left keys pointing into the wrong layout -- reads returned wrong
+// bytes with no error.
 //
 // A key written to Dyna keeps a stale copy in Perm, which compaction
 // does not remove; Get resolves the layer order, so the copy is dead
@@ -372,35 +426,12 @@ func (k *KV2) Put(key [32]byte, value []byte) (writes int, err error) {
 //
 // TODO: Cleanse PermKV of keys in DynaKV
 func (k *KV2) Compress() error {
+	if _, err := k.DynaKV.CompactHistory(); err != nil {
+		return err
+	}
 	k.Mutex.Lock()
-	defer k.Mutex.Unlock()
-
-	// Do nothing unless there is enough garbage to be worth a rewrite
-	// of the layer.  A caller drives this on a cadence -- every K
-	// commits -- and the cadence says when to *consider* compacting,
-	// not that a compaction is due: obeying it literally cost O(N) per
-	// call and O(N × commits/K) over a run, so reclaiming a fixed
-	// amount of garbage got more expensive the larger the database grew
-	// (issue #31).
-	//
-	// The seal is inside the check for the same reason.  Sealing first
-	// and then compacting is what made compaction unable to opt out:
-	// the seal had already added a second segment, so the
-	// single-generation early-out never applied.
-	k.DynaKV.Mutex.Lock()
-	worth := k.DynaKV.worthCompacting(CompactRatio)
-	k.DynaKV.Mutex.Unlock()
-	if !worth {
-		return nil
-	}
-
-	if _, err := k.DynaKV.SealNext(); err != nil { // Everything to reclaim must be sealed
-		return err
-	}
-	if _, err := k.DynaKV.CompactNext(); err != nil {
-		return err
-	}
 	k.DWrites = 0 // Clear write counts
 	k.PWrites = 0
+	k.Mutex.Unlock()
 	return nil
 }

--- a/database/kv_2_test.go
+++ b/database/kv_2_test.go
@@ -166,7 +166,7 @@ func TestKV2BlockSealAfterAutoSeals(t *testing.T) {
 		_, err = kv.PutPerm(keys[i], []byte("v"))
 		require.NoError(t, err)
 	}
-	require.Greater(t, len(kv.PermKV.segments), 1, "the tail must have auto-sealed for this to test anything")
+	require.Greater(t, len(kv.PermKV.sealedSegments()), 1, "the tail must have auto-sealed for this to test anything")
 
 	_, err = kv.Seal(1)
 	require.NoError(t, err, "the first block boundary must be sealable after auto-seals")

--- a/database/kv_shard.go
+++ b/database/kv_shard.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 )
 
 const NumShards = 512
@@ -27,9 +28,10 @@ func ShardIndex(key []byte) int {
 // Concurrency: KVShard methods are safe for concurrent use.  The Shards
 // array is fixed after creation, and each KV2 serializes access with its
 // own mutex - so operations on different shards run in parallel, while
-// operations on the same shard are serialized.  (BFile and SegmentStore
-// are NOT safe for concurrent use on their own; they rely on the KV2
-// lock when accessed through this layer.)
+// operations on the same shard are serialized.  The finalisation
+// methods -- MergeFinalized, PackFinalized, Compress -- take no
+// shard's store lock: they work on history, under each store's own
+// history lock, and run alongside the commits (issue #57).
 type KVShard struct {
 	Directory string
 	Shards    [NumShards]*KV2
@@ -88,8 +90,8 @@ func OpenKVShard(directory string) (kVShard *KVShard, err error) {
 		return nil, err
 	}
 	// A shard still naming segments a committed set already holds was
-	// interrupted between the set's commit and its own next manifest;
-	// drop them again, and that next manifest retires them
+	// interrupted between the set's commit and its own drop; drop them
+	// again, which commits and retires them
 	if newest, ok := kVShard.Sets.Newest(); ok {
 		for i, shard := range kVShard.Shards {
 			if _, err = shard.PermKV.DropBelow(newest.Last + 1); err != nil {
@@ -134,11 +136,12 @@ func NewKVShard(directory string, sealLimit uint64) (kvs *KVShard, err error) {
 }
 
 // SetFilterBlocks
-// Set the key filter's roll period on every shard: the window, N to 2N
-// blocks, over which a permanent key cannot be overwritten
-// (keyfilter.go).  A creation-time call -- it commits a manifest per
-// shard, two barriers each -- and a period below MinFilterBlocks is
-// refused before any shard is touched.
+// Set N on every shard, both layers: the key filters' roll period --
+// the window, N to 2N blocks, over which a permanent key cannot be
+// overwritten (keyfilter.go) -- and the line between the active tier
+// and history (issue #57).  A creation-time call -- it commits a
+// manifest per layer per shard, two barriers each -- and a period
+// below MinFilterBlocks is refused before any shard is touched.
 func (k *KVShard) SetFilterBlocks(n uint64) (err error) {
 	if err = checkFilterBlocks(n); err != nil {
 		return err
@@ -329,8 +332,14 @@ func (k *KVShard) adoptBlockHeight() error {
 		return nil
 	}
 	for _, shard := range k.Shards {
-		if shard != nil && shard.PermKV != nil {
+		if shard == nil {
+			continue
+		}
+		if shard.PermKV != nil {
 			shard.PermKV.AdvanceBlock(height)
+		}
+		if shard.DynaKV != nil { // So that its window is where the set's is
+			shard.DynaKV.AdvanceBlock(height)
 		}
 	}
 	return nil
@@ -430,9 +439,13 @@ func (k *KVShard) MergeFinalized(height uint64) (mergedShards int, err error) {
 // then deletes the files, so a crash in between costs the space of the
 // segments until that seal (DropBelow).
 //
-// Not safe to run concurrently with MergeFinalized at the same
-// watermark: the merge retires the segments this is copying.  Drive
-// both from one scheduler, in order.
+// Only HISTORY is packed -- a segment still inside a shard's window
+// is the protocol's -- so a watermark inside the window packs what
+// has rolled out of it and no more; the rest follows once it has.  No
+// shard's store lock is taken: the segments are read pinned, so a
+// merge that commits meanwhile leaves their files readable until the
+// pack is done, and whichever of the two lands first, the drop that
+// follows removes what the set holds.
 func (k *KVShard) PackFinalized(height uint64) (meta SetMeta, packed bool, err error) {
 	if newest, ok := k.Sets.Newest(); ok && height <= newest.Last+1 {
 		return meta, false, nil // Everything below is already packed
@@ -443,9 +456,11 @@ func (k *KVShard) PackFinalized(height uint64) (meta SetMeta, packed bool, err e
 		if err = shard.Open(); err != nil {
 			return meta, false, fmt.Errorf("shard %d: %w", i, err)
 		}
-		if shards[i], err = shard.PermKV.segmentsBelow(height); err != nil {
+		var release func()
+		if shards[i], release, err = shard.PermKV.historyBelow(height); err != nil {
 			return meta, false, fmt.Errorf("shard %d: %w", i, err)
 		}
+		defer release()
 		for _, seg := range shards[i] {
 			if h := seg.meta.Height; !any || h > last {
 				last = h
@@ -469,13 +484,33 @@ func (k *KVShard) PackFinalized(height uint64) (meta SetMeta, packed bool, err e
 		return meta, false, err
 	}
 	// Committed.  The shards can stop serving what the set now holds.
+	// Each drop is a history commit of its own -- two barriers -- so
+	// they run concurrently and the barriers overlap on the device:
+	// what took 512 seals' worth of fsync in series takes a few dozen.
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	slots := make(chan struct{}, packDropWorkers)
 	for i, shard := range k.Shards {
-		if _, dropErr := shard.PermKV.DropBelow(height); dropErr != nil && err == nil {
-			err = fmt.Errorf("shard %d: %w", i, dropErr)
-		}
+		wg.Add(1)
+		slots <- struct{}{}
+		go func(i int, shard *KV2) {
+			defer wg.Done()
+			defer func() { <-slots }()
+			if _, dropErr := shard.PermKV.DropBelow(height); dropErr != nil {
+				mu.Lock()
+				if err == nil {
+					err = fmt.Errorf("shard %d: %w", i, dropErr)
+				}
+				mu.Unlock()
+			}
+		}(i, shard)
 	}
+	wg.Wait()
 	return set.meta, true, err
 }
+
+// packDropWorkers is how many shards PackFinalized drops at once
+const packDropWorkers = 16
 
 // Compress
 // Compress all the shards

--- a/database/merge_test.go
+++ b/database/merge_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,6 +20,7 @@ func TestMergeBelowKeepsEveryKeyAndCutsFiles(t *testing.T) {
 	dir := storeDir(t, "merge")
 	store, err := NewSegmentStore(dir, false)
 	require.NoError(t, err)
+	require.NoError(t, store.SetFilterBlocks(MinFilterBlocks))
 
 	kr := NewFastRandom([]byte{171})
 	const blocks = 20
@@ -36,17 +38,22 @@ func TestMergeBelowKeepsEveryKeyAndCutsFiles(t *testing.T) {
 		_, err = store.Seal(h)
 		require.NoError(t, err)
 	}
-	require.Len(t, store.segments, blocks, "one segment per block before merging")
+	require.Len(t, store.sealedSegments(), blocks, "one segment per block before merging")
+
+	// A merge works on history, so roll the window past every block
+	// (a merge below a watermark still inside the window waits until
+	// the window has passed it)
+	ageOut(t, store)
 
 	// Finalise everything below block 20, leaving the newest alone
 	meta, merged, err := store.MergeBelow(20)
 	require.NoError(t, err)
 	require.True(t, merged, "19 segments below the watermark must merge")
-	assert.Len(t, store.segments, 2, "19 merged into 1, plus the segment at block 20")
+	assert.Len(t, store.sealedSegments(), 2, "19 merged into 1, plus the segment at block 20")
 	assert.Equal(t, uint64(19*perBlock), meta.Count, "the merged segment holds every key below the watermark")
 
 	// The merged segment must order before what was left standing
-	assert.True(t, store.segments[1].meta.after(store.segments[0].meta),
+	assert.True(t, store.sealedSegments()[1].meta.after(store.sealedSegments()[0].meta),
 		"the merged segment must still order before the segments it did not replace")
 
 	// Every key still reads back, from a segment that no longer exists
@@ -56,22 +63,23 @@ func TestMergeBelowKeepsEveryKeyAndCutsFiles(t *testing.T) {
 		assert.Equal(t, values[key], string(v))
 	}
 
-	// The files the merge replaced are gone
+	// And it survives a reopen: the manifest names the merged segment.
+	// The files the merge replaced are gone by then: the active
+	// manifest still named them as handoffs in flight, and the close
+	// is the active commit that stops naming them and deletes them.
+	require.NoError(t, store.Close())
 	segFiles := 0
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
 	for _, e := range entries {
-		if filepath.Ext(e.Name()) == segDataSuffix {
+		if e.Name() == segLiveName || (strings.HasPrefix(e.Name(), segFilePrefix) && filepath.Ext(e.Name()) == segDataSuffix) {
 			segFiles++
 		}
 	}
-	assert.Equal(t, 3, segFiles, "2 sealed segments plus live.dat")
-
-	// And it survives a reopen: the manifest names the merged segment
-	require.NoError(t, store.Close())
+	assert.Equal(t, 3, segFiles, "2 sealed segments plus live.dat: %v", entries)
 	reopened, err := OpenSegmentStore(dir)
 	require.NoError(t, err)
-	require.Len(t, reopened.segments, 2)
+	require.Len(t, reopened.sealedSegments(), 2)
 	for i, key := range keys {
 		v, err := reopened.Get(key)
 		require.NoErrorf(t, err, "key %d lost across the reopen", i)
@@ -88,6 +96,7 @@ func TestMergeBelowLeavesTheWatermarkAlone(t *testing.T) {
 	store, err := NewSegmentStore(dir, false)
 	require.NoError(t, err)
 	defer store.Close()
+	require.NoError(t, store.SetFilterBlocks(MinFilterBlocks))
 
 	kr := NewFastRandom([]byte{172})
 	for h := uint64(1); h <= 10; h++ {
@@ -95,6 +104,7 @@ func TestMergeBelowLeavesTheWatermarkAlone(t *testing.T) {
 		_, err = store.Seal(h)
 		require.NoError(t, err)
 	}
+	ageOut(t, store)
 
 	_, merged, err := store.MergeBelow(6)
 	require.NoError(t, err)
@@ -102,18 +112,29 @@ func TestMergeBelowLeavesTheWatermarkAlone(t *testing.T) {
 
 	// Blocks 6..10 must still be individually present
 	heights := map[uint64]bool{}
-	for _, seg := range store.segments {
+	for _, seg := range store.sealedSegments() {
 		heights[seg.meta.Height] = true
 	}
 	for h := uint64(6); h <= 10; h++ {
 		assert.Truef(t, heights[h], "block %d is at or above the watermark and must not be merged", h)
 	}
-	assert.Len(t, store.segments, 6, "blocks 1-5 merged into one, 6..10 left standing")
+	assert.Len(t, store.sealedSegments(), 6, "blocks 1-5 merged into one, 6..10 left standing")
 
 	// Merging again changes nothing: only one segment is below 6 now
 	_, merged, err = store.MergeBelow(6)
 	require.NoError(t, err)
 	assert.False(t, merged, "a single segment below the watermark is not worth merging")
+}
+
+// ageOutShards
+// Close a run of empty blocks so that every block up to `last` falls
+// below every shard's window and is handed to history -- what
+// finalisation works on.  Returns the next block the set will seal.
+func ageOutShards(t *testing.T, kvs *KVShard, last uint64) (next uint64) {
+	t.Helper()
+	next = last + 3*MinFilterBlocks
+	require.NoError(t, kvs.SealBlock(next))
+	return next + 1
 }
 
 // TestMergeFinalizedAcrossShards
@@ -125,6 +146,7 @@ func TestMergeFinalizedAcrossShards(t *testing.T) {
 
 	kvs, err := NewKVShard(dir, 100_000) // High, so only block boundaries seal
 	require.NoError(t, err)
+	require.NoError(t, kvs.SetFilterBlocks(MinFilterBlocks))
 
 	kr := NewFastRandom([]byte{173})
 	vr := NewFastRandom([]byte{173, 173})
@@ -140,10 +162,11 @@ func TestMergeFinalizedAcrossShards(t *testing.T) {
 		}
 		require.NoError(t, kvs.SealBlock(h))
 	}
+	ageOutShards(t, kvs, 8) // A merge works on history: roll the window past the blocks
 
 	before := 0
 	for _, sh := range kvs.Shards {
-		before += len(sh.PermKV.segments)
+		before += len(sh.PermKV.sealedSegments())
 	}
 
 	mergedShards, err := kvs.MergeFinalized(7)
@@ -152,7 +175,7 @@ func TestMergeFinalizedAcrossShards(t *testing.T) {
 
 	after := 0
 	for _, sh := range kvs.Shards {
-		after += len(sh.PermKV.segments)
+		after += len(sh.PermKV.sealedSegments())
 	}
 	assert.Less(t, after, before, "merging must reduce the segment count (%d -> %d)", before, after)
 
@@ -182,6 +205,7 @@ func TestMergeDoesNotDisturbBlockExport(t *testing.T) {
 
 	nodeA, err := NewKVShard(dirA, 100_000)
 	require.NoError(t, err)
+	require.NoError(t, nodeA.SetFilterBlocks(MinFilterBlocks))
 
 	kr := NewFastRandom([]byte{174})
 	vr := NewFastRandom([]byte{174, 174})
@@ -203,7 +227,10 @@ func TestMergeDoesNotDisturbBlockExport(t *testing.T) {
 	}
 
 	// Now finalise the blocks a peer has already taken: both stages, so
-	// blocks 1-4 leave the shards altogether for a block-set file
+	// blocks 1-4 leave the shards altogether for a block-set file.
+	// Finalisation works on history, so first the window rolls past
+	// them, which closes a run of empty blocks.
+	next := ageOutShards(t, nodeA, 6)
 	mergedShards, err := nodeA.MergeFinalized(5)
 	require.NoError(t, err)
 	require.Greater(t, mergedShards, 0, "the merge must have done something for this to test anything")
@@ -219,14 +246,14 @@ func TestMergeDoesNotDisturbBlockExport(t *testing.T) {
 		keys = append(keys, key)
 		values[key] = val
 	}
-	_, err = nodeA.ExportBlock(exportDir, 7, prev)
+	_, err = nodeA.ExportBlock(exportDir, next, prev)
 	require.NoError(t, err)
 
 	// A fresh node syncs from the exported blocks and gets everything
 	nodeB, err := NewKVShard(dirB, 100_000)
 	require.NoError(t, err)
 	var total uint64
-	for h := 1; h <= 7; h++ {
+	for _, h := range []uint64{1, 2, 3, 4, 5, 6, next} {
 		n, err := nodeB.ImportBlock(filepath.Join(exportDir, fmt.Sprintf("block-%08d", h)))
 		require.NoErrorf(t, err, "import block %d after a merge on the exporting node", h)
 		total += n
@@ -251,9 +278,10 @@ func TestRepeatedMergesKeepDeepEntriesReachable(t *testing.T) {
 	dir := storeDir(t, "deep")
 	store, err := NewSegmentStore(dir, false)
 	require.NoError(t, err)
+	require.NoError(t, store.SetFilterBlocks(MinFilterBlocks))
 
-	const sets = 8    // Eight completed block sets
-	const setSize = 5 // Blocks per set, standing in for N
+	const sets = 8                  // Eight completed block sets
+	const setSize = MinFilterBlocks // Blocks per set: N, so each set rolls the window once
 	const perBlock = 10
 
 	kr := NewFastRandom([]byte{175})
@@ -278,12 +306,15 @@ func TestRepeatedMergesKeepDeepEntriesReachable(t *testing.T) {
 			require.NoError(t, err)
 		}
 		// Finalise every set but the one just written, so each merge
-		// after the first folds in what the previous merge produced
+		// after the first folds in what the previous merge produced.  A
+		// merge works on history -- what the window, N to 2N blocks, has
+		// rolled past -- so the first set has nothing to merge and every
+		// later one merges the set before the one the window still holds.
 		watermark := block - uint64(setSize) + 1
 		if watermark > 1 {
 			_, merged, err := store.MergeBelow(watermark)
 			require.NoErrorf(t, err, "merge after set %d", set)
-			require.Truef(t, merged, "set %d should have merged", set)
+			require.Equalf(t, set >= 1, merged, "set %d: merged=%v", set, merged)
 		}
 	}
 
@@ -312,7 +343,7 @@ func TestRepeatedMergesKeepDeepEntriesReachable(t *testing.T) {
 		require.Equal(t, e.value, string(v))
 	}
 	t.Logf("%d entries over %d blocks, %d merges, %d segments standing",
-		len(all), block, sets-1, len(reopened.segments))
+		len(all), block, sets-1, len(reopened.sealedSegments()))
 	require.NoError(t, reopened.Close())
 }
 
@@ -361,12 +392,12 @@ func TestRejectedImportIsNotAdoptedAfterACrash(t *testing.T) {
 
 	err = dst.ImportSegmentFile(segPath, metas[0])
 	require.Error(t, err, "a conflicting segment must be refused")
-	require.Empty(t, dst.segments, "nothing may be adopted by a refused import")
+	require.Empty(t, dst.sealedSegments(), "nothing may be adopted by a refused import")
 
 	// Reopen without closing: recovery sees whatever the refusal left
 	reopened, err := OpenSegmentStore(dstDir)
 	require.NoError(t, err)
-	assert.Empty(t, reopened.segments,
+	assert.Empty(t, reopened.sealedSegments(),
 		"recovery adopted the segment whose import was refused")
 
 	v, err := reopened.Get(key)

--- a/database/segment_test.go
+++ b/database/segment_test.go
@@ -51,8 +51,8 @@ func TestSegmentRoundTrip(t *testing.T) {
 	// Confirm the premise: some shard really did auto-seal
 	autoSealed := 0
 	for _, sh := range nodeA.Shards {
-		if len(sh.PermKV.segments) > 0 {
-			autoSealed += len(sh.PermKV.segments)
+		if len(sh.PermKV.sealedSegments()) > 0 {
+			autoSealed += len(sh.PermKV.sealedSegments())
 		}
 	}
 	require.Greater(t, autoSealed, 0, "no shard auto-sealed; the test would not exercise issue #27")
@@ -295,7 +295,7 @@ func TestQuietShardKeepsItsBlockAcrossAReopen(t *testing.T) {
 		keys[i] = keyForShard(kr, quiet)
 		require.NoError(t, reopened.PutPerm(keys[i], vr.RandBuff(20, 100)))
 	}
-	segs := reopened.Shards[quiet].PermKV.segments
+	segs := reopened.Shards[quiet].PermKV.sealedSegments()
 	require.NotEmpty(t, segs, "the quiet shard must have auto-sealed for this to test anything")
 	for _, seg := range segs {
 		assert.GreaterOrEqualf(t, seg.meta.Height, uint64(5),

--- a/database/segstore.go
+++ b/database/segstore.go
@@ -28,8 +28,21 @@ import (
 //	live.dat            records accepted since the last seal
 //	seg-<height>.dat    a sealed, immutable segment (transport format)
 //	seg-<height>.idx    its key index: sorted 48-byte records + a bloom
-//	segments.json       the manifest: the segments, counts, and hashes
+//	segments.json       the active manifest: the store's settings and
+//	                    the sealed segments of the newest 2N blocks
+//	history.json        the history manifest: every older segment
 //	filters.dat         the live key filters, saved on close (keyfilter.go)
+//
+// A store is two tiers with two locks (issue #57).  The ACTIVE tier is
+// the live tail and the sealed segments of the last N to 2N blocks --
+// the window the key filters cover -- and it is what a commit writes
+// and a consensus-path read hits; Mutex is its lock.  HISTORY is every
+// sealed segment below that window, plus the packed sets; History is
+// its lock, and merging, compacting and packing it are its business.
+// A segment moves from active to history when the window rolls past
+// it (handoffBelowWindow), which is the only moment both locks are
+// held together.  See the field comments on SegmentStore for the
+// rules, and docs/design/segment-store.md for why.
 //
 // An index record is key(32) offset(8) length(8), and the offset is
 // relative to the segment's BODY -- its records, after the header --
@@ -58,6 +71,7 @@ import (
 
 const (
 	segManifestName = "segments.json"
+	segHistoryName  = "history.json"
 	segLiveName     = "live.dat"
 	segFilePrefix   = "seg-"
 	segDataSuffix   = ".dat"
@@ -96,7 +110,16 @@ const (
 	// FilterBlocks, and a Span on each merged segment saying how far
 	// back it reaches.  A version-2 build would take a merged segment
 	// for a single block and let a filter claim keys it never held.
-	StoreFormatVersion = 3
+	//
+	// Version 4 split the manifest in two (issue #57): segments.json
+	// names the active tier and history.json names history, so that a
+	// commit and a merge each write their own and neither waits for the
+	// other.  The union of the two is the store; a segment may be named
+	// by both while its handoff is being recorded.  Shadowed is gone
+	// from the manifest with the whole-layer compaction it drove.  A
+	// version-3 build would read segments.json alone and silently lose
+	// every segment history.json names.
+	StoreFormatVersion = 4
 	segIndexHdrSize    = 32 // magic(4) version(4) count(8) bloomBytes(8) bloomK(4) reserved(4)
 	segDataHdrSize     = 24 // magic(4) version(4) sinceOffset(8) count(8) -- segment.go's stream header
 	segRecHdrSize      = 40 // key(32) valueLen(8) precede each value in a .dat
@@ -138,8 +161,18 @@ func (a SegmentMeta) after(b SegmentMeta) bool {
 }
 
 // StoreManifest
-// The authoritative list of a store's sealed segments.  Replacing it
-// is the commit point for both sealing and compaction.
+// The active manifest: the store's settings and the sealed segments of
+// the active tier.  Replacing it is the commit point for sealing and
+// importing.
+//
+// Segments is the active tier, oldest first, PLUS any segment the
+// window has rolled into history that history.json has not yet
+// recorded (SegmentStore.pendingHistory).  The rule that makes the two
+// manifests one store is that every sealed segment is named by at
+// least one of them at every moment: a handoff records nothing, so the
+// segment stays here until a history commit names it there, and only
+// a later active commit drops it from here.  A segment named by both
+// is simply the same segment.
 type StoreManifest struct {
 	// Version is the on-disk format; see StoreFormatVersion.  It is
 	// first so that it is readable at the head of the file.
@@ -150,18 +183,6 @@ type StoreManifest struct {
 	FilterBlocks uint64        `json:"filterBlocks"` // Roll period of the key filter; never 0
 	BlockHeight  uint64        `json:"blockHeight"`  // Block currently being accumulated
 	Segments     []SegmentMeta `json:"segments"`     // Oldest first
-
-	// Shadowed carries the store's estimate of how many of its records
-	// a later write has superseded -- its garbage -- across a restart.
-	//
-	// Without it a reopened store believed it held none, whatever it
-	// actually held, and deferred reclaiming until it had accumulated a
-	// threshold fraction of the whole layer again in fresh overwrites
-	// (issue #40).  It is written whenever the manifest is, so a crash
-	// costs the writes since the last seal, import, or compaction: an
-	// under-estimate, which defers compaction rather than forcing a
-	// pointless one.
-	Shadowed uint64 `json:"shadowed,omitempty"`
 
 	// FilterValid says the persisted key filters (filters.dat) cover
 	// the store exactly as this manifest lists it, and the other three
@@ -175,6 +196,17 @@ type StoreManifest struct {
 	FilterHeight   uint64 `json:"filterHeight,omitempty"`
 	FilterSeq      uint64 `json:"filterSeq,omitempty"`
 	FilterSegments uint64 `json:"filterSegments,omitempty"`
+}
+
+// HistoryManifest
+// The history manifest: the sealed segments below the active window,
+// oldest first.  Replacing it is the commit point for a merge, a
+// history compaction, and the retirement of packed segments.  It
+// carries no settings -- those are the active manifest's -- so that a
+// history commit needs nothing from the active tier.
+type HistoryManifest struct {
+	Version  uint32        `json:"version"`
+	Segments []SegmentMeta `json:"segments"` // Oldest first
 }
 
 // segment
@@ -279,20 +311,72 @@ func (s *segment) value(dbb *DBBKey) (value []byte, err error) {
 // A key/value store built from sealed segments and a live tail.
 // Methods are safe for concurrent use.
 type SegmentStore struct {
-	// Mutex guards the store.  Writers -- anything that appends to the
-	// live tail, seals, compacts, merges, imports, or closes -- take it
-	// exclusively.  Readers take it SHARED: a sealed segment is
-	// immutable and the pool hands out descriptors for pread, so
-	// lookups against sealed data need no lock at all; the shared lock
-	// exists only to keep the live map and the segment list stable
-	// while a reader is looking at them.
+	// Mutex guards the ACTIVE tier: the live tail, the key filters, the
+	// block height, and the sealed segments inside the window.  It is
+	// the protocol's lock -- what Put, PutIfAbsent, Seal, Sync and the
+	// first half of Get take -- and nothing it protects grows with the
+	// chain, so nothing held under it takes longer as history does.
+	// Writers take it exclusively; readers take it SHARED, because a
+	// sealed segment is immutable and the pool hands out descriptors
+	// for pread, so the shared lock exists only to keep the live map
+	// and the segment list stable while a reader looks (issue #50).
+	//
+	// History is never taken while Mutex is held on the protocol path.
+	// The two meet in exactly two places, both under Mutex first:
+	// handoffBelowWindow, which moves the segments the window has
+	// rolled past into history and holds History for the length of an
+	// append, and Close/Open, which are not the protocol path.  A
+	// history operation never takes Mutex.
 	//
 	// It was an exclusive mutex for reads too, and that serialised
 	// every read in the process on one lock whose hold time grew with
 	// the segment walk.  Measured on an 8-node Accumulate network at
 	// 500 tx/s: the busiest node ran at ~110% CPU -- one core, seven
 	// idle -- while block time climbed from 3.0 s to 5.2 s (issue #50).
-	Mutex     sync.RWMutex
+	Mutex sync.RWMutex
+
+	// History guards the HISTORY tier: the sealed segments below the
+	// window.  A merge, a history compaction, or a pack copies those
+	// segments with NO lock -- they are immutable -- and takes History
+	// exclusively only to swap the list and commit history.json; a
+	// reader of history takes it shared for the length of its walk.
+	//
+	// It exists because one lock covered both tiers, and a merge or a
+	// compaction held it for the whole copy: measured on an 8-node
+	// Accumulate network at 500 tx/s, every node stopped producing
+	// blocks for 12 s at block 400 and 23-32 s at block 1,040 -- ~2.3 s
+	// per GB of the dynamic layer, growing without bound -- because a
+	// lock on history was held against the protocol (issue #57).
+	History sync.RWMutex
+
+	// maint serialises history maintenance -- MergeBelow,
+	// CompactHistory, DropBelow -- for the whole of an operation, copy
+	// and swap.  Only maintainers take it; the protocol path never
+	// does, so it can be held for as long as a copy takes.  Order:
+	// maint, then History.  Never Mutex after either.
+	maint sync.Mutex
+
+	// handoffMu is a leaf lock over pendingHistory and
+	// retireAfterActiveCommit, the two lists the tiers hand each other.
+	// Held for the length of a slice append, under either tier lock,
+	// never around anything that blocks.
+	handoffMu sync.Mutex
+
+	// retireMu is a leaf lock over iterating and pendingDelete, so that
+	// either tier can retire a file and either can hold one open.
+	retireMu sync.Mutex
+
+	// unlinkMu guards the queue of files waiting to be deleted, which a
+	// goroutine drains with no store lock held (unlinkLater): a
+	// compaction can retire thousands of files, and deleting them under
+	// either tier's lock was a pause proportional to history -- 236 ms
+	// on a Seal after a 3,579-segment compaction.  unlinking says the
+	// goroutine is running, and unlinkDone is signalled when it stops.
+	unlinkMu    sync.Mutex
+	unlinkQueue []string
+	unlinking   bool
+	unlinkDone  *sync.Cond
+
 	Directory string
 	Mutable   bool // Mutable: newer segments shadow older; immutable: conflicts error
 
@@ -331,12 +415,60 @@ type SegmentStore struct {
 	// selects by block -- would then never export those records.
 	ExternalBlockRecord bool
 
-	segments    []*segment           // Sealed segments, oldest first
+	// active is the sealed segments inside the window, oldest first:
+	// every one has first() >= tierStart(), and the key filters cover
+	// all of them.  Under Mutex.
+	active []*segment
+
+	// history is the sealed segments below the window, oldest first:
+	// every one has first() < tierStart().  Under History.  A segment
+	// is in exactly one of the two lists; ordered by (Height, Seq),
+	// history precedes active, because the window only ever moves up.
+	history []*segment
+
+	// historyNewest is the identity of history's newest segment as the
+	// active tier last saw it, kept under Mutex so that a seal needing
+	// the store's newest identity (nextKeyAt) never takes History.  It
+	// can lag: a merge replaces history's newest with one sequence
+	// higher, under History alone.  That is safe, because the identity
+	// is only compared against heights at or above the window, and
+	// everything in history is below it.
+	historyNewest SegmentMeta
+	historyAny    bool
+
+	// handoffs is the segments the window has rolled into history whose
+	// files the active manifest on disk may still name.  An entry is
+	// added at the handoff; `recorded` is set by the history commit
+	// that names the segment (or what it was merged into); and the
+	// active commit after that drops the entry, because it is the first
+	// active manifest that does not name the segment.  Until an entry
+	// is gone, a history operation that retires the segment's files
+	// hands them to retireAfterActiveCommit instead of deleting them.
+	// Under handoffMu.
+	handoffs []handoff
+
+	// retireAfterActiveCommit is the files history made unreachable
+	// that the active manifest on disk may still name.  They are
+	// deleted after the next active commit, which is the first manifest
+	// that no longer names them.  Under handoffMu.
+	retireAfterActiveCommit []string
+
+	// epoch counts handoffs.  A write that had to consult history
+	// without the active lock checks it before writing, and starts
+	// over if the window rolled in between.  Under Mutex.
+	epoch uint64
+
 	live        map[[32]byte]*DBBKey // Keys written since the last seal
 	liveFile    *BFile               // Their records
 	liveRecords uint64               // Physical records in liveFile (>= len(live) if keys repeat)
 	liveDirty   bool                 // Records written to the tail since the last fsync of it
-	closed      bool                 // Set by Close; cleared by Open
+
+	// closed is set by Close and cleared by Open, under BOTH tier
+	// locks, so that a check under either is enough.  Atomic so that
+	// Open on an open store can say so without taking either: every
+	// KVShard operation calls Open first, maintenance included, and a
+	// merge must not queue behind a commit to learn its store is open.
+	closed atomic.Bool
 
 	// cold is where this store's keys go once they leave its segments:
 	// the block-set files a sharded database packs its finalized Perm
@@ -349,58 +481,25 @@ type SegmentStore struct {
 	// history should not have to know where the store keeps it.  The
 	// key filters do not cover the cold keys -- that is what bounds them
 	// (keyfilter.go) -- so a key they rule out is looked for cold by Get,
-	// and by nothing else: see lookup.
+	// and by nothing else: see lookupHistory.
 	cold coldStore
 
-	// retireOnCommit holds segments dropped from the list -- their keys
-	// now held cold -- whose files the manifest still names.  They are
-	// deleted after the next manifest commit, whatever causes it, so
-	// that dropping a segment costs no barrier of its own: a shard
-	// commits a manifest every block it seals in anyway, and this rides
-	// on that one.  Until then the files stay, and a crash leaves them
-	// named by a manifest that still points at whole segments.
-	retireOnCommit []*segment
-
-	// iterating counts the iterations in flight, and pendingDelete
-	// holds the files a compaction wanted to delete while one was.
+	// iterating counts the iterations and pinned snapshots in flight,
+	// and pendingDelete holds the files a commit wanted to delete while
+	// one was.
 	//
-	// ForEach runs its callback without the store's lock (issue #31),
-	// so a compaction can commit underneath it.  That is fine for what
-	// the iteration reports -- it snapshots the segment list and shows
-	// the store as it was when it started -- but not for the files:
-	// compaction deletes the generation it replaced, and the iterator
-	// is still reading it.  Deferring the unlink until the last
-	// iteration finishes keeps those reads valid.  The files are
-	// already unreachable through the manifest, so a crash in between
+	// ForEach runs its callback without any store lock (issue #31), so
+	// a merge or a compaction can commit underneath it.  That is fine
+	// for what the iteration reports -- it snapshots the segment lists
+	// and shows the store as it was when it started -- but not for the
+	// files: the commit deletes the segments it replaced, and the
+	// iterator is still reading them.  Deferring the unlink until the
+	// last iteration finishes keeps those reads valid.  The files are
+	// already unreachable through the manifests, so a crash in between
 	// costs nothing: recoverOrphans sweeps them on the next open.
+	// Under retireMu.
 	iterating     int
 	pendingDelete []string
-
-	// shadowed estimates how many records this store holds that a later
-	// write has superseded -- its garbage -- counted since the last
-	// compaction.
-	//
-	// It exists so that "is there anything worth reclaiming?" can be
-	// answered without reading anything.  Compaction itself is the only
-	// exact answer, and it costs a scan of every index plus a copy of
-	// every live value, so asking it that question is the thing being
-	// avoided (issue #31).
-	//
-	// A mutable store appends without checking, on purpose, so the count
-	// comes from a probe of the store's own key filter before the write
-	// is recorded in it: a key already there means this write shadows an
-	// older copy.  The filter's false positives make that an
-	// over-estimate and its lack of false negatives keeps it from ever
-	// being an under-estimate, so the error is on the side of compacting
-	// slightly early.  Nil filter means no estimate, and the caller
-	// falls back to compacting unconditionally.
-	//
-	// It survives a restart: the manifest carries it, so a reopened
-	// store resumes its estimate rather than believing it holds no
-	// garbage at all (issue #40).  What a crash costs is the writes
-	// since the last manifest -- an under-estimate, which defers a
-	// compaction rather than forcing a pointless one.
-	shadowed uint64
 
 	// filters are the live key filters, oldest first: one or two
 	// membership sets over the keys of the last N to 2N blocks and the
@@ -472,7 +571,9 @@ type coldStore interface {
 func (s *SegmentStore) attachCold(cold coldStore) (err error) {
 	s.Mutex.Lock()
 	defer s.Mutex.Unlock()
+	s.History.Lock() // cold is read under either lock; set it under both
 	s.cold = cold
+	s.History.Unlock()
 	if s.filtersLackCold {
 		for _, f := range s.filters {
 			if err = cold.forEachKeySince(f.start, f.keys.Set); err != nil {
@@ -555,6 +656,9 @@ func NewSegmentStore(directory string, mutable bool) (store *SegmentStore, err e
 	if err = store.newLiveFile(); err != nil {
 		return nil, err
 	}
+	if err = store.writeHistoryManifest(); err != nil {
+		return nil, err
+	}
 	if err = store.writeManifest(); err != nil {
 		return nil, err
 	}
@@ -633,21 +737,37 @@ func (s *SegmentStore) newKeyFilter(expected uint64) *BloomSet {
 // Reopen a closed store.  Cheap and safe to call on an open store,
 // which callers on the hot path rely on.
 func (s *SegmentStore) Open() (err error) {
+	if !s.closed.Load() {
+		return nil // No lock: see closed
+	}
 	s.Mutex.Lock()
 	defer s.Mutex.Unlock()
-	if !s.closed {
+	if !s.closed.Load() {
 		return nil
 	}
+	s.History.Lock()
+	defer s.History.Unlock()
 	return s.load()
 }
 
 // load
-// Read the store off disk.  The caller must hold the Mutex (or hold
-// the only reference, as the constructors do).
+// Read the store off disk.  The caller must hold both tier locks (or
+// hold the only reference, as the constructors do).
+//
+// The two manifests are read and their union taken -- a segment named
+// by both is one segment -- and each segment is then placed in the
+// tier its oldest block puts it in, for the block the store is in.
+// Tier membership is derived, never recorded: a segment's tier is a
+// function of its block range and the window, so a crash between a
+// handoff and either commit changes nothing about where a segment
+// belongs.  Whichever manifest is found not to match its tier is
+// rewritten, so that the store leaves open with each manifest naming
+// its own tier and nothing pending between them.
 func (s *SegmentStore) load() (err error) {
 	s.live = make(map[[32]byte]*DBBKey)
-	s.segments = nil
-	s.retireOnCommit = nil // The manifest being read is the truth again
+	s.active, s.history = nil, nil
+	s.historyNewest, s.historyAny = SegmentMeta{}, false
+	s.handoffs, s.retireAfterActiveCommit = nil, nil // The manifests being read are the truth again
 	s.liveRecords = 0
 
 	m, err := s.readManifest()
@@ -659,6 +779,15 @@ func (s *SegmentStore) load() (err error) {
 			"%s is on-disk format version %d; this build reads version %d",
 			s.Directory, m.Version, StoreFormatVersion)
 	}
+	hm, err := s.readHistoryManifest()
+	if err != nil {
+		return err
+	}
+	if hm.Version != StoreFormatVersion {
+		return fmt.Errorf(
+			"%s is on-disk format version %d; this build reads version %d",
+			filepath.Join(s.Directory, segHistoryName), hm.Version, StoreFormatVersion)
+	}
 	s.Mutable = m.Mutable
 	s.SealLimit = m.SealLimit
 	if err = checkFilterBlocks(m.FilterBlocks); err != nil {
@@ -666,20 +795,52 @@ func (s *SegmentStore) load() (err error) {
 	}
 	s.FilterBlocks = m.FilterBlocks
 	s.blockHeight = m.BlockHeight
-	s.shadowed = m.Shadowed
 
-	for _, meta := range m.Segments {
+	// The union, in (Height, Seq) order, which is the order both tiers
+	// keep and the order the lists had before any restart
+	var all []*segment
+	seen := make(map[string]bool)
+	for _, meta := range append(append([]SegmentMeta(nil), hm.Segments...), m.Segments...) {
+		if seen[meta.File] {
+			continue
+		}
+		seen[meta.File] = true
 		seg, err := s.openSegment(meta)
 		if err != nil {
 			return err
 		}
-		s.segments = append(s.segments, seg)
+		all = append(all, seg)
 	}
+	sort.SliceStable(all, func(i, j int) bool { return all[j].meta.after(all[i].meta) })
 
-	adopted, err := s.recoverOrphans()
+	all, adopted, err := s.recoverOrphans(all)
 	if err != nil {
 		return err
 	}
+	// The block the tail is in is at least the block of the newest
+	// segment.  The manifest can say less: the Dyna layer's block
+	// advances in memory with every KV2.Seal and is persisted only by
+	// its own seals, so a segment it sealed and a crash left for
+	// recoverOrphans to adopt can sit many blocks above the block the
+	// manifest recorded -- and a store that then auto-sealed at the
+	// recorded block would refuse, "block height 5 is below the newest
+	// segment's block 68".  It also keeps the tiers consistent: a
+	// segment is never newer than the window it is placed by.
+	if n := len(all); n > 0 && all[n-1].meta.Height > s.blockHeight {
+		s.blockHeight = all[n-1].meta.Height
+	}
+	start := s.tierStart()
+	for _, seg := range all {
+		if seg.meta.first() < start {
+			s.history = append(s.history, seg)
+		} else {
+			s.active = append(s.active, seg)
+		}
+	}
+	if n := len(s.history); n > 0 {
+		s.historyNewest, s.historyAny = s.history[n-1].meta, true
+	}
+
 	// After recoverOrphans, because an adopted segment changes what the
 	// filters have to cover; before openLive, which adds the live keys
 	// as it replays them.
@@ -689,8 +850,124 @@ func (s *SegmentStore) load() (err error) {
 	if err = s.openLive(); err != nil {
 		return err
 	}
-	s.closed = false
+	s.closed.Store(false)
+
+	// Reconcile the tiers with what the manifests name, writing as
+	// little as possible: a store opens 1,024 of these at a time.  A
+	// history segment the active manifest still names is a handoff in
+	// flight, recorded or not according to whether history.json names
+	// it, and the commits that follow finish it as they would have.  A
+	// segment named by NEITHER -- an adopted orphan -- or an active
+	// segment only history.json names -- one the window at the block
+	// this store recorded has not yet passed, though a later history
+	// commit would drop it -- needs its own tier's manifest to name it
+	// before anything else is committed.
+	inActive, inHistory := make(map[string]bool), make(map[string]bool)
+	for _, meta := range m.Segments {
+		inActive[meta.File] = true
+	}
+	for _, meta := range hm.Segments {
+		inHistory[meta.File] = true
+	}
+	writeHistory, writeActive := false, false
+	for _, seg := range s.history {
+		switch {
+		case inActive[seg.meta.File]:
+			s.handoffs = append(s.handoffs, handoff{seg: seg, recorded: inHistory[seg.meta.File]})
+		case !inHistory[seg.meta.File]:
+			writeHistory = true
+		}
+	}
+	for _, seg := range s.active {
+		if !inActive[seg.meta.File] {
+			writeActive = true
+		}
+	}
+	if writeHistory {
+		if err = s.writeHistoryManifest(); err != nil {
+			return err
+		}
+	}
+	if writeActive {
+		if err = s.writeManifest(); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+// tierStart is the block that divides the tiers: a segment whose
+// oldest block is at or above it is active, and one below it is
+// history.  It is the start of the oldest key filter the schedule
+// calls for at the block the tail is in -- the same line the filters'
+// coverage claim is drawn at (keyfilter.go) -- and a pure function of
+// the block height, so it only ever moves up.  The caller must hold
+// the Mutex.
+func (s *SegmentStore) tierStart() uint64 {
+	return filterStarts(s.blockHeight, s.FilterBlocks)[0]
+}
+
+// handoffBelowWindow
+// Move the active segments the window has rolled past into history.
+// Called from advanceBlock, under the Mutex, whenever the block moves;
+// it is the one place the protocol path takes History, and it holds
+// it for an append.
+//
+// Nothing is written.  The segments stay named by the active manifest
+// until a history commit names them (pendingHistory), so a crash at
+// any point leaves them named by at least one manifest.
+func (s *SegmentStore) handoffBelowWindow() {
+	start := s.tierStart()
+	n := 0
+	for _, seg := range s.active {
+		if seg.meta.first() >= start {
+			break // Ordered: the rest are inside the window too
+		}
+		n++
+	}
+	if n == 0 {
+		return
+	}
+	moved := s.active[:n]
+	s.active = append([]*segment(nil), s.active[n:]...)
+	s.epoch++
+
+	s.History.Lock()
+	s.history = append(s.history, moved...)
+	s.historyNewest, s.historyAny = moved[n-1].meta, true
+	s.handoffMu.Lock()
+	for _, seg := range moved {
+		s.handoffs = append(s.handoffs, handoff{seg: seg})
+	}
+	s.handoffMu.Unlock()
+	s.History.Unlock()
+}
+
+// handoff is one segment in transit between the manifests; see
+// SegmentStore.handoffs
+type handoff struct {
+	seg      *segment
+	recorded bool // history.json names it (or its replacement)
+}
+
+// releaseFromHistory
+// Retire a segment's files on history's behalf: now, if no manifest
+// on disk can still name them, and after the next active commit if
+// the active manifest might.  The caller must hold History and must
+// already have committed a history manifest that does not name the
+// segment.
+func (s *SegmentStore) releaseFromHistory(seg *segment) {
+	seg.close()
+	s.handoffMu.Lock()
+	defer s.handoffMu.Unlock()
+	for i, h := range s.handoffs {
+		if h.seg == seg {
+			s.handoffs = append(s.handoffs[:i], s.handoffs[i+1:]...)
+			s.retireAfterActiveCommit = append(s.retireAfterActiveCommit, seg.dataPath, seg.indexPath)
+			return
+		}
+	}
+	s.unlinkLater(seg.dataPath, seg.indexPath)
 }
 
 // addSegmentKeys
@@ -898,22 +1175,28 @@ func (s *SegmentStore) openLive() (err error) {
 // Adopt a sealed segment whose manifest update did not complete, and
 // delete leftovers a completed compaction made unreachable.
 //
-// The rule is the manifest's newest height: a data file above it is a
-// seal (or compaction) that reached disk but not the manifest, and is
-// complete by construction -- it was fsynced before being renamed into
-// place.  A data file at or below that height was superseded by a
-// committed compaction.  Reports how many segments were adopted.
-func (s *SegmentStore) recoverOrphans() (adopted int, err error) {
+// The rule is the manifests' newest height: a data file above it is a
+// seal (or a compaction of a store whose every segment was history)
+// that reached disk but not the manifest, and is complete by
+// construction -- it was fsynced before being renamed into place.  A
+// data file at or below that height was superseded by a committed
+// merge or compaction.  Takes and returns the store's segments, both
+// tiers in (Height, Seq) order, and reports how many were adopted.
+func (s *SegmentStore) recoverOrphans(all []*segment) (segs []*segment, adopted int, err error) {
 	entries, err := os.ReadDir(s.Directory)
 	if err != nil {
-		return 0, err
+		return all, 0, err
 	}
 
 	known := make(map[string]bool)
-	for _, seg := range s.segments {
+	for _, seg := range all {
 		known[seg.meta.File] = true
 	}
-	newest, haveSegments := s.newestMeta()
+	var newest SegmentMeta
+	haveSegments := len(all) > 0
+	if haveSegments {
+		newest = all[len(all)-1].meta
+	}
 
 	var orphans []SegmentMeta
 	for _, e := range entries {
@@ -938,25 +1221,26 @@ func (s *SegmentStore) recoverOrphans() (adopted int, err error) {
 		}
 		hash, count, err := s.identify(path)
 		if err != nil {
-			return 0, err
+			return all, 0, err
 		}
 		orphans = append(orphans, SegmentMeta{Height: height, Seq: seq, File: name, Count: count, Hash: hash})
 	}
 	if len(orphans) == 0 {
-		return 0, nil
+		return all, 0, nil
 	}
 
 	sort.Slice(orphans, func(i, j int) bool { return orphans[j].after(orphans[i]) })
 	for _, meta := range orphans {
 		seg, err := s.openSegment(meta)
 		if err != nil {
-			return 0, err
+			return all, 0, err
 		}
 		meta.Count = uint64(seg.count) // Indexed keys, not physical records
 		seg.meta = meta
-		s.segments = append(s.segments, seg)
+		all = append(all, seg) // Above the newest, so this keeps the order
 	}
-	return len(orphans), s.writeManifest()
+	// The manifests are rewritten by load once the tiers are placed
+	return all, len(orphans), nil
 }
 
 // heightFromName parses seg-<height>.dat
@@ -994,12 +1278,25 @@ func (s *SegmentStore) readManifest() (m *StoreManifest, err error) {
 	return m, nil
 }
 
+// readHistoryManifest loads history.json
+func (s *SegmentStore) readHistoryManifest() (m *HistoryManifest, err error) {
+	data, err := os.ReadFile(filepath.Join(s.Directory, segHistoryName))
+	if err != nil {
+		return nil, err
+	}
+	m = new(HistoryManifest)
+	if err = json.Unmarshal(data, m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 // writeManifest
-// Replace the manifest atomically.  This is the commit point for
-// sealing, importing, and compaction -- and the single durability
-// barrier for the whole operation.
+// Replace the active manifest atomically.  This is the commit point
+// for sealing and importing -- and the single durability barrier for
+// the whole operation.  The caller must hold the Mutex.
 //
-// The directory fsync at the end is the only one any of those paths
+// The directory fsync at the end is the only one either of those paths
 // performs.  Each of them renames files into this directory before
 // calling here -- the sealed data file, its index, then the manifest
 // itself -- and one fsync of a directory commits every name change
@@ -1012,29 +1309,106 @@ func (s *SegmentStore) readManifest() (m *StoreManifest, err error) {
 // published, so a name that survives a crash never points at a file
 // that does not.  A seal was paying six barriers for that; three of
 // them were this directory, fsynced three times over (issue #33).
+//
+// What it names is the active tier plus the handoffs no history commit
+// has recorded yet; what it takes with it is the handoffs one has, and
+// the files history left for this commit to delete.  Both are read
+// before the manifest is built, so a handoff or a retirement that
+// arrives while the file is being written waits for the next commit.
 func (s *SegmentStore) writeManifest() (err error) {
 	// The coverage claim is true only of the manifest written directly
 	// after the filters were saved.  Everything else that writes a
-	// manifest -- a seal, a compaction, an import -- has changed the
-	// segment set, so clearing it here means no path can forget to.
+	// manifest -- a seal, an import -- has changed the segment set, so
+	// clearing it here means no path can forget to.
 	defer func() { s.filterValid = false }()
+
+	s.handoffMu.Lock()
+	var unrecorded, recorded []*segment
+	for _, h := range s.handoffs {
+		if h.recorded {
+			recorded = append(recorded, h.seg)
+		} else {
+			unrecorded = append(unrecorded, h.seg)
+		}
+	}
+	retire := append([]string(nil), s.retireAfterActiveCommit...)
+	s.handoffMu.Unlock()
 
 	m := StoreManifest{Version: StoreFormatVersion,
 		Mutable: s.Mutable, SealLimit: s.SealLimit, FilterBlocks: s.FilterBlocks,
-		BlockHeight: s.blockHeight, Shadowed: s.shadowed}
+		BlockHeight: s.blockHeight}
 	if s.filterValid {
 		m.FilterValid = true
 		m.FilterStart, m.FilterHeight = s.filterSaved.Start, s.filterSaved.Height
 		m.FilterSeq, m.FilterSegments = s.filterSaved.Seq, s.filterSaved.Segments
 	}
-	for _, seg := range s.segments {
+	for _, seg := range unrecorded { // Older than anything active
 		m.Segments = append(m.Segments, seg.meta)
 	}
-	data, err := json.MarshalIndent(&m, "", "  ")
+	for _, seg := range s.active {
+		m.Segments = append(m.Segments, seg.meta)
+	}
+	if err = commitJSON(s.Directory, segManifestName, &m); err != nil {
+		return err
+	}
+
+	// Committed.  The handoffs history has recorded are named by neither
+	// this manifest nor any later one, and the files history left for
+	// this commit are named by nothing.
+	s.handoffMu.Lock()
+	kept := s.handoffs[:0]
+	for _, h := range s.handoffs {
+		done := false
+		for _, seg := range recorded {
+			if h.seg == seg {
+				done = true
+			}
+		}
+		if !done {
+			kept = append(kept, h)
+		}
+	}
+	s.handoffs = kept
+	s.retireAfterActiveCommit = s.retireAfterActiveCommit[len(retire):]
+	s.handoffMu.Unlock()
+	s.unlinkLater(retire...)
+	return nil
+}
+
+// writeHistoryManifest
+// Replace the history manifest atomically: the commit point for a
+// merge, a history compaction, and the retirement of packed segments.
+// The caller must hold History exclusively (or the only reference).
+//
+// It names history as it stands, which includes every segment handed
+// off so far -- a handoff appends under History, so none can be in
+// flight -- and so every handoff is recorded by this commit: the next
+// active commit may stop naming them.
+func (s *SegmentStore) writeHistoryManifest() (err error) {
+	m := HistoryManifest{Version: StoreFormatVersion}
+	for _, seg := range s.history {
+		m.Segments = append(m.Segments, seg.meta)
+	}
+	if err = commitJSON(s.Directory, segHistoryName, &m); err != nil {
+		return err
+	}
+	s.handoffMu.Lock()
+	for i := range s.handoffs {
+		s.handoffs[i].recorded = true
+	}
+	s.handoffMu.Unlock()
+	return nil
+}
+
+// commitJSON writes a manifest to a tmp file, fsyncs it, renames it
+// over the name, and fsyncs the directory: the one barrier that makes
+// every rename issued before it durable too (see writeManifest)
+func commitJSON(directory, name string, m any) (err error) {
+	data, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {
 		return err
 	}
-	tmp := filepath.Join(s.Directory, segManifestName+segTmpSuffix)
+	tmp := filepath.Join(directory, name+segTmpSuffix)
 	f, err := os.Create(tmp)
 	if err != nil {
 		return err
@@ -1050,21 +1424,10 @@ func (s *SegmentStore) writeManifest() (err error) {
 	if err = f.Close(); err != nil {
 		return err
 	}
-	if err = os.Rename(tmp, filepath.Join(s.Directory, segManifestName)); err != nil {
+	if err = os.Rename(tmp, filepath.Join(directory, name)); err != nil {
 		return err
 	}
-	if err = syncDir(s.Directory); err != nil {
-		return err
-	}
-	// Committed: the manifest no longer names what DropBelow dropped, so
-	// the files can go
-	for _, seg := range s.retireOnCommit {
-		seg.close()
-		s.retire(seg.dataPath)
-		s.retire(seg.indexPath)
-	}
-	s.retireOnCommit = nil
-	return nil
+	return syncDir(directory)
 }
 
 // errStoreClosed is returned by every operation that would read or
@@ -1100,7 +1463,7 @@ var ErrImmutable = errors.New("cannot overwrite immutable value")
 // checkOpen reports whether the store can be operated on.  The caller
 // must hold the Mutex.
 func (s *SegmentStore) checkOpen() error {
-	if s.closed {
+	if s.closed.Load() {
 		return errStoreClosed
 	}
 	return nil
@@ -1108,72 +1471,102 @@ func (s *SegmentStore) checkOpen() error {
 
 // Get
 // Return the value for a key, wherever the store holds it: the live
-// tail, the sealed segments newest to oldest, then the packed sets.
+// tail, the active segments newest to oldest, then history newest to
+// oldest, then the packed sets.
+//
+// Two locks, never together.  The active tier is read under Mutex,
+// shared, and released before history is read under History, shared.
+// A segment that moves between the two in the gap is looked at twice
+// at worst, and a merge that commits in the gap is seen either as its
+// inputs or as its output: both hold the same keys.
 func (s *SegmentStore) Get(key [32]byte) (value []byte, err error) {
 	s.Mutex.RLock()
-	defer s.Mutex.RUnlock()
-	return s.get(key)
+	value, inWindow, found, err := s.lookupActive(key)
+	s.Mutex.RUnlock()
+	if err != nil || found {
+		return value, err
+	}
+	return s.lookupHistory(key, inWindow)
 }
 
-// get is Get; the caller must hold the Mutex
-func (s *SegmentStore) get(key [32]byte) (value []byte, err error) {
-	return s.lookup(key, true)
-}
-
-// lookup
-// Find a key.  The caller must hold the Mutex.
+// lookupActive
+// Find a key in the active tier: the live tail, then the sealed
+// segments inside the window, newest first.  The caller must hold the
+// Mutex.  inWindow reports what the key filters said, which decides
+// whether history has to be consulted for a key not found here.
 //
 // One probe of the live filters settles the window: a "no" is
-// definitive for every segment whose blocks all lie inside it, and
-// that is the part of the walk that grows with the seal count.  What
-// the filters do not speak for is the history below the window -- the
-// segments a merge has stretched back past it, and the packed sets --
-// each of which carries a filter of its own, and `deep` says whether
-// to go there when the window says no.
-//
-// Get does.  A caller asking for a key is owed the answer wherever the
-// store keeps it, and a key that old is looked for in every set, one
-// bloom probe each.  A WRITE does not: immutability is a windowed
-// guarantee (issue #44).  The check exists for replay safety, which is
-// recent by nature, and a Perm key is the hash of its value, so "same
-// key, different value" beyond the window would be a hash collision.
-// Stopping at the window is what keeps a write's cost independent of
-// how much history the store holds.  A filter hit -- a key that is in
-// the window, or a false positive -- is followed wherever it leads,
-// so that a key written in the last N to 2N blocks is refused whether
-// it now sits in a segment, a merged segment, or a set.
-func (s *SegmentStore) lookup(key [32]byte, deep bool) (value []byte, err error) {
+// definitive for every active segment -- every one of them lies
+// inside the window, that being what makes it active -- and that is
+// the part of the walk that grows with the seal count.  What the
+// filters do not speak for is the history below the window and the
+// packed sets, each of which carries a filter of its own.
+func (s *SegmentStore) lookupActive(key [32]byte) (value []byte, inWindow, found bool, err error) {
+	return s.findActive(key, true)
+}
+
+// findActive is lookupActive, counting what happened in the stats
+// only when `count` says so: a write that had to consult history looks
+// at the active tier twice, and that is one lookup.
+func (s *SegmentStore) findActive(key [32]byte, count bool) (value []byte, inWindow, found bool, err error) {
 	if err = s.checkOpen(); err != nil {
-		return nil, err
+		return nil, false, false, err
 	}
-	s.stats.lookupTotal.Add(1)
+	if count {
+		s.stats.lookupTotal.Add(1)
+	}
 	if dbb, ok := s.live[key]; ok {
 		value = make([]byte, dbb.Length)
 		if err = s.liveFile.ReadAt(dbb.Offset, value); err != nil {
-			return nil, err
+			return nil, false, false, err
 		}
-		s.stats.liveHit.Add(1)
-		return value, nil
+		if count {
+			s.stats.liveHit.Add(1)
+		}
+		return value, true, true, nil
 	}
-	inWindow := s.filterTest(key)
-	if inWindow {
+	inWindow = s.filterTest(key)
+	if !inWindow {
+		if count {
+			s.stats.filterAbsent.Add(1)
+		}
+		return nil, false, false, nil
+	}
+	if count {
 		s.stats.filterWalked.Add(1)
-	} else {
-		s.stats.filterAbsent.Add(1)
-		if !deep {
-			return nil, errNotFound
+	}
+	for i := len(s.active) - 1; i >= 0; i-- { // Newest segment wins
+		dbb, found, err := s.active[i].lookup(key)
+		if err != nil {
+			return nil, true, false, err
+		}
+		if found {
+			value, err = s.active[i].value(dbb)
+			return value, true, true, err
 		}
 	}
-	for i := len(s.segments) - 1; i >= 0; i-- { // Newest segment wins
-		if !inWindow && s.covered(s.segments[i]) {
-			continue
-		}
-		dbb, found, err := s.segments[i].lookup(key)
+	return nil, true, false, nil
+}
+
+// lookupHistory
+// Find a key below the window: the history segments newest first, then
+// the packed sets.  Takes History shared for the length of the walk,
+// which is what lets a merge retire the segments it replaced the
+// moment its swap is done.  inWindow is what the filters said, for
+// the misled counter.
+func (s *SegmentStore) lookupHistory(key [32]byte, inWindow bool) (value []byte, err error) {
+	s.History.RLock()
+	defer s.History.RUnlock()
+	if err = s.checkOpen(); err != nil {
+		return nil, err
+	}
+	for i := len(s.history) - 1; i >= 0; i-- { // Newest segment wins
+		dbb, found, err := s.history[i].lookup(key)
 		if err != nil {
 			return nil, err
 		}
 		if found {
-			return s.segments[i].value(dbb)
+			return s.history[i].value(dbb)
 		}
 	}
 	if s.cold != nil { // Then whatever left the segments for a block set
@@ -1198,31 +1591,99 @@ func (s *SegmentStore) lookup(key [32]byte, deep bool) (value []byte, err error)
 // no-op (this is what makes replay and re-import idempotent) and
 // rewriting it with a different value is an error.  The check reaches
 // back over the key filters' window, N to 2N blocks, and no further:
-// see lookup.
+// immutability is a windowed guarantee (issue #44).  The check exists
+// for replay safety, which is recent by nature, and a Perm key is the
+// hash of its value, so "same key, different value" beyond the window
+// would be a hash collision.  Stopping at the window is what keeps a
+// write's cost independent of how much history the store holds.  A
+// filter hit -- a key that is in the window, or a false positive -- is
+// followed wherever it leads, so that a key written in the last N to
+// 2N blocks is refused whether it now sits in an active segment, a
+// merged segment in history, or a set.
 func (s *SegmentStore) Put(key [32]byte, value []byte) (err error) {
-	s.Mutex.Lock()
-	defer s.Mutex.Unlock()
-	return s.put(key, value)
-}
-
-// put is Put; the caller must hold the Mutex
-func (s *SegmentStore) put(key [32]byte, value []byte) (err error) {
-	if err = s.checkOpen(); err != nil {
+	existing, existed, err := s.putUnlessPresent(key, value, s.Mutable)
+	if err != nil || !existed {
 		return err
 	}
-	s.stats.putTotal.Add(1)
-	if !s.Mutable {
-		if existing, err := s.lookup(key, false); err == nil {
-			if bytes.Equal(existing, value) {
-				s.stats.putDuplicate.Add(1)
-				return nil // Same value: no-op
-			}
-			s.stats.putConflict.Add(1)
-			return ErrImmutable
-		}
+	if bytes.Equal(existing, value) {
+		s.stats.putDuplicate.Add(1)
+		return nil // Same value: no-op
 	}
-	s.stats.putNew.Add(1)
-	return s.writeRecord(key, value)
+	s.stats.putConflict.Add(1)
+	return ErrImmutable
+}
+
+// putUnlessPresent
+// Append a record unless the key is already held, and report what was
+// found.  `blind` skips the check altogether, which is what a mutable
+// store's Put wants: it appends and lets the newest record win.
+//
+// The check takes the Mutex, and only the Mutex, in the common cases:
+// a key the filters rule out of the window is written at once, and a
+// key found in the active tier is answered at once.  A filter hit
+// that the active tier cannot settle -- the key is in history, or the
+// hit was a false positive -- is followed into history WITHOUT the
+// Mutex, so that the protocol path never holds the two locks together
+// and never waits on a history swap while holding the store: the
+// Mutex is released, history is read under its own lock, and the
+// Mutex is taken again for the write.  If the window rolled in
+// between (epoch), the whole check starts over, because a segment the
+// active walk saw may now be one the history walk missed.
+func (s *SegmentStore) putUnlessPresent(key [32]byte, value []byte, blind bool) (existing []byte, existed bool, err error) {
+	s.stats.putTotal.Add(1)
+	if blind {
+		s.Mutex.Lock()
+		defer s.Mutex.Unlock()
+		if err = s.checkOpen(); err != nil {
+			return nil, false, err
+		}
+		s.stats.putNew.Add(1)
+		return nil, false, s.writeRecord(key, value)
+	}
+	for {
+		s.Mutex.Lock()
+		existing, inWindow, found, err := s.lookupActive(key)
+		if err != nil {
+			s.Mutex.Unlock()
+			return nil, false, err
+		}
+		if found {
+			s.Mutex.Unlock()
+			return existing, true, nil
+		}
+		if !inWindow {
+			s.stats.putNew.Add(1)
+			err = s.writeRecord(key, value)
+			s.Mutex.Unlock()
+			return nil, false, err
+		}
+		epoch := s.epoch
+		s.Mutex.Unlock()
+
+		existing, err = s.lookupHistory(key, true)
+		if err == nil {
+			return existing, true, nil
+		}
+		if !errors.Is(err, errNotFound) {
+			return nil, false, err
+		}
+
+		s.Mutex.Lock()
+		if s.epoch != epoch {
+			s.Mutex.Unlock()
+			continue // The window rolled while history was being read
+		}
+		// The key could have arrived in the tail meanwhile; the active
+		// tier is the only place it can have gone, and it is still the
+		// same tier this loop looked at -- and already counted
+		existing, _, found, err = s.findActive(key, false)
+		if err == nil && !found {
+			s.stats.putNew.Add(1)
+			err = s.writeRecord(key, value)
+		}
+		s.Mutex.Unlock()
+		return existing, found, err
+	}
 }
 
 // writeRecord
@@ -1243,18 +1704,7 @@ func (s *SegmentStore) writeRecord(key [32]byte, value []byte) (err error) {
 	s.live[key] = &DBBKey{Offset: offset + segRecHdrSize, Length: uint64(len(value))}
 	s.liveRecords++
 	s.liveDirty = true
-	if s.filters != nil {
-		// Probe before Set: a key the store already holds means this
-		// record supersedes an older one, which is what compaction has
-		// to reclaim.  Only a mutable store can shadow -- an immutable
-		// one refuses the write instead -- so only it counts.  The
-		// window is the whole store for a mutable layer, whose block
-		// never advances, so the estimate is not windowed in practice.
-		if s.Mutable && s.filterTest(key) {
-			s.shadowed++
-		}
-		s.filterSet(key)
-	}
+	s.filterSet(key)
 	return nil
 }
 
@@ -1274,28 +1724,19 @@ func (s *SegmentStore) writeRecord(key [32]byte, value []byte) (err error) {
 // authorises the write; anything else is returned.  "Absent" means
 // absent from the window the key filters cover, as it does for Put.
 func (s *SegmentStore) PutIfAbsent(key [32]byte, value []byte) (existing []byte, existed bool, err error) {
-	s.Mutex.Lock()
-	defer s.Mutex.Unlock()
-	if err = s.checkOpen(); err != nil {
+	existing, existed, err = s.putUnlessPresent(key, value, false)
+	if err != nil || !existed {
 		return nil, false, err
 	}
-	s.stats.putTotal.Add(1)
-	switch existing, err = s.lookup(key, false); {
-	case err == nil:
-		// Split the two ways a key can already be here, because they
-		// mean opposite things: an identical rewrite is a write this
-		// check avoided, a differing one is a write it caught.
-		if bytes.Equal(existing, value) {
-			s.stats.putDuplicate.Add(1)
-		} else {
-			s.stats.putConflict.Add(1)
-		}
-		return existing, true, nil
-	case !errors.Is(err, errNotFound):
-		return nil, false, err
+	// Split the two ways a key can already be here, because they mean
+	// opposite things: an identical rewrite is a write this check
+	// avoided, a differing one is a write it caught.
+	if bytes.Equal(existing, value) {
+		s.stats.putDuplicate.Add(1)
+	} else {
+		s.stats.putConflict.Add(1)
 	}
-	s.stats.putNew.Add(1)
-	return nil, false, s.writeRecord(key, value)
+	return existing, true, nil
 }
 
 // LiveCount
@@ -1317,11 +1758,64 @@ func (s *SegmentStore) LiveRecords() uint64 {
 	return s.liveRecords
 }
 
+// unlinkLater
+// Queue files a commit has made unreachable for deletion by a
+// goroutine that holds no store lock.  The files are already named by
+// no manifest, so nothing depends on when the unlink happens: a crash
+// first leaves orphans that recoverOrphans sweeps on the next open.
+// Close and the tests wait for the queue to drain (awaitUnlinks).
+func (s *SegmentStore) unlinkLater(paths ...string) {
+	if len(paths) == 0 {
+		return
+	}
+	s.unlinkMu.Lock()
+	defer s.unlinkMu.Unlock()
+	s.unlinkQueue = append(s.unlinkQueue, paths...)
+	if s.unlinking {
+		return
+	}
+	if s.unlinkDone == nil {
+		s.unlinkDone = sync.NewCond(&s.unlinkMu)
+	}
+	s.unlinking = true
+	go s.drainUnlinks()
+}
+
+// drainUnlinks deletes queued files until the queue is empty
+func (s *SegmentStore) drainUnlinks() {
+	for {
+		s.unlinkMu.Lock()
+		if len(s.unlinkQueue) == 0 {
+			s.unlinking = false
+			s.unlinkDone.Broadcast()
+			s.unlinkMu.Unlock()
+			return
+		}
+		batch := s.unlinkQueue
+		s.unlinkQueue = nil
+		s.unlinkMu.Unlock()
+		for _, path := range batch {
+			s.retire(path)
+		}
+	}
+}
+
+// awaitUnlinks blocks until every queued deletion has been done
+func (s *SegmentStore) awaitUnlinks() {
+	s.unlinkMu.Lock()
+	defer s.unlinkMu.Unlock()
+	for s.unlinking {
+		s.unlinkDone.Wait()
+	}
+}
+
 // retire
 // Delete a file a commit has made unreachable, or defer the delete
-// until the iterations reading it have finished.  The caller must hold
-// the Mutex.
+// until the iterations and pinned snapshots reading it have finished.
+// Safe under either tier lock, or none.
 func (s *SegmentStore) retire(path string) {
+	s.retireMu.Lock()
+	defer s.retireMu.Unlock()
 	if s.iterating > 0 {
 		s.pendingDelete = append(s.pendingDelete, path)
 		return
@@ -1329,37 +1823,22 @@ func (s *SegmentStore) retire(path string) {
 	os.Remove(path)
 }
 
-// beginIterate
-// Take a snapshot to iterate: the sealed segments as they stand, and
-// the live tail's values copied out.  Holding the segments in a local
-// slice is what makes the iteration a snapshot; holding off deletion
-// is what keeps their files readable.  The caller must hold the Mutex.
-func (s *SegmentStore) beginIterate() (segs []*segment, live map[[32]byte][]byte, err error) {
-	if err = s.checkOpen(); err != nil {
-		return nil, nil, err
-	}
-	// The live tail is not a file the pool can hold open for us -- it is
-	// still being appended to -- so its values are copied out under the
-	// lock rather than read during the iteration
-	live = make(map[[32]byte][]byte, len(s.live))
-	for key, dbb := range s.live {
-		value := make([]byte, dbb.Length)
-		if err = s.liveFile.ReadAt(dbb.Offset, value); err != nil {
-			return nil, nil, err
-		}
-		live[key] = value
-	}
-	segs = append([]*segment(nil), s.segments...)
+// pin
+// Hold off every file deletion until unpin: what a snapshot of either
+// tier needs in order to read the files it names after the locks are
+// released.  Taken BEFORE the snapshot, so that nothing the snapshot
+// names can be deleted between the two.
+func (s *SegmentStore) pin() {
+	s.retireMu.Lock()
 	s.iterating++
-	return segs, live, nil
+	s.retireMu.Unlock()
 }
 
-// endIterate
-// Finish an iteration and, if it was the last, delete what a
-// compaction retired while it ran.
-func (s *SegmentStore) endIterate() {
-	s.Mutex.Lock()
-	defer s.Mutex.Unlock()
+// unpin releases a pin and, if it was the last, deletes what was
+// retired meanwhile
+func (s *SegmentStore) unpin() {
+	s.retireMu.Lock()
+	defer s.retireMu.Unlock()
 	s.iterating--
 	if s.iterating > 0 {
 		return
@@ -1368,6 +1847,48 @@ func (s *SegmentStore) endIterate() {
 		os.Remove(path)
 	}
 	s.pendingDelete = nil
+}
+
+// beginIterate
+// Take a snapshot to iterate: the sealed segments of both tiers as
+// they stand, history first, and the live tail's values copied out.
+// Holding the segments in a local slice is what makes the iteration a
+// snapshot; the pin is what keeps their files readable.  Each tier is
+// read under its own lock, one after the other, never both at once.
+// The caller must unpin when done.
+func (s *SegmentStore) beginIterate() (segs []*segment, live map[[32]byte][]byte, cold coldStore, err error) {
+	s.pin()
+	defer func() {
+		if err != nil {
+			s.unpin()
+		}
+	}()
+
+	s.Mutex.RLock()
+	if err = s.checkOpen(); err != nil {
+		s.Mutex.RUnlock()
+		return nil, nil, nil, err
+	}
+	// The live tail is not a file the pool can hold open for us -- it is
+	// still being appended to -- so its values are copied out under the
+	// lock rather than read during the iteration
+	live = make(map[[32]byte][]byte, len(s.live))
+	for key, dbb := range s.live {
+		value := make([]byte, dbb.Length)
+		if err = s.liveFile.ReadAt(dbb.Offset, value); err != nil {
+			s.Mutex.RUnlock()
+			return nil, nil, nil, err
+		}
+		live[key] = value
+	}
+	active := append([]*segment(nil), s.active...)
+	cold = s.cold
+	s.Mutex.RUnlock()
+
+	s.History.RLock()
+	segs = append(append([]*segment(nil), s.history...), active...)
+	s.History.RUnlock()
+	return segs, live, cold, nil
 }
 
 // BlockHeight
@@ -1426,16 +1947,32 @@ func (s *SegmentStore) sync() (err error) {
 	if err = s.checkOpen(); err != nil {
 		return err
 	}
-	if !s.liveDirty {
-		return nil
+	if s.liveDirty {
+		if err = s.liveFile.Flush(); err != nil {
+			return err
+		}
+		if err = s.liveFile.File.Sync(); err != nil {
+			return err
+		}
+		s.liveDirty = false
 	}
-	if err = s.liveFile.Flush(); err != nil {
-		return err
+	// A layer that is synced rather than sealed at the block boundary
+	// -- the Dyna layer -- may go many blocks between active commits,
+	// and history is waiting on the next one to finish a handoff or to
+	// delete the inputs of a compaction the active manifest still
+	// names.  Commit one here when there is anything to finish: two
+	// barriers, once per compaction, at a boundary that already pays
+	// for a sync.  Otherwise a compacted layer keeps its old
+	// generations on disk until its tail next fills.
+	s.handoffMu.Lock()
+	finish := len(s.retireAfterActiveCommit) > 0
+	for _, h := range s.handoffs {
+		finish = finish || h.recorded
 	}
-	if err = s.liveFile.File.Sync(); err != nil {
-		return err
+	s.handoffMu.Unlock()
+	if finish {
+		return s.writeManifest()
 	}
-	s.liveDirty = false
 	return nil
 }
 
@@ -1519,10 +2056,11 @@ func (s *SegmentStore) seal(height uint64, blockBoundary bool) (meta SegmentMeta
 	if err != nil {
 		return meta, err
 	}
-	s.segments = append(s.segments, seg)
+	s.active = append(s.active, seg)
 	// The tail's keys are in every live filter already, and the segment
 	// they now sit in is inside the window by construction, so the
-	// filters cover it; advancing the block is what may roll them
+	// filters cover it; advancing the block is what may roll them, and
+	// what may hand the oldest active segments to history
 	s.advanceBlock(height)
 	if blockBoundary {
 		s.advanceBlock(height + 1) // The next writes belong to the next block
@@ -1543,14 +2081,14 @@ func (s *SegmentStore) seal(height uint64, blockBoundary bool) (meta SegmentMeta
 // newestMeta
 // The newest sealed segment by (Height, Seq).  ok is false when the
 // store has no sealed segments, so that height 0 (a genesis block) is
-// a usable height rather than a sentinel.
+// a usable height rather than a sentinel.  The caller must hold the
+// Mutex; history is consulted through the identity the active tier
+// keeps of it (historyNewest), not through History.
 func (s *SegmentStore) newestMeta() (newest SegmentMeta, ok bool) {
-	for _, seg := range s.segments {
-		if !ok || seg.meta.after(newest) {
-			newest, ok = seg.meta, true
-		}
+	if n := len(s.active); n > 0 {
+		return s.active[n-1].meta, true
 	}
-	return newest, ok
+	return s.historyNewest, s.historyAny
 }
 
 // nextKeyAt
@@ -1722,77 +2260,177 @@ func (s *SegmentStore) rewriteLiveFile(dataPath string) (sl sealed, err error) {
 }
 
 // DefaultCompactRatio
-// The share of a mutable store's records that must be superseded
-// before compacting is worth what it costs.
+// How much newer data must have gathered behind a history segment, as
+// a share of that segment's size, before a compaction rewrites it to
+// fold that data in.
 //
-// Compaction rewrites the whole layer: every live value is copied.
-// Doing that on a cadence -- every K commits, which is how a node
-// drives it -- costs O(N) each time and O(N × commits/K) over a run,
-// so the price of reclaiming a fixed amount of garbage grows with the
-// database (issue #31).  Waiting until a fixed *fraction* is garbage
-// makes the amortised cost constant instead: a compaction still costs
-// O(N), but roughly N/(1-r) × r overwrites happen before the next one
-// is due, so the cost per overwrite settles at a constant that depends
-// on r and not on N.
+// History is compacted in runs (CompactHistory): the newest segments
+// are always the run, and an older segment joins it only once the run
+// has grown to this share of the older one.  That is what makes the
+// cost amortised: a segment is rewritten only when enough has arrived
+// to make the rewrite worth its size, so the bytes rewritten over a
+// store's life are a constant multiple -- a few levels deep -- of the
+// bytes written, rather than a whole-layer copy per compaction
+// (issue #31).  Between rewrites the older segment holds records the
+// run's newer copies have superseded; that space is bounded by this
+// ratio.
 //
-// 0.25 spends at most a third of the layer's space on garbage and
-// compacts about once per quarter-layer of overwrites.
+// 0.25 folds a segment in once a quarter of its size has gathered
+// behind it.
 const DefaultCompactRatio = 0.25
 
-// CompactRatio is the ratio Compress uses.  Raise it to compact less
-// often and hold more garbage; lower it for the reverse.
+// CompactRatio is the ratio CompactHistory uses.  Raise it to rewrite
+// large segments less often and hold more garbage; lower it for the
+// reverse.
 var CompactRatio = DefaultCompactRatio
 
-// worthCompacting
-// Whether enough of this store is superseded records to pay for a
-// compaction.  The caller must hold the Mutex.
-//
-// An unmeasurable store -- no key filter, so no estimate -- says yes:
-// compacting when it was not needed costs time, and skipping when it
-// was needed costs unbounded space.
-func (s *SegmentStore) worthCompacting(ratio float64) bool {
-	if !s.Mutable || s.filters == nil {
-		return true
+// compactionRun
+// The suffix of history worth compacting into one segment: the newest
+// segment, and each older one in turn while it is no larger than
+// 1/ratio times what has gathered behind it.  A run shorter than two
+// is nothing to do.  Sized by physical record count, which every
+// segment holds in memory, so choosing costs no I/O.
+func compactionRun(history []*segment, ratio float64) (run []*segment) {
+	n := len(history)
+	if n == 0 {
+		return nil
 	}
-	var records uint64
-	for _, seg := range s.segments {
-		records += uint64(seg.records)
+	var behind float64
+	i := n - 1
+	for ; i >= 0; i-- {
+		if i < n-1 && float64(history[i].records)*ratio > behind {
+			break // Too big for what has gathered behind it, and so is everything older
+		}
+		behind += float64(history[i].records)
 	}
-	records += s.liveRecords
-	if records == 0 {
-		return false
+	if run = history[i+1:]; len(run) < 2 {
+		return nil
 	}
-	return float64(s.shadowed) >= ratio*float64(records)
+	return run
 }
 
-// Compact
-// Replace every sealed segment with one new segment holding only the
-// keys that are still live, and commit it by replacing the manifest.
+// CompactHistory
+// Reclaim what overwriting left behind in history: rewrite the run of
+// history segments compactionRun chooses into one segment holding
+// only the newest record for each key in the run.  Reports whether
+// anything was compacted.
 //
-// Crash-atomic: the new generation is fully durable before the
-// manifest names it, and a crash before that leaves the old generation
-// in force (issue #19).  The live tail is untouched.
-func (s *SegmentStore) Compact(height uint64) (meta SegmentMeta, err error) {
-	s.Mutex.Lock()
-	defer s.Mutex.Unlock()
-	return s.compact(height)
+// This is the Dyna layer's compaction, and it touches HISTORY ONLY.  A
+// record written inside the window -- the last N to 2N blocks -- is in
+// the active tier, and compaction never reads or rewrites it; what it
+// reclaims is a record superseded by a later one that has also left
+// the window.  A record in history superseded only by an active one
+// stays until that newer record reaches history and a run includes
+// both, which bounds the garbage compaction cannot yet see by the size
+// of the window, not the size of the layer.  It replaced Compact, which
+// rewrote every generation under the store lock: on a node whose
+// dynamic layer had grown to 9.8 GB that was a 23-32 s pause of every
+// commit and every read, every 128 blocks (issue #57).
+//
+// The copy takes no store lock: the inputs are immutable and the
+// output is written aside.  History is taken exclusively only to swap
+// the run for its replacement and commit history.json, and the swap
+// checks that the run is still exactly where it was -- a drop or an
+// import could have changed history meanwhile -- and abandons the
+// output if not.  The identity is the sequence after the run's
+// newest, which is free: everything in history is below the window
+// and the run is history's newest suffix.  Crash safety is the merge's
+// rule: an uncommitted output sits below the newest active segment
+// and recoverOrphans deletes it, while the inputs are still named.
+func (s *SegmentStore) CompactHistory() (compacted bool, err error) {
+	s.maint.Lock()
+	defer s.maint.Unlock()
+
+	s.History.RLock()
+	if err = s.checkOpen(); err != nil {
+		s.History.RUnlock()
+		return false, err
+	}
+	run := compactionRun(s.history, CompactRatio)
+	at := len(s.history) - len(run) // Where the run sits: history's newest suffix
+	s.History.RUnlock()
+	if run == nil {
+		return false, nil
+	}
+	// A run of one segment that holds one record per key has nothing
+	// to reclaim; compactionRun already refuses runs shorter than two,
+	// so anything here has at least two segments to fold together.
+
+	winners, keys, err := s.mergeInputs(run)
+	if err != nil {
+		return false, err
+	}
+	last := run[len(run)-1].meta
+	meta, seg, err := s.writeMergedSegment(winners, keys, last.Height, last.Seq+1)
+	if err != nil {
+		return false, err
+	}
+	// The new segment holds every key of every input, so it reaches
+	// back as far as the oldest of them
+	meta.Span = last.Height - run[0].meta.first()
+	seg.meta = meta
+	if maintenanceHook != nil {
+		maintenanceHook()
+	}
+
+	return s.swapHistory(run, seg, at)
 }
 
-// CompactNext
-// Compact at the next available height.  The Dyna layer numbers its
-// segments by generation rather than by block height, so it compacts
-// by generation too.
-func (s *SegmentStore) CompactNext() (meta SegmentMeta, err error) {
-	s.Mutex.Lock()
-	defer s.Mutex.Unlock()
-	return s.compact(s.blockHeight)
+// swapHistory
+// Commit a history operation: replace `run`, which must still be the
+// n-th through last..th segments of history, with `out`, and write the
+// history manifest.  Takes History exclusively for exactly that.  If
+// history no longer holds the run where it was, or the commit fails,
+// the output is discarded and history is left as it was.  The caller
+// must hold maint.
+func (s *SegmentStore) swapHistory(run []*segment, out *segment, at int) (ok bool, err error) {
+	s.History.Lock()
+	defer s.History.Unlock()
+	discard := func() {
+		out.close()
+		s.unlinkLater(out.dataPath, out.indexPath)
+	}
+	if err = s.checkOpen(); err != nil {
+		discard()
+		return false, err
+	}
+	if at < 0 || at+len(run) > len(s.history) {
+		discard()
+		return false, nil
+	}
+	for i, seg := range run {
+		if s.history[at+i] != seg {
+			discard()
+			return false, nil // History changed under the copy
+		}
+	}
+	old := s.history
+	s.history = make([]*segment, 0, len(old)-len(run)+1)
+	s.history = append(s.history, old[:at]...)
+	s.history = append(s.history, out)
+	s.history = append(s.history, old[at+len(run):]...)
+	if err = s.writeHistoryManifest(); err != nil {
+		s.history = old // Uncommitted; the inputs still stand
+		discard()
+		return false, err
+	}
+	for _, seg := range run {
+		s.releaseFromHistory(seg)
+	}
+	return true, nil
 }
+
+// maintenanceHook, when set, is called by a history operation after
+// its copy and before its swap, with no store lock held.  It exists so
+// that a test can hold a merge or a compaction at that point and show
+// what the protocol path can do meanwhile.  Nil except under test.
+var maintenanceHook func()
 
 // writeMergedSegment
 // Write the resolved keys and values of a merge into a new sealed
-// segment at (height, seq), build its index, and open it.  The caller
-// must hold the Mutex and is responsible for committing it into the
-// segment list.
+// segment at (height, seq), build its index, and open it.  No lock is
+// needed -- the inputs are immutable -- and the caller is responsible
+// for committing it into the segment list.
 //
 // The segment is complete and durable when this returns; it is simply
 // not yet named by the manifest, which is what makes the commit that
@@ -2027,7 +2665,7 @@ func shiftedIndex(segs []*segment, bases []uint64) (records []byte, err error) {
 // becomes dead bytes.  That is the trade: a little space in exchange
 // for never touching a value.
 //
-// The caller must hold the Mutex.
+// No lock: the sources are immutable and the output is written aside.
 func (s *SegmentStore) concatSegments(segs []*segment, height, seq uint64) (meta SegmentMeta, merged *segment, err error) {
 	// The index first: it needs only the sizes, and it is where a
 	// damaged source would be found, before anything is written
@@ -2112,7 +2750,7 @@ func (s *SegmentStore) concatSegments(segs []*segment, height, seq uint64) (meta
 }
 
 // MergeBelow
-// Merge every sealed segment belonging to a block below `height` into
+// Merge every history segment belonging to a block below `height` into
 // one, leaving the rest untouched.  Reports whether it merged anything.
 //
 // This is tier one of keeping the file count survivable.  A block
@@ -2125,15 +2763,26 @@ func (s *SegmentStore) concatSegments(segs []*segment, height, seq uint64) (meta
 //
 // It merges WITHIN one store, never across shards.  That keeps the
 // working set small -- a shard holds a few hundred entries per set --
-// and keeps the merge under the shard's own lock, so shards merge
-// independently and in parallel.  Merging across shards is what
-// produces globally sorted runs, and it is a separate, rarer pass.
+// so shards merge independently and in parallel.  Merging across
+// shards is what produces globally sorted runs, and it is a separate,
+// rarer pass.
 //
 // `height` is the caller's finalisation watermark: the block below
 // which nothing more will arrive and nothing is still being healed.
 // Segments at or above it are left alone, so a block a peer might
 // still ask for by number is never merged away, and block export is
-// untouched.
+// untouched.  Only HISTORY is merged: a segment still inside the
+// window is the protocol's, whatever the watermark says, and it is
+// merged once the window has rolled past it.  The watermark is free
+// to lag behind the window, and so is the merge behind the watermark;
+// nothing about correctness needs either to be current (issue #47).
+//
+// The copy takes no store lock.  Sealed segments are immutable and the
+// pool hands out descriptors for pread, so the run is read and the
+// merged file written aside while commits and reads carry on; History
+// is taken exclusively only to swap the run for the merged segment and
+// commit history.json.  A concurrent read of history sees either the
+// run or the merged segment, and both hold the same keys.
 //
 // Crash safety follows the same rule as compaction.  The merged file
 // is written and renamed before the manifest names it, and it takes an
@@ -2143,24 +2792,27 @@ func (s *SegmentStore) concatSegments(segs []*segment, height, seq uint64) (meta
 // manifest and are only retired after the commit succeeds, so the
 // discarded merge costs space and nothing else.
 func (s *SegmentStore) MergeBelow(height uint64) (meta SegmentMeta, merged bool, err error) {
-	s.Mutex.Lock()
-	defer s.Mutex.Unlock()
+	s.maint.Lock()
+	defer s.maint.Unlock()
+
+	s.History.RLock()
 	if err = s.checkOpen(); err != nil {
+		s.History.RUnlock()
 		return meta, false, err
 	}
-
 	// Segments are oldest first, so the finalised ones are a prefix
 	n := 0
-	for _, seg := range s.segments {
+	for _, seg := range s.history {
 		if seg.meta.Height >= height {
 			break
 		}
 		n++
 	}
+	run := append([]*segment(nil), s.history[:n]...)
+	s.History.RUnlock()
 	if n < 2 {
 		return meta, false, nil // Nothing to gain from merging one segment
 	}
-	run := s.segments[:n]
 
 	// The merged segment takes the sequence after the newest it
 	// replaces.  That is free and correctly ordered: everything merged
@@ -2180,68 +2832,66 @@ func (s *SegmentStore) MergeBelow(height uint64) (meta SegmentMeta, merged bool,
 	// run's first block never saw its oldest keys and must not claim it.
 	meta.Span = outHeight - run[0].meta.first()
 	seg.meta = meta
-
-	// Commit: the manifest names the merged segment in place of the run
-	old := s.segments
-	s.segments = append([]*segment{seg}, old[n:]...)
-	if err = s.writeManifest(); err != nil {
-		s.segments = old // Uncommitted; the originals still stand
-		seg.close()
-		s.retire(seg.dataPath)
-		s.retire(seg.indexPath)
-		return meta, false, err
+	if maintenanceHook != nil {
+		maintenanceHook()
 	}
 
-	for _, o := range run {
-		o.close()
-		s.retire(o.dataPath)
-		s.retire(o.indexPath)
-	}
-	return meta, true, nil
+	merged, err = s.swapHistory(run, seg, 0)
+	return meta, merged, err
 }
 
-// segmentsBelow
-// The sealed segments belonging to blocks below `height`, oldest
-// first.  Segments are kept in order, so it is a prefix of the list.
-func (s *SegmentStore) segmentsBelow(height uint64) (segs []*segment, err error) {
-	s.Mutex.Lock()
-	defer s.Mutex.Unlock()
+// historyBelow
+// The history segments belonging to blocks below `height`, oldest
+// first, pinned: their files stay readable until release is called,
+// whatever a merge or a drop does to them meanwhile.  Takes History
+// shared for the length of the copy of the list.
+func (s *SegmentStore) historyBelow(height uint64) (segs []*segment, release func(), err error) {
+	s.pin()
+	s.History.RLock()
+	defer s.History.RUnlock()
 	if err = s.checkOpen(); err != nil {
-		return nil, err
+		s.unpin()
+		return nil, nil, err
 	}
 	n := 0
-	for _, seg := range s.segments {
+	for _, seg := range s.history {
 		if seg.meta.Height >= height {
 			break
 		}
 		n++
 	}
-	return append([]*segment(nil), s.segments[:n]...), nil
+	return append([]*segment(nil), s.history[:n]...), s.unpin, nil
 }
 
 // DropBelow
-// Stop serving the sealed segments belonging to blocks below `height`
-// from this store, because their keys are now held cold.  Reports how
+// Stop serving the history segments belonging to blocks below `height`
+// from this store, because their keys are now held cold: commit a
+// history manifest without them and retire their files.  Reports how
 // many were dropped.
 //
-// No manifest is written.  Dropping is a consequence of a commit that
-// has already happened -- the block set holding these keys is durable
-// before anyone calls this -- so nothing is lost by recording it late,
-// and recording it now would cost two barriers per shard for a fact the
-// shard's next seal records for free.  The files stay until then
-// (retireOnCommit), still named by the manifest and still whole, so a
-// crash in between leaves a store that opens exactly as before and
-// simply drops them again.
+// The commit is this store's own, two barriers, off the protocol
+// path.  It used to be deferred to the shard's next seal, which
+// recorded it for free -- but the seal writes the active manifest
+// now and the drop is history's to record, and leaving the files to
+// the next merge would keep a packed set's worth of segments on disk
+// in every shard that merges rarely.  A pack drops its shards
+// concurrently, so the barriers overlap.  Dropping is a consequence
+// of a commit that has already happened -- the block set holding
+// these keys is durable before anyone calls this -- so a crash before
+// this commit leaves a store that opens exactly as before and simply
+// drops them again.
 //
 // The caller asserts the keys are held cold; the store cannot check.
 func (s *SegmentStore) DropBelow(height uint64) (dropped int, err error) {
-	s.Mutex.Lock()
-	defer s.Mutex.Unlock()
+	s.maint.Lock()
+	defer s.maint.Unlock()
+	s.History.Lock()
+	defer s.History.Unlock()
 	if err = s.checkOpen(); err != nil {
 		return 0, err
 	}
 	n := 0
-	for _, seg := range s.segments {
+	for _, seg := range s.history {
 		if seg.meta.Height >= height {
 			break
 		}
@@ -2250,8 +2900,15 @@ func (s *SegmentStore) DropBelow(height uint64) (dropped int, err error) {
 	if n == 0 {
 		return 0, nil
 	}
-	s.retireOnCommit = append(s.retireOnCommit, s.segments[:n]...)
-	s.segments = append([]*segment(nil), s.segments[n:]...)
+	old := s.history
+	s.history = append([]*segment(nil), old[n:]...)
+	if err = s.writeHistoryManifest(); err != nil {
+		s.history = old
+		return 0, err
+	}
+	for _, seg := range old[:n] {
+		s.releaseFromHistory(seg)
+	}
 	return n, nil
 }
 
@@ -2273,7 +2930,7 @@ type mergeInput struct {
 // one.  The copies agree, so which one survives does not matter -- but
 // the merge still has to emit only one.
 //
-// The caller must hold the Mutex.
+// No lock: the segments are immutable and the caller holds them.
 func (s *SegmentStore) mergeInputs(segs []*segment) (winners map[[32]byte]mergeInput, keys [][32]byte, err error) {
 	winners = make(map[[32]byte]mergeInput)
 	for i := len(segs) - 1; i >= 0; i-- { // Newest first, so it wins
@@ -2306,93 +2963,32 @@ func (s *SegmentStore) mergeInputs(segs []*segment) (winners map[[32]byte]mergeI
 	return winners, keys, nil
 }
 
-// compact is Compact; the caller must hold the Mutex
-func (s *SegmentStore) compact(height uint64) (meta SegmentMeta, err error) {
-	if err = s.checkOpen(); err != nil {
-		return meta, err
-	}
-	if len(s.segments) == 0 {
-		return meta, nil
-	}
-	seq, err := s.nextKeyAt(height)
-	if err != nil {
-		return meta, err
-	}
-	s.advanceBlock(height)
-
-	// A single generation holding one record per key has nothing to
-	// reclaim: rewriting it would copy every value to produce the same
-	// file.  The Dyna layer compacts on a write count, so it lands here
-	// whenever a compaction has already run since the last seal.  The
-	// meta returned is the standing generation's, at its own height --
-	// not the height asked for, since no segment was written.
-	//
-	// count is the index's key count and records the data file's
-	// physical count, so their being equal is exactly "no key appears
-	// twice", which is what there would be to reclaim.
-	if len(s.segments) == 1 && s.segments[0].count == s.segments[0].records {
-		return s.segments[0].meta, nil
-	}
-
-	winners, keys, err := s.mergeInputs(s.segments)
-	if err != nil {
-		return meta, err
-	}
-
-	meta, seg, err := s.writeMergedSegment(winners, keys, height, seq)
-	if err != nil {
-		return meta, err
-	}
-	// The new generation holds every key of every old one, so it reaches
-	// back as far as the oldest of them
-	meta.Span = height - s.segments[0].meta.first()
-	seg.meta = meta
-
-	// Commit: the manifest now names only the new generation
-	old := s.segments
-	s.segments = []*segment{seg}
-	if err = s.writeManifest(); err != nil {
-		s.segments = old // Uncommitted; keep serving the old generation
-		seg.close()
-		return meta, err
-	}
-
-	// Committed.  The old files are unreachable; removing them is
-	// cleanup, and anything left behind is swept on the next open.
-	for _, o := range old {
-		o.close()
-		s.retire(o.dataPath)
-		s.retire(o.indexPath)
-	}
-
-	// Compaction is the one moment the true key set is already in hand:
-	// what survived is exactly the new generation plus the live tail.
-	// Keeping the old filters would only cost lookups -- they can name
-	// keys that are gone but never miss one that stayed -- but a
-	// rebuild here is free of that drift and bounds the layer count.
-	if s.filters != nil {
-		if err := s.rebuildKeyFilters(); err != nil {
-			s.filters = nil // Correct, just slower: lookups walk again
-		}
-	}
-	// Everything that was superseded has just been dropped; the count
-	// starts again from what the new generation accumulates
-	s.shadowed = 0
-	return meta, nil
-}
-
 // SegmentPaths
 // The sealed segment files backing this store, oldest first, with the
 // manifest metadata that identifies and verifies each one.  Syncing a
 // peer is copying these files.
 func (s *SegmentStore) SegmentPaths() (metas []SegmentMeta, paths []string) {
-	s.Mutex.Lock()
-	defer s.Mutex.Unlock()
-	for _, seg := range s.segments {
+	for _, seg := range s.sealedSegments() {
 		metas = append(metas, seg.meta)
 		paths = append(paths, filepath.Join(s.Directory, seg.meta.File))
 	}
 	return metas, paths
+}
+
+// sealedSegments
+// Both tiers as they stand, history then active, oldest first.  Each
+// tier is read under its own lock, one after the other: the list can
+// name a segment twice or miss one that moved between the two reads
+// only if the window rolled in between, which a caller wanting a
+// consistent view avoids by not sealing meanwhile.
+func (s *SegmentStore) sealedSegments() (segs []*segment) {
+	s.History.RLock()
+	segs = append(segs, s.history...)
+	s.History.RUnlock()
+	s.Mutex.RLock()
+	segs = append(segs, s.active...)
+	s.Mutex.RUnlock()
+	return segs
 }
 
 // ImportSegmentFile
@@ -2413,14 +3009,12 @@ func (s *SegmentStore) ImportSegmentFile(path string, meta SegmentMeta) (err err
 		return fmt.Errorf("segment (block %d, seq %d) claims to reach %d blocks back", meta.Height, meta.Seq, meta.Span)
 	}
 
-	for _, seg := range s.segments {
+	// Only the active tier can hold it: a peer's segment is at or above
+	// the window, and one in history would fail the ordering check below
+	for _, seg := range s.active {
 		if seg.meta.Height == meta.Height && seg.meta.Seq == meta.Seq && seg.meta.Hash == meta.Hash {
 			return nil // Already have it
 		}
-	}
-	if newest, ok := s.newestMeta(); ok && !meta.after(newest) {
-		return fmt.Errorf("segment (block %d, seq %d) is not above the newest segment (block %d, seq %d)",
-			meta.Height, meta.Seq, newest.Height, newest.Seq)
 	}
 	// A block already packed into a set is finalized: the set is what
 	// answers for it, and a store that has dropped every segment has no
@@ -2430,6 +3024,10 @@ func (s *SegmentStore) ImportSegmentFile(path string, meta SegmentMeta) (err err
 			return fmt.Errorf("segment (block %d, seq %d) is not above the newest block set, which ends at block %d",
 				meta.Height, meta.Seq, last)
 		}
+	}
+	if newest, ok := s.newestMeta(); ok && !meta.after(newest) {
+		return fmt.Errorf("segment (block %d, seq %d) is not above the newest segment (block %d, seq %d)",
+			meta.Height, meta.Seq, newest.Height, newest.Seq)
 	}
 	if err = VerifySegmentFile(path, meta.Hash); err != nil {
 		return err
@@ -2502,7 +3100,22 @@ func (s *SegmentStore) ImportSegmentFile(path string, meta SegmentMeta) (err err
 	seg.dataPath, seg.indexPath = dataPath, indexPath
 	s.advanceBlock(meta.Height)
 
-	s.segments = append(s.segments, seg)
+	if seg.meta.first() < s.tierStart() {
+		// A segment reaching below the window belongs to history, and
+		// the filters must not claim it.  It is the newest thing in the
+		// store, so it goes last, and the active manifest names it
+		// until a history commit does (a handoff, like any other).
+		s.History.Lock()
+		s.history = append(s.history, seg)
+		s.historyNewest, s.historyAny = seg.meta, true
+		s.handoffMu.Lock()
+		s.handoffs = append(s.handoffs, handoff{seg: seg})
+		s.handoffMu.Unlock()
+		s.History.Unlock()
+		s.epoch++
+		return s.writeManifest() // Commit
+	}
+	s.active = append(s.active, seg)
 	// Into every live filter, whether or not the segment's block is in
 	// its range: a filter holding a key it need not is slower, never
 	// wrong, and the segment is the newest thing in the store
@@ -2519,9 +3132,14 @@ func (s *SegmentStore) ImportSegmentFile(path string, meta SegmentMeta) (err err
 // Verify that no key in an incoming segment already has a different
 // value in this store, within the window the key filters cover: the
 // same N-to-2N-block guarantee a write gets, for the same reason (see
-// lookup).  A peer's segment is always the newest thing in the store,
-// so what it could diverge from is recent by construction.  The
-// caller must hold the Mutex, and seg must not yet be in s.segments.
+// Put).  A peer's segment is always the newest thing in the store, so
+// what it could diverge from is recent by construction.  The caller
+// must hold the Mutex, and seg must not yet be in either tier.
+//
+// A filter hit is followed into history under History, shared, while
+// the Mutex is held -- the one nesting the protocol path never does.
+// An import is not the protocol path: a node syncing is not one in
+// consensus, and what it waits for is at most a history swap.
 func (s *SegmentStore) checkNoConflicts(seg *segment) (err error) {
 	index, release, err := seg.index() // One borrow for the whole scan
 	if err != nil {
@@ -2544,8 +3162,20 @@ func (s *SegmentStore) checkNoConflicts(seg *segment) (err error) {
 			if err != nil {
 				return err
 			}
-			existing, err := s.lookup(key, false) // Filter-gated; no disk I/O unless a filter hits
+			// Filter-gated; no disk I/O unless a filter hits, and history
+			// only on a hit the active tier could not settle
+			existing, inWindow, found, err := s.lookupActive(key)
 			if err != nil {
+				return err
+			}
+			if !found && inWindow {
+				existing, err = s.lookupHistory(key, true)
+				found = err == nil
+				if err != nil && !errors.Is(err, errNotFound) {
+					return err
+				}
+			}
+			if !found {
 				continue // Not held locally: the common case
 			}
 			incoming, err := seg.value(dbb)
@@ -2566,20 +3196,31 @@ func (s *SegmentStore) checkNoConflicts(seg *segment) (err error) {
 func (s *SegmentStore) Close() (err error) {
 	s.Mutex.Lock()
 	defer s.Mutex.Unlock()
+	s.History.Lock() // Both, in the one order they may nest; not the protocol path
+	defer s.History.Unlock()
+	if s.closed.Load() {
+		return nil
+	}
 
-	// Persist the key filters, then record in the manifest that they
-	// are current -- in that order, so a crash between the two leaves a
-	// manifest saying "rebuild" rather than one pointing at filters that
-	// have fallen behind the segments.  A save that fails is not a
+	// History first, then the active manifest: the history commit
+	// records every handoff, and the active commit that follows is the
+	// one that may stop naming them and delete what history retired.
+	// Then the key filters, and the manifest that says they are
+	// current -- in that order, so a crash between the two leaves a
+	// manifest saying "rebuild" rather than one pointing at filters
+	// that have fallen behind the segments.  A save that fails is not a
 	// reason to fail the close: the next open rebuilds.
-	if !s.closed && s.filters != nil {
+	if err = s.writeHistoryManifest(); err != nil {
+		return err
+	}
+	if s.filters != nil {
 		if claim, err := s.saveKeyFilters(); err == nil {
 			s.filterSaved = claim
 			s.filterValid = true
-			if err := s.writeManifest(); err != nil {
-				return err
-			}
 		}
+	}
+	if err = s.writeManifest(); err != nil {
+		return err
 	}
 
 	if s.liveFile != nil && s.liveFile.File != nil {
@@ -2587,11 +3228,16 @@ func (s *SegmentStore) Close() (err error) {
 			return err
 		}
 	}
-	for _, seg := range s.segments {
+	for _, seg := range s.active {
 		seg.close()
 	}
-	s.segments = nil
-	s.closed = true
+	for _, seg := range s.history {
+		seg.close()
+	}
+	s.active, s.history = nil, nil
+	s.historyNewest, s.historyAny = SegmentMeta{}, false
+	s.closed.Store(true)
+	s.awaitUnlinks() // So that a closed store has deleted what it retired
 	return nil
 }
 

--- a/database/segstore_bench_test.go
+++ b/database/segstore_bench_test.go
@@ -158,8 +158,10 @@ func TestDynaCost(t *testing.T) {
 	dir := filepath.Join(base, "dyna")
 	store, err := NewSegmentStore(dir, true)
 	require.NoError(t, err)
+	require.NoError(t, store.SetFilterBlocks(MinFilterBlocks))
 	vr := NewFastRandom([]byte{121, 121})
 	written := 0
+	block := uint64(0)
 	start := time.Now()
 	for round := 0; round < rounds; round++ {
 		for i := range keys {
@@ -173,16 +175,22 @@ func TestDynaCost(t *testing.T) {
 				require.NoError(t, err)
 			}
 			if written++; written%compressEvery == 0 {
+				// Compaction works on history: what the window has
+				// rolled past.  Roll it past everything sealed so far.
 				_, err = store.SealNext()
 				require.NoError(t, err)
-				_, err = store.CompactNext()
+				block += 3 * MinFilterBlocks
+				store.AdvanceBlock(block)
+				_, err = store.CompactHistory()
 				require.NoError(t, err)
 			}
 		}
 	}
 	_, err = store.SealNext()
 	require.NoError(t, err)
-	_, err = store.CompactNext()
+	block += 3 * MinFilterBlocks
+	store.AdvanceBlock(block)
+	_, err = store.CompactHistory()
 	require.NoError(t, err)
 	elapsed := time.Since(start)
 	require.NoError(t, store.Close())

--- a/database/segstore_test.go
+++ b/database/segstore_test.go
@@ -175,6 +175,7 @@ func TestSegmentStoreCompact(t *testing.T) {
 	dir := storeDir(t, "s")
 	store, err := NewSegmentStore(dir, true)
 	require.NoError(t, err)
+	require.NoError(t, store.SetFilterBlocks(MinFilterBlocks))
 
 	kr := NewFastRandom([]byte{104})
 	vr := NewFastRandom([]byte{104, 104})
@@ -195,13 +196,22 @@ func TestSegmentStoreCompact(t *testing.T) {
 	}
 
 	sizeBefore := dirSize(t, dir)
-	require.Len(t, store.segments, 10, "should have ten sealed segments")
+	require.Len(t, store.sealedSegments(), 10, "should have ten sealed segments")
 
-	meta, err := store.Compact(11)
+	ageOut(t, store) // Compaction works on history: roll the window past them
+	compacted, err := store.CompactHistory()
 	require.NoError(t, err, "compact")
+	require.True(t, compacted)
+	require.Len(t, store.sealedSegments(), 1, "compaction should leave one generation")
+	meta := store.sealedSegments()[0].meta
 	assert.Equal(t, uint64(200), meta.Count, "compacted generation should hold the live keys")
-	require.Len(t, store.segments, 1, "compaction should leave one generation")
 
+	// The old generations were handoffs the active manifest still
+	// named, so their files wait for the next active commit
+	require.NoError(t, store.Put(kr.NextHash(), []byte("after")))
+	_, err = store.SealNext()
+	require.NoError(t, err)
+	store.awaitUnlinks()
 	sizeAfter := dirSize(t, dir)
 	assert.Lessf(t, sizeAfter, sizeBefore/5, "space not reclaimed (%d -> %d)", sizeBefore, sizeAfter)
 
@@ -274,7 +284,7 @@ func TestSegmentStoreSyncIsFileCopy(t *testing.T) {
 
 	// Re-import is a no-op (interrupted syncs resume)
 	require.NoError(t, dst.ImportSegmentFile(paths[2], metas[2]))
-	require.Len(t, dst.segments, 3)
+	require.Len(t, dst.sealedSegments(), 3)
 
 	// A tampered file is rejected
 	tampered := filepath.Join(os.TempDir(), t.Name()+"_tampered.dat")
@@ -325,7 +335,7 @@ func TestSegmentStoreRecovery(t *testing.T) {
 	// Open must adopt the orphaned segment (and rebuild its index)
 	store, err = OpenSegmentStore(dir)
 	require.NoError(t, err, "open must recover the orphaned segment")
-	require.Len(t, store.segments, 1, "orphaned segment should be adopted")
+	require.Len(t, store.sealedSegments(), 1, "orphaned segment should be adopted")
 	for i := range keys {
 		v, err := store.Get(keys[i])
 		require.NoErrorf(t, err, "key %d lost in recovery", i)
@@ -451,7 +461,7 @@ func TestSegmentStoreClosedRejectsOperations(t *testing.T) {
 			require.NoError(t, err)
 		}
 	}
-	sealed := len(store.segments)
+	sealed := len(store.sealedSegments())
 	require.Equal(t, 5, sealed, "expected five sealed segments")
 	require.NoError(t, store.Close())
 
@@ -463,15 +473,15 @@ func TestSegmentStoreClosedRejectsOperations(t *testing.T) {
 	require.ErrorIs(t, err, errStoreClosed, "Seal on a closed store")
 	_, err = store.SealNext()
 	require.ErrorIs(t, err, errStoreClosed, "SealNext on a closed store")
-	_, err = store.Compact(99)
-	require.ErrorIs(t, err, errStoreClosed, "Compact on a closed store")
-	_, err = store.CompactNext()
-	require.ErrorIs(t, err, errStoreClosed, "CompactNext on a closed store")
+	_, err = store.CompactHistory()
+	require.ErrorIs(t, err, errStoreClosed, "CompactHistory on a closed store")
+	_, _, err = store.MergeBelow(99)
+	require.ErrorIs(t, err, errStoreClosed, "MergeBelow on a closed store")
 
 	// and nothing they did may have reached the manifest
 	reopened, err := OpenSegmentStore(dir)
 	require.NoError(t, err)
-	require.Len(t, reopened.segments, sealed, "sealed segments lost")
+	require.Len(t, reopened.sealedSegments(), sealed, "sealed segments lost")
 	for i, key := range keys {
 		got, err := reopened.Get(key)
 		require.NoErrorf(t, err, "key %d lost", i)
@@ -558,8 +568,8 @@ func TestAutoSealDoesNotConsumeBlockHeights(t *testing.T) {
 		_, err = store.SealNext()
 		require.NoError(t, err)
 	}
-	require.Len(t, store.segments, 8)
-	for i, seg := range store.segments {
+	require.Len(t, store.sealedSegments(), 8)
+	for i, seg := range store.sealedSegments() {
 		assert.Equal(t, uint64(0), seg.meta.Height, "auto-seal %d must stay in block 0", i)
 		assert.Equal(t, uint64(i), seg.meta.Seq, "auto-seal %d must take the next sequence", i)
 	}

--- a/database/tiering_test.go
+++ b/database/tiering_test.go
@@ -1,0 +1,534 @@
+package blockchainDB
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Two tiers, two locks (issue #57).
+//
+// The active tier -- the live tail and the sealed segments of the last
+// N to 2N blocks -- is the protocol's, under Mutex.  History -- every
+// older segment -- is the maintainer's, under History.  Neither side
+// takes the other's lock on its way, so a merge or a compaction never
+// stops a commit or a read, and a commit never stops a merge.  Most
+// of these tests are deterministic rather than timings: hold one lock
+// from outside and show the other side still runs.  Two use the
+// maintenance hook to hold a merge and a compaction between their
+// copy and their swap, which is the moment the old code held the
+// store lock through, and show a Put, a Seal and a Get complete
+// meanwhile.
+
+// tieredStore seals `blocks` blocks of `perBlock` keys with N =
+// MinFilterBlocks, so that the last N to 2N blocks are active and
+// everything older is history, and returns the keys by block.
+func tieredStore(t *testing.T, dir string, seed byte, mutable bool, blocks, perBlock int) (store *SegmentStore, keys [][][32]byte) {
+	t.Helper()
+	store, err := NewSegmentStore(dir, mutable)
+	require.NoError(t, err)
+	require.NoError(t, store.SetFilterBlocks(MinFilterBlocks))
+	kr := NewFastRandom([]byte{seed})
+	keys = make([][][32]byte, blocks+1)
+	for h := 1; h <= blocks; h++ {
+		for i := 0; i < perBlock; i++ {
+			key := kr.NextHash()
+			require.NoError(t, store.Put(key, []byte(fmt.Sprintf("b%d-%d", h, i))))
+			keys[h] = append(keys[h], key)
+		}
+		_, err = store.Seal(uint64(h))
+		require.NoError(t, err)
+	}
+	return store, keys
+}
+
+// tiers reads both lists' heights, each under its own lock
+func tiers(s *SegmentStore) (history, active []uint64) {
+	s.History.RLock()
+	for _, seg := range s.history {
+		history = append(history, seg.meta.Height)
+	}
+	s.History.RUnlock()
+	s.Mutex.RLock()
+	for _, seg := range s.active {
+		active = append(active, seg.meta.Height)
+	}
+	s.Mutex.RUnlock()
+	return history, active
+}
+
+// within runs fn and fails if it takes longer than d
+func within(t *testing.T, d time.Duration, what string, fn func() error) {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- fn() }()
+	select {
+	case err := <-done:
+		require.NoError(t, err, what)
+	case <-time.After(d):
+		t.Fatalf("%s did not complete within %v", what, d)
+	}
+}
+
+// TestSegmentsHandOffAtTheRoll
+// After 60 blocks with N=20 the window starts at block 40: blocks 40
+// on are active, blocks 1-39 are history, and both survive a reopen
+// with each manifest naming its own tier.
+func TestSegmentsHandOffAtTheRoll(t *testing.T) {
+	dir := storeDir(t, "tiers")
+	store, keys := tieredStore(t, dir, 71, false, 60, 5)
+	require.Equal(t, uint64(40), func() uint64 { store.Mutex.RLock(); defer store.Mutex.RUnlock(); return store.tierStart() }())
+
+	history, active := tiers(store)
+	require.Len(t, history, 39, "blocks 1-39 are below the window")
+	require.Len(t, active, 21, "blocks 40-60 are inside it")
+	assert.Equal(t, uint64(39), history[len(history)-1])
+	assert.Equal(t, uint64(40), active[0])
+
+	// A key from either tier reads back
+	for _, h := range []int{1, 39, 40, 60} {
+		v, err := store.Get(keys[h][0])
+		require.NoErrorf(t, err, "block %d", h)
+		assert.Equal(t, fmt.Sprintf("b%d-0", h), string(v))
+	}
+
+	// The handoffs are in flight: the active manifest still names them
+	// and the history manifest does not, until a history commit
+	m, err := store.readManifest()
+	require.NoError(t, err)
+	hm, err := store.readHistoryManifest()
+	require.NoError(t, err)
+	assert.Len(t, m.Segments, 60, "the active manifest names every segment until history records the handoffs")
+	assert.Empty(t, hm.Segments)
+
+	// A merge is that commit, and it merges history only: block 45 is
+	// below the watermark but inside the window, and stays
+	_, merged, err := store.MergeBelow(50)
+	require.NoError(t, err)
+	require.True(t, merged)
+	history, active = tiers(store)
+	require.Len(t, history, 1, "blocks 1-39 merged into one")
+	assert.Len(t, active, 21, "the active tier is untouched")
+	hm, err = store.readHistoryManifest()
+	require.NoError(t, err)
+	assert.Len(t, hm.Segments, 1)
+	assert.Equal(t, uint64(38), hm.Segments[0].Span, "the merged segment reaches back to block 1")
+
+	// The next active commit drops the recorded handoffs from the
+	// active manifest and deletes the merge inputs
+	require.NoError(t, store.Put(NewFastRandom([]byte{72}).NextHash(), []byte("v")))
+	_, err = store.Seal(61)
+	require.NoError(t, err)
+	m, err = store.readManifest()
+	require.NoError(t, err)
+	assert.Len(t, m.Segments, 22, "the active manifest names the active tier alone")
+	store.awaitUnlinks() // Deletion is a goroutine's, off both locks
+	dataFiles := 0
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == segDataSuffix {
+			dataFiles++
+		}
+	}
+	assert.Equal(t, 1+22+1, dataFiles, "one merged, 22 active, live.dat")
+
+	for h := 1; h <= 60; h++ {
+		for _, key := range keys[h] {
+			_, err := store.Get(key)
+			require.NoErrorf(t, err, "block %d", h)
+		}
+	}
+	require.NoError(t, store.Close())
+
+	reopened, err := OpenSegmentStore(dir)
+	require.NoError(t, err)
+	history, active = tiers(reopened)
+	assert.Len(t, history, 1)
+	assert.Len(t, active, 22)
+	for h := 1; h <= 60; h++ {
+		for _, key := range keys[h] {
+			_, err := reopened.Get(key)
+			require.NoErrorf(t, err, "block %d after a reopen", h)
+		}
+	}
+	require.NoError(t, reopened.Close())
+}
+
+// TestProtocolPathDoesNotTakeTheHistoryLock
+// Hold History exclusively from outside -- a swap in progress -- and
+// show that a Put, a Seal, a Sync and a Get of active data all
+// complete.  Deterministic: if any of them took History it would
+// block forever, and the bound is the failure.
+func TestProtocolPathDoesNotTakeTheHistoryLock(t *testing.T) {
+	dir := storeDir(t, "hlock")
+	store, keys := tieredStore(t, dir, 73, false, 45, 5)
+	defer store.Close()
+
+	store.History.Lock()
+	defer store.History.Unlock()
+
+	kr := NewFastRandom([]byte{74})
+	within(t, 10*time.Second, "the protocol path with History held", func() error {
+		if _, err := store.Get(keys[42][0]); err != nil { // Active
+			return err
+		}
+		if _, err := store.Get(keys[45][0]); err != nil { // Active, newest block
+			return err
+		}
+		if err := store.Put(kr.NextHash(), []byte("new")); err != nil { // Absent from the window: no history walk
+			return err
+		}
+		if err := store.Put(keys[42][0], []byte("b42-0")); err != nil { // In the window: settled by the active tier
+			return err
+		}
+		if err := store.Sync(); err != nil {
+			return err
+		}
+		if _, err := store.Seal(46); err != nil {
+			return err
+		}
+		_, err := store.SealNext()
+		return err
+	})
+}
+
+// TestHistoryMaintenanceDoesNotTakeTheStoreLock
+// The other direction: hold the store's Mutex exclusively -- a commit
+// in progress -- and show that a merge and a compaction of history
+// both complete.
+func TestHistoryMaintenanceDoesNotTakeTheStoreLock(t *testing.T) {
+	t.Run("merge", func(t *testing.T) {
+		dir := storeDir(t, "slock")
+		store, _ := tieredStore(t, dir, 75, false, 60, 5)
+		defer store.Close()
+		store.Mutex.Lock()
+		defer store.Mutex.Unlock()
+		within(t, 10*time.Second, "MergeBelow with the store lock held", func() error {
+			_, merged, err := store.MergeBelow(50)
+			if err == nil && !merged {
+				err = fmt.Errorf("nothing merged")
+			}
+			return err
+		})
+	})
+	t.Run("compact", func(t *testing.T) {
+		dir := storeDir(t, "slock")
+		store, _ := tieredStore(t, dir, 76, true, 60, 5)
+		defer store.Close()
+		store.Mutex.Lock()
+		defer store.Mutex.Unlock()
+		within(t, 10*time.Second, "CompactHistory with the store lock held", func() error {
+			compacted, err := store.CompactHistory()
+			if err == nil && !compacted {
+				err = fmt.Errorf("nothing compacted")
+			}
+			return err
+		})
+	})
+}
+
+// TestCommitsRunDuringHistoryMaintenance
+// The regression test for the pause itself.  A merge and then a
+// compaction are held between their copy and their swap -- with the
+// old code that is inside the store lock, and a Put, a Seal and a Get
+// wait there for as long as the copy takes -- and each of the three
+// must complete within a second while the maintenance is held.  Then
+// the maintenance is released and must still commit correctly.
+func TestCommitsRunDuringHistoryMaintenance(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		mutable bool
+		run     func(s *SegmentStore) (bool, error)
+	}{
+		{"merge", false, func(s *SegmentStore) (bool, error) { _, m, err := s.MergeBelow(50); return m, err }},
+		{"compact", true, func(s *SegmentStore) (bool, error) { return s.CompactHistory() }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := storeDir(t, "pause")
+			store, keys := tieredStore(t, dir, 77, tc.mutable, 60, 5)
+			defer store.Close()
+
+			held := make(chan struct{})
+			release := make(chan struct{})
+			released := false
+			maintenanceHook = func() {
+				close(held)
+				<-release
+			}
+			defer func() { // Let the maintenance finish if an assertion failed, so Close can run
+				maintenanceHook = nil
+				if !released {
+					close(release)
+				}
+			}()
+
+			done := make(chan error, 1)
+			go func() {
+				did, err := tc.run(store)
+				if err == nil && !did {
+					err = fmt.Errorf("the maintenance did nothing")
+				}
+				done <- err
+			}()
+			<-held // The copy is finished; the swap has not begun
+
+			kr := NewFastRandom([]byte{78})
+			fresh := kr.NextHash()
+			within(t, time.Second, "a commit during "+tc.name, func() error {
+				if err := store.Put(fresh, []byte("during")); err != nil {
+					return err
+				}
+				_, err := store.Seal(61)
+				return err
+			})
+			within(t, time.Second, "a read during "+tc.name, func() error {
+				if _, err := store.Get(keys[55][0]); err != nil { // Active
+					return err
+				}
+				if _, err := store.Get(keys[5][0]); err != nil { // History: sees the inputs
+					return err
+				}
+				_, err := store.Get(fresh)
+				return err
+			})
+
+			close(release)
+			released = true
+			require.NoError(t, <-done)
+			for h := 1; h <= 60; h++ {
+				for _, key := range keys[h] {
+					_, err := store.Get(key)
+					require.NoErrorf(t, err, "block %d after the %s", h, tc.name)
+				}
+			}
+			history, _ := tiers(store)
+			assert.Len(t, history, 1, "the %s committed", tc.name)
+		})
+	}
+}
+
+// TestKV2CommitsRunDuringCompress
+// The same at the KV2 level, where Compress used to take the KV2 lock
+// and the Dyna layer's lock for the whole rewrite: a PutPerm, a
+// PutDyna, a Seal and a Get complete while a Compress is held between
+// its copy and its swap.
+func TestKV2CommitsRunDuringCompress(t *testing.T) {
+	dir := storeDir(t, "kv2")
+	kv2, err := NewKV2(dir, 100)
+	require.NoError(t, err)
+	defer kv2.Close()
+	require.NoError(t, kv2.SetFilterBlocks(MinFilterBlocks))
+
+	kr := NewFastRandom([]byte{79})
+	vr := NewFastRandom([]byte{79, 79})
+	hot := make([][32]byte, 50)
+	for i := range hot {
+		hot[i] = kr.NextHash()
+	}
+	var h uint64
+	for round := 0; round < 3*MinFilterBlocks; round++ {
+		for _, key := range hot {
+			_, err = kv2.PutDyna(key, vr.RandBuff(20, 60))
+			require.NoError(t, err)
+		}
+		_, err = kv2.PutPerm(kr.NextHash(), []byte("p"))
+		require.NoError(t, err)
+		h++
+		_, err = kv2.Seal(h)
+		require.NoError(t, err)
+	}
+	history, _ := tiers(kv2.DynaKV)
+	require.Greater(t, len(history), 1, "the Dyna layer must hold history to compact")
+
+	held := make(chan struct{})
+	release := make(chan struct{})
+	released := false
+	maintenanceHook = func() {
+		close(held)
+		<-release
+	}
+	defer func() {
+		maintenanceHook = nil
+		if !released {
+			close(release)
+		}
+	}()
+	done := make(chan error, 1)
+	go func() { done <- kv2.Compress() }()
+	<-held
+
+	within(t, time.Second, "a commit during Compress", func() error {
+		if _, err := kv2.PutPerm(kr.NextHash(), []byte("p")); err != nil {
+			return err
+		}
+		if _, err := kv2.PutDyna(hot[0], []byte("during")); err != nil {
+			return err
+		}
+		if _, err := kv2.Get(hot[1]); err != nil {
+			return err
+		}
+		h++
+		_, err := kv2.Seal(h)
+		return err
+	})
+	close(release)
+	released = true
+	require.NoError(t, <-done)
+	v, err := kv2.Get(hot[0])
+	require.NoError(t, err)
+	assert.Equal(t, "during", string(v))
+	history, _ = tiers(kv2.DynaKV)
+	assert.Len(t, history, 1, "the compaction committed")
+}
+
+// TestPackRunsWithAShardLockHeld
+// PackFinalized reads and drops history only, and the drop is a
+// history commit: it must complete while a shard's store lock is held.
+func TestPackRunsWithAShardLockHeld(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	kvs, keys, values := packedFixture(t, dir, 80, 4, 60)
+	ageOutShards(t, kvs, 4)
+	_, err := kvs.MergeFinalized(4)
+	require.NoError(t, err)
+
+	shard := kvs.Shards[ShardIndex(keys[0][:])]
+	shard.PermKV.Mutex.Lock()
+	within(t, 30*time.Second, "PackFinalized with a shard's store lock held", func() error {
+		_, packed, err := kvs.PackFinalized(4)
+		if err == nil && !packed {
+			err = fmt.Errorf("nothing packed")
+		}
+		return err
+	})
+	shard.PermKV.Mutex.Unlock()
+	checkEveryKey(t, kvs, keys, values, "after packing")
+	require.NoError(t, kvs.Close())
+}
+
+// TestHandoffSurvivesACrash
+// A segment in transit between the manifests is named by at least one
+// of them at every moment.  Three crash points, each reproduced by
+// reopening without closing: after the roll (named by the active
+// manifest only), after the merge (its replacement named by history,
+// itself still named by the active manifest, its file still on disk),
+// and after the next seal (named by history only, inputs gone).
+func TestHandoffSurvivesACrash(t *testing.T) {
+	check := func(t *testing.T, dir string, keys [][][32]byte, when string) {
+		t.Helper()
+		store, err := OpenSegmentStore(dir)
+		require.NoErrorf(t, err, "open %s", when)
+		for h := 1; h < len(keys); h++ {
+			for _, key := range keys[h] {
+				v, err := store.Get(key)
+				require.NoErrorf(t, err, "block %d %s", h, when)
+				require.Equal(t, fmt.Sprintf("b%d-0", h), string(v))
+			}
+		}
+		// Reopening does not itself rewrite either manifest: what it
+		// read was enough, and the commits that follow finish the job
+		require.NoError(t, store.Close())
+	}
+
+	dir := storeDir(t, "crash")
+	store, keys := tieredStore(t, dir, 81, false, 60, 1)
+	check(t, dir, keys, "after the roll")
+
+	_, merged, err := store.MergeBelow(50)
+	require.NoError(t, err)
+	require.True(t, merged)
+	check(t, dir, keys, "after the merge")
+	// The check closed a store opened on the same directory, which
+	// committed both manifests; this handle is stale from here on, and
+	// only its files matter.  Reopen it for the last step.
+	store, err = OpenSegmentStore(dir)
+	require.NoError(t, err)
+	require.NoError(t, store.Put(NewFastRandom([]byte{82}).NextHash(), []byte("v")))
+	_, err = store.Seal(61)
+	require.NoError(t, err)
+	check(t, dir, keys, "after the seal")
+	require.NoError(t, store.Close())
+}
+
+// TestHistoryManifestIsRequired
+// A store is two manifests, and a build reading one alone would
+// silently lose every segment the other names.
+func TestHistoryManifestIsRequired(t *testing.T) {
+	dir := storeDir(t, "hist")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+	require.NoError(t, store.Put(NewFastRandom([]byte{83}).NextHash(), []byte("v")))
+	_, err = store.Seal(1)
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+
+	path := filepath.Join(dir, segHistoryName)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var hm HistoryManifest
+	require.NoError(t, json.Unmarshal(data, &hm))
+	assert.Equal(t, uint32(StoreFormatVersion), hm.Version)
+
+	hm.Version = StoreFormatVersion + 1
+	out, err := json.Marshal(&hm)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, out, 0644))
+	_, err = OpenSegmentStore(dir)
+	require.Error(t, err, "a history manifest of another version must be refused")
+	assert.Contains(t, err.Error(), "format version")
+
+	require.NoError(t, os.Remove(path))
+	_, err = OpenSegmentStore(dir)
+	require.Error(t, err, "a store without its history manifest must be refused, not opened as if history were empty")
+}
+
+// TestReopenRaisesTheBlockToTheNewestSegment
+// The Dyna layer's block advances in memory with every KV2.Seal and is
+// persisted only by its own seals.  A segment it sealed far above the
+// block its manifest recorded, left for recoverOrphans by a crash
+// before the manifest commit, must not leave the reopened store
+// believing it is in an older block than its newest segment: its next
+// auto-seal would refuse, "block height 5 is below the newest
+// segment's block 68", and the layer would never seal again.  Found
+// by TestCrashRecoverySeal, once in ~40 runs.
+func TestReopenRaisesTheBlockToTheNewestSegment(t *testing.T) {
+	dir := storeDir(t, "raise")
+	store, err := NewSegmentStore(dir, true)
+	require.NoError(t, err)
+	require.NoError(t, store.SetFilterBlocks(MinFilterBlocks))
+	kr := NewFastRandom([]byte{84})
+	require.NoError(t, store.Put(kr.NextHash(), []byte("v")))
+	_, err = store.SealNext() // Segment (0,0); the manifest records block 0
+	require.NoError(t, err)
+	saved, err := os.ReadFile(filepath.Join(dir, segManifestName))
+	require.NoError(t, err)
+
+	// The blocks pass without a manifest of this store's own, then a
+	// seal lands a segment at block 60 -- and the manifest naming it is
+	// never written: a crash between the rename and the commit
+	store.AdvanceBlock(3 * MinFilterBlocks)
+	key := kr.NextHash()
+	require.NoError(t, store.Put(key, []byte("late")))
+	meta, err := store.SealNext()
+	require.NoError(t, err)
+	require.Equal(t, uint64(3*MinFilterBlocks), meta.Height)
+	require.NoError(t, store.Close())
+	require.NoError(t, os.WriteFile(filepath.Join(dir, segManifestName), saved, 0644))
+
+	reopened, err := OpenSegmentStore(dir)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, reopened.BlockHeight(), meta.Height, "the block must be at least the newest segment's")
+	v, err := reopened.Get(key)
+	require.NoError(t, err, "the adopted segment's key")
+	assert.Equal(t, "late", string(v))
+	require.NoError(t, reopened.Put(kr.NextHash(), []byte("after")))
+	_, err = reopened.SealNext()
+	require.NoError(t, err, "the store must be able to seal again after adopting a segment above its recorded block")
+	require.NoError(t, reopened.Close())
+}

--- a/docs/design/durability.md
+++ b/docs/design/durability.md
@@ -61,8 +61,13 @@ land kills in the buffered-write, seal, compaction, and manifest-commit
 paths.  The child compacts on its own cadence (`crashCompressEvery`)
 because nothing in `KV2` compacts by itself -- `sealPermIfFull` and
 `sealDynaIfFull` seal and stop there -- so without it the compaction
-path would never be under the kill.  Adding it is what surfaced the
-three defects listed under *Fixed here*.
+path would never be under the kill.  Compaction works on history, the
+segments the window of the last N to 2N blocks has rolled past, and a
+child that lives for a few hundred puts never seals that many blocks,
+so before each `Compress` it advances the Dyna layer's block past the
+window (`AdvanceBlock`), which is what the blocks passing would do.
+Adding the compaction is what surfaced the three defects listed under
+*Fixed here*.
 
 `TestCrashRecoverySeal` runs the same rounds against the other
 durability point: the child checkpoints at `Seal` and never closes.
@@ -86,17 +91,18 @@ state survives until the new state is durable:
 | operation | mechanism |
 |---|---|
 | seal | the usual path renames `live.dat` itself: the header is filled in, the file fsynced, then renamed to `seg-<height>.dat`, so no record is copied and a `.dat` on disk is complete by construction. A tail holding overwrites is rewritten to `seg-<height>.dat.tmp` first, then fsynced and renamed |
-| manifest commit | `segments.json.tmp` + rename; the manifest is the single point at which a seal or compaction becomes real |
-| compaction | writes a whole new sealed generation, then commits it with one manifest rename (issue #19) — there is no window in which keys and values disagree |
-| interrupted seal | a data file *above* the manifest's newest height reached disk but not the manifest; `recoverOrphans` adopts it on open |
-| superseded files | a data file at or below the newest height was replaced by a committed compaction; `recoverOrphans` deletes it |
+| manifest commit | `segments.json.tmp` + rename for the active tier, `history.json.tmp` + rename for history; each is the single point at which its tier's operation becomes real — a seal or import for the active manifest, a merge, compaction or drop for the history manifest (issue #57) |
+| a segment between the manifests | the window rolling past a segment moves it to history in memory and writes nothing.  The active manifest keeps naming it until a history commit names it, and only the active commit after that stops; so every sealed segment is named by at least one manifest on disk at every moment, and open reads both and takes the union.  A merge's inputs that the active manifest might still name are deleted only after the next active commit (`TestHandoffSurvivesACrash`, three crash points) |
+| compaction | rewrites a run of history segments into one holding the newest record per key, then commits it with one history-manifest rename (issue #19) — there is no window in which keys and values disagree.  It never touches a segment inside the window: a record last written in the last N to 2N blocks is the protocol's (issue #57) |
+| interrupted seal | a data file *above* the newest height either manifest names reached disk but not the manifest; `recoverOrphans` adopts it on open |
+| superseded files | a data file at or below the newest height was replaced by a committed merge or compaction; `recoverOrphans` deletes it.  A compaction's output takes the sequence after its run's newest segment, which is below the active tier, so an uncommitted one is deleted while its inputs still stand (`TestDynaCompressCrashMidway`) |
 | stale tmp files | removed on open; a `.tmp` file is by construction always incomplete |
 | torn live-tail record | the live tail is replayed record by record on open; a record whose value bytes run past end-of-data is dropped **and the file is truncated to the last complete record**, so the next append lands on a record boundary |
 | live file with no header | `seal` creates the new `live.dat` and leaves its 24-byte header in the `BFile` buffer, so a crash before the first flush leaves the file at 0 bytes; open rewrites the header rather than trusting it to be there |
 | the block a shard is in | recorded once for the whole shard set (`block.json`, one fsync), not once per shard.  A shard with no writes advances in memory and commits nothing.  On open the set tells every shard the block it is in, which is what a shard needs it for: `SealNext` tags an auto-sealed segment with its block height, so a shard that came back believing it was in an older block would label segments with a block they do not belong to and `ExportBlock`, which selects by block, would never export them.  A missing file reads as 0 and constrains nothing, so an existing database opens unchanged (issue #32) |
 | merge of finalized segments | the merged segment is written, fsynced and renamed before the manifest names it, at an identity *below* the manifest's newest, so an uncommitted one is deleted by `recoverOrphans` while the originals it would replace are still named (issue #47) |
 | key filters | saved to `filters.dat` (tmp file, fsync, rename, directory fsync) at close, and the manifest written straight after carries the claim of what they cover: the window's start, the newest segment in it, and the count of segments covered.  Every other manifest commit clears the claim, and on open any doubt -- an adopted orphan, a dropped segment, a different window -- rebuilds from the segments inside the window (issue #44) |
-| block-set file | written to `sets/set-….bset.tmp`, fsynced, renamed, and the set directory fsynced: the rename is the commit.  A `.tmp` left by a crash is deleted on open.  Only after that commit do the shards drop the segments the set holds -- **without a manifest of their own**.  The shard's next manifest commit (its next seal, or its close) is what stops naming them, and the files are deleted only after it.  A crash in between leaves every shard's manifest naming whole, intact segments that the set also holds; on open the shard set drops them again (`TestPackFinalizedSurvivesACrashBeforeTheShardsCommit`).  Nothing is ever in only one place until the second place is durable |
+| block-set file | written to `sets/set-….bset.tmp`, fsynced, renamed, and the set directory fsynced: the rename is the commit.  A `.tmp` left by a crash is deleted on open.  Only after that commit do the shards drop the segments the set holds, each with a history-manifest commit of its own (two barriers, off the protocol path, sixteen shards at a time), and the files are deleted only after it.  A crash before a shard's drop leaves its history manifest naming whole, intact segments that the set also holds; on open the shard set drops them again (`TestPackFinalizedSurvivesACrashBeforeTheShardsCommit`).  Nothing is ever in only one place until the second place is durable |
 | one barrier per operation | a seal renames up to three files into the same directory -- the sealed data file, its index, then the manifest -- and fsyncs that directory once, at the manifest commit. One directory fsync commits every name change made in it, and the renames are issued in order, so the manifest can never become durable ahead of the data file it names. Each file's own fsync is still taken before its rename: that is what makes a published name always point at durable contents. Six barriers a seal became four, measured 36 ms to 24.6 ms (issue #33) |
 | operations on a closed store | `Close` drops the sealed segment list but keeps the live map, so reads and writes refuse with `errStoreClosed` rather than running against half a store |
 
@@ -178,12 +184,18 @@ The first three have a regression test in `segstore_test.go`
 - A key written to Dyna keeps a stale copy in Perm. `Get` resolves the
   layer order, so the copy is dead weight rather than a wrong answer,
   but compaction does not reclaim it.
-- `recoverOrphans` adopts any complete data file *above* the manifest's
-  newest segment.  Two paths can leave such a file that duplicates
-  data the manifest already names: a merge of a shard whose every
-  segment was below the watermark (the merged file is then above
+- `recoverOrphans` adopts any complete data file *above* the newest
+  segment the manifests name.  Two paths can leave such a file that
+  duplicates data a manifest already names: a merge or compaction of a
+  store whose every segment was history (the output is then above
   everything), and a shard that dropped its last segment for a block
   set, committed, and crashed before the unlink.  Either way the
-  adopted file holds keys with identical values elsewhere; lookups are
-  right, the next merge or drop folds it away, and the cost is space
-  until then.
+  adopted file holds keys with identical or newer values elsewhere;
+  lookups are right, the next merge, compaction or drop folds it away,
+  and the cost is space until then.
+- The Dyna layer's block advances in memory with every `KV2.Seal` and
+  is persisted only by its own next seal, so a reopened layer can be a
+  few blocks behind: segments the window had rolled past are placed
+  in the active tier again, covered by the rebuilt filters, and handed
+  off again as the block catches up.  Correct, and at worst one
+  window's worth of history compacted a little later.

--- a/docs/design/segment-store.md
+++ b/docs/design/segment-store.md
@@ -13,7 +13,8 @@ v2 makes the segment format the *storage* itself.
     live.dat                  records accepted since the last seal
     seg-<block>-<seq>.dat     a sealed, immutable segment (the transport format)
     seg-<block>-<seq>.idx     its index: sorted 48-byte key records + a bloom
-    segments.json             the manifest: segments, counts, hashes
+    segments.json             the active manifest: settings, the active tier's segments
+    history.json              the history manifest: every segment below the window
     filters.dat               the live key filters, saved on close
 
 An index record is `key(32) offset(8) length(8)`. The offset is
@@ -96,32 +97,35 @@ bytes against nothing.
 whole key bin whenever it outgrew its slot. Sealed segments never
 move, so a write costs what it weighs.
 
-**Compaction is crash-atomic (issue #19).** `Compact(height)` writes a
-new generation holding only live keys, fsyncs it, and commits by
-replacing the manifest — one atomic rename. There is no window where
-keys and values disagree. Measured: ten sealed generations of
-overwrites compact to one, ~90% of bytes reclaimed, values unchanged.
+**Compaction is crash-atomic (issue #19).** `CompactHistory` writes a
+new segment holding only the newest record per key of the run it
+replaces, fsyncs it, and commits by replacing the history manifest —
+one atomic rename. There is no window where keys and values disagree.
+Measured: ten sealed generations of overwrites compact to one, ~90% of
+bytes reclaimed, values unchanged.
 
-A crash before that commit is safe but not free. The compacted file
-sits above every height the manifest names, so the recovery rule below
-adopts it as the newest segment rather than deleting it — correct,
-since newest wins and it holds every live key, but the old generation
-it was meant to replace is still on disk. What the crash costs is that
-space, until the next compaction. (An earlier draft of this document
-said the orphan was swept; it is adopted. `TestDynaCompressCrashMidway`
-pins the behaviour.)
+A crash before that commit is safe and costs only the copy. The
+compacted file takes the sequence after the run's newest segment, which
+sits below the active tier, so the recovery rule below deletes it while
+the run it would have replaced is still named and whole
+(`TestDynaCompressCrashMidway`). Only a store with no active segment
+at all — every segment in history — leaves the file above everything
+the manifests name, and then it is adopted as a duplicate that the
+next compaction folds away; that is the shape of issue #52.
 
 ## Crash recovery
 
-The manifest is the commit point for sealing, importing, and
-compaction, and its newest `(block, seq)` decides what to do with a
-data file the manifest does not name:
+The manifests are the commit points — the active manifest for sealing
+and importing, the history manifest for merging, compacting, and
+dropping — and the newest `(block, seq)` either of them names decides
+what to do with a data file neither names:
 
 - **above** the newest `(block, seq)` — a seal or import that reached
   disk but not the manifest. It is complete by construction (fsync
   precedes the rename), so it is adopted, its index rebuilt if missing,
   and the manifest updated.
-- **at or below** — superseded by a committed compaction; deleted.
+- **at or below** — superseded by a committed merge or compaction;
+  deleted.
 - `*.tmp` — never complete; deleted.
 
 The live tail is replayed record by record on open; a torn trailing
@@ -148,9 +152,9 @@ record from a crash mid-write is dropped.
    push, no kfile rewrite, no bin relocation, and no `Stat` per put.
 
 2. **Done** — `SegmentStore` is KV2's Dyna layer too, in mutable mode.
-   `KV2.Compress` is now a seal plus a `Compact`, so the layer's
-   compaction is crash-atomic and `KV.Compress` is off the database's
-   path (#19). The Dyna layer seals on **physical records**, not
+   `KV2.Compress` is now a `CompactHistory` of the layer's history
+   tier, so the layer's compaction is crash-atomic, off the protocol's
+   lock, and `KV.Compress` is off the database's path (#19, #57). The Dyna layer seals on **physical records**, not
    distinct keys: a mutable layer leaves one record per write, so a
    handful of hot state keys rewritten every block would hold the key
    count flat while the tail — replayed in full on every open — grew
@@ -249,9 +253,18 @@ manifest. Either way the crash costs space and nothing else.
 
 Merging happens **within a shard**, never across. That keeps the
 working set small — a shard holds a few hundred entries per set — and
-keeps the merge under the shard's own lock, so shards merge
+keeps the merge to the shard's own files, so shards merge
 independently and in parallel. `KVShard.MergeFinalized` drives it per
 shard and keeps going past a failure, reporting the first error.
+
+Only **history** is merged — the segments the window of the last N to
+2N blocks has rolled past (*Two tiers, two locks*, below). A watermark
+inside the window merges what has left it and no more, and the rest
+follows once the window has passed; the merge lags the watermark by up
+to N blocks, and nothing about correctness needs either to be current.
+With Accumulate's N of 64 and its watermark of `version − 64`, a
+shard holds per-block segments for at most 128 blocks before they are
+merged.
 
 It is not a goroutine this package starts. Only the caller knows its
 block rate and how far back healing may still write, which is what
@@ -323,17 +336,19 @@ memory; slices over 64 KB are binary-searched on disk), and one read of
 the value. Sets are walked newest to oldest; a key the shard's own
 filter says is absent never reaches them.
 
-`KVShard.PackFinalized(height)` builds it: every shard's segments below
-the watermark — expected to be stage one's single merged segment each,
-though it copes with more — into one set, committed by the rename of
-the file and one fsync of the set directory. Then each shard **drops**
-those segments (`SegmentStore.DropBelow`) without writing a manifest:
-the shard's next seal records the drop, and only then are the files
-deleted. That is deliberate. Recording it immediately would cost two
-barriers per shard — ~5.6 s a set, the same cost issue #32 removed from
-the block boundary — for a fact the next seal records for free. A crash
-in between leaves a shard whose manifest still names segments the set
-also holds; on open it drops them again
+`KVShard.PackFinalized(height)` builds it: every shard's history
+segments below the watermark — expected to be stage one's single
+merged segment each, though it copes with more — into one set,
+committed by the rename of the file and one fsync of the set
+directory. The segments are read pinned, so a merge that commits
+meanwhile leaves their files readable until the pack is done. Then
+each shard **drops** those segments (`SegmentStore.DropBelow`), which
+is a history commit of its own: two barriers per shard, off the
+protocol path, run sixteen shards at a time so the barriers overlap.
+It used to ride on the shard's next seal for free, but the seal writes
+the active manifest now and the drop is history's to record. A crash
+before a shard's drop leaves its history manifest naming segments the
+set also holds; on open it drops them again
 (`TestPackFinalizedSurvivesACrashBeforeTheShardsCommit`).
 
 Measured, the same 20-block set of 40,000 keys: **~30 ms** for the
@@ -497,9 +512,143 @@ it), not the store. The count is what separates "covers nothing" from
 "covers segment (0, 0)", the ambiguity of issue #35; it is kept, and
 `TestKeyFilterEmptyDoesNotCoverSegmentZero` still exercises it.
 
-The Dyna layer runs on the same code with its block never advancing,
-so it has one filter, over everything, rebuilt and right-sized at each
-compaction — the same reach it had, and the same bound.
+The Dyna layer runs on the same code and its block advances with every
+`KV2.Seal`, so its filters roll like Perm's: what is resident is the
+keys of the last N to 2N blocks of state writes, and what has left the
+window is history, which is what makes it compactable off the
+protocol path (*Two tiers, two locks*, below).
+
+### Two tiers, two locks
+
+A store holds two kinds of files with two different owners, and one
+mutex used to cover both. Measured on an 8-node Accumulate network at
+500 tx/s, with the adapter merging below `version − 64` and compacting
+every 128 commits (issue #57):
+
+| block | pause on every node | dynamic layer (one engine) |
+|---|---|---|
+| 400 | 12 s | — |
+| 656 | 13–16 s | 5.9 GB, 292 segments |
+| 784 | 18–19 s | 7.0 GB, 326 |
+| 1,040 | 23–32 s | 9.8 GB, 400 |
+
+About 2.3 s per GB of the dynamic layer, every 128 blocks, growing
+without bound — because `Compress` rewrote the whole layer and
+`MergeBelow` copied the whole run under the store's lock, so every
+commit and every read on the node waited for the copy. Each pause
+seeded a cross-partition backlog and the partitions fell behind.
+
+The invariant now is: **the consensus path only ever reads and writes
+the last 2N blocks, and the pause it can suffer from storage
+maintenance is bounded by the size of those 2N blocks, never by the
+size of the chain.**
+
+**The tiers.** The *active* tier is the live tail plus the sealed
+segments whose oldest block is at or above the window's start — the
+same line the key filters draw, `tierStart`, a pure function of the
+block height and N — and every active segment is covered by the
+filters. *History* is every older segment, plus the packed sets. A
+segment moves from active to history when the window rolls past it
+(`handoffBelowWindow`, from `advanceBlock`), never back, except when
+`SetFilterBlocks` widens the window at creation time. Tier membership
+is derived, not recorded: on open each segment is placed by its oldest
+block, so a crash at any moment changes nothing about where a segment
+belongs.
+
+**The locks**, and who takes which:
+
+| operation | Mutex (active) | History | maint |
+|---|---|---|---|
+| `Put`, `PutIfAbsent` | exclusive | — (see below) | — |
+| `Get` | shared, released | then shared, released | — |
+| `Seal`, `SealNext`, `Sync`, `AdvanceBlock` | exclusive | exclusive, inside Mutex, for an append (the handoff) | — |
+| `MergeBelow`, `CompactHistory` | — | shared to read the list; exclusive for the swap | whole operation |
+| `DropBelow` | — | exclusive for the swap | whole operation |
+| `PackFinalized` (per shard) | — | shared to read the list, pinned | — |
+| `ImportSegmentFile` | exclusive | shared inside Mutex on a filter hit; exclusive inside Mutex if the segment lands in history | — |
+| `ForEach` | shared, released | then shared, released; files pinned first | — |
+| `Close`, `Open`, `SetFilterBlocks` | exclusive | exclusive, inside Mutex | — |
+
+The order is always Mutex → History → the leaf locks (`handoffMu`,
+`retireMu`), and maint → History; nothing ever takes Mutex while
+holding History or maint, so no cycle exists. On the protocol path the
+two are never held together: a `Get` reads the active tier under Mutex,
+releases it, and only then reads history under History. A `Put` whose
+key the filters rule out of the window — a new key — writes under
+Mutex alone; a filter hit the active tier settles is answered under
+Mutex alone; a filter hit it cannot settle releases Mutex, reads
+history under History, and takes Mutex again for the write, starting
+over if the window rolled in between (`epoch`). A history operation
+copies immutable segments with no lock at all, writes its output
+aside, and takes History exclusively for the swap and the history
+manifest commit — two barriers — so the longest a history reader can
+wait is that commit, and a commit or an active read never waits at
+all. `KV2.MergeBelow` and `KV2.Compress` do not take the KV2 lock
+either, and `Open`, which every shard operation calls first, answers
+without a lock on an open store.
+
+**Two manifests.** A commit and a merge each write their own, so
+neither waits for the other and neither manifest grows with the
+other's tier: `segments.json` carries the settings and the active
+tier, `history.json` the history tier, and the store is their union
+(a segment named by both is one segment). The handoff records nothing:
+a segment the window has just rolled past stays named by the active
+manifest until a history commit names it, and only the active commit
+after *that* stops naming it — so at every moment every sealed segment
+is named by at least one manifest on disk, and a crash between any two
+commits is recovered by reading both. The files a history operation
+retires are deleted at once if only the history manifest could have
+named them, and after the next active commit if the active manifest
+still might (`retireAfterActiveCommit`); until then a merge's inputs
+sit beside its output, for one seal. Format version 4.
+
+**The dynamic layer ages.** `KV2.Seal` advances the Dyna layer's block
+too, so its auto-sealed segments carry the block they were sealed in
+and its window rolls with Perm's. A state record last written inside
+the window is active and compaction never reads or rewrites it; one
+that has not been rewritten for 2N blocks is history. `CompactHistory`
+— what `KV2.Compress` calls — rewrites a **run** of history segments
+into one holding the newest record per key of the run: the newest
+segment always, and each older one while it is no larger than
+1/`CompactRatio` (4×, at the default 0.25) of what has gathered behind
+it. A large old segment is therefore rewritten only once a quarter of
+its size has arrived, which is what keeps the bytes rewritten over the
+store's life a constant multiple of the bytes written rather than a
+whole-layer copy per call; between rewrites it holds records the newer
+segments have superseded, bounded by the ratio. A record in history
+superseded only by one still in the window waits until that one has
+rolled out and a run holds both — garbage the compaction cannot yet
+see, bounded by the window. `TestCompressNeverTouchesTheWindow` pins
+both halves. The garbage estimate that used to gate `Compress`
+(`Shadowed`, issue #40) is gone with the whole-layer rewrite it gated.
+
+**Measured.** A `KV2` with N=20, 1,000 blocks of 500 permanent keys
+and a dynamic layer of the size shown, with a state key rewritten ~5
+times on average so ~20% of the layer is live; a writer doing
+`PutPerm` + `PutDyna` + `Seal` every 50 ms and a reader doing `GetPerm`
++ `GetDyna` of recent keys every 2 ms, while `Compress` and then
+`MergeBelow(height − 64)` run once. The longest any of their calls
+took while the maintenance ran, before and after, on one NVMe:
+
+| dyna layer | segments | `Compress` before → after | `MergeBelow` before → after | max Put before → after | max Get before → after |
+|---|---|---|---|---|---|
+| 0.60 GB | 447 | 0.77 s → 0.71 s | 0.34 s → 0.32 s | **1.06 s** → <1 ms | **1.10 s** → 20 ms |
+| 1.20 GB | 894 | 1.83 s → 1.71 s | 0.34 s → 0.33 s | **2.13 s** → <1 ms | **2.17 s** → 24 ms |
+| 2.40 GB | 1,789 | 4.60 s → 4.81 s | 0.33 s → 0.35 s | **4.88 s** → <1 ms | **4.92 s** → 48 ms |
+| 4.81 GB | 3,579 | 11.75 s → 11.09 s | 0.35 s → 0.33 s | **12.09 s** → <1 ms | **12.09 s** → 55 ms |
+
+Before, the pause is the compaction: 2.4 s per GB, the curve of the
+issue's table. After, the compaction takes the same time (it is the same copy, off the lock) and the longest a `Put` waited was under a millisecond in every row; the longest a `Seal` waited was 22, 22, 50 and 56 ms against an idle 15-23 ms, and the longest a `Get` 20, 24, 48 and 55 ms -- the history swap and the disk contention of a multi-GB copy, not the copy itself. Memory is lower too: heap 7/10/16/28 MB before against 6/7/10/14 MB after, and the Dyna layer's resident filters 2.4/4.7/9.4/18.7 MB before against 0.3/0.6/1.1/2.1 MB after, because the filter covers the window rather than the whole layer. The idle maxima — the same
+writer and reader with no maintenance running — were 15–23 ms for a
+`Seal` and under 1 ms for a `Put` or a `Get` in every row.
+
+The deterministic tests are in `tiering_test.go`: hold `History`
+exclusively and a `Put`, `Seal`, `Sync` and `Get` complete; hold
+`Mutex` exclusively and a merge, a compaction and a pack complete; hold
+a merge and a compaction between their copy and their swap
+(`maintenanceHook`) and a `Put`+`Seal` and a `Get` complete within a
+second. Against the old locking the last two fail with "did not
+complete within 1s" and "did not complete within 10s".
 
 ### File descriptors are borrowed, not held
 
@@ -535,9 +684,10 @@ queued on that lock and its hold time grew with the segment walk
 (issue #50).
 
 Readers now take both locks shared. Writers — anything that appends,
-seals, compacts, merges, imports, or closes — still take them
-exclusively, so a reader never sees the live map or the segment list
-mid-change. Three things had to follow:
+seals, imports, or closes — still take them exclusively, so a reader
+never sees the live map or the segment list mid-change; a merge or a
+compaction takes neither (*Two tiers, two locks*). Three things had to
+follow:
 
 - **The counters are atomic.** A plain increment under a shared lock
   is a data race.
@@ -581,12 +731,13 @@ profile). That is the segment count, which block-set packing collapses
 callback that called `Get` deadlocked and any callback blocked every
 other reader and writer for as long as it ran (issue #31).
 
-It now copies the live tail's values and the segment list under the
-lock, releases it, and calls back with nothing held. What the callback
-sees is the store as it stood when iteration began. A compaction is
-free to commit underneath it; the files it retires are unlinked when
-the last iteration finishes rather than immediately, so the reads stay
-valid (`TestForEachSurvivesConcurrentCompaction`).
+It now copies the live tail's values and the segment lists — each tier
+under its own lock, one after the other — releases them, and calls back
+with nothing held. What the callback sees is the store as it stood when
+iteration began. A compaction is free to commit underneath it; the
+files it retires are unlinked when the last iteration finishes rather
+than immediately, so the reads stay valid
+(`TestForEachSurvivesConcurrentCompaction`).
 
 Sealing is also still where the Perm layer's time goes — about 60% of
 it at a 25,000-key block, of which the largest remaining piece is the

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -61,13 +61,24 @@ key count flat while the tail grew without bound.
 
 ### Filter Window
 
-`SetFilterBlocks(n)` on a `KVShard` or `KV2` sets N, the roll period of
-the Perm layer's key filter (default `DefaultFilterBlocks`, 128;
-minimum `MinFilterBlocks`, 20).  A fresh filter starts every N blocks
-and covers 2N, so two are live at once and the store holds the keys of
-the last N to 2N blocks in memory -- and no more, whatever the chain's
-length.  It is persisted in each shard's manifest; set it when the
-database is created, since changing it commits a manifest per shard.
+`SetFilterBlocks(n)` on a `KVShard` or `KV2` sets N for both layers:
+the roll period of the key filters (default `DefaultFilterBlocks`, 128;
+minimum `MinFilterBlocks`, 20), and the line between the **active
+tier** -- the live tail and the sealed segments of the last N to 2N
+blocks, which is all a commit writes and a consensus-path read hits --
+and **history**, which is everything older and is what merging,
+packing and compaction work on, under a lock of its own.  A fresh
+filter starts every N blocks and covers 2N, so two are live at once
+and the store holds the keys of the last N to 2N blocks in memory --
+and no more, whatever the chain's length.  It is persisted in each
+layer's manifest; set it when the database is created, since changing
+it commits a manifest per layer per shard.
+
+N is the caller's, and it is what bounds the pause a commit can suffer
+from storage maintenance: a merge or a compaction copies history with
+no lock and swaps under history's own lock, so the protocol path waits
+for nothing that grows with the chain (see *Maintenance Pauses*,
+below).
 
 N is the reach of the immutability check: a permanent key written in
 the last N to 2N blocks cannot be overwritten; older history is not
@@ -106,7 +117,15 @@ whatever window may still be written to -- healing, in Accumulate's
 case -- because segments at or above it are left alone so that block
 export keeps working.
 
-1. `KVShard.MergeFinalized(height)` merges each shard's sealed Perm
+Both stages work on **history** -- the segments the window of the
+last N to 2N blocks has rolled past -- and never on a segment still
+inside the window, whatever the watermark says.  A watermark inside
+the window finalises what has left it, and the rest follows once the
+window has passed; the merge lags the watermark by up to N blocks.
+Neither stage takes a shard's store lock: the copy is lock-free and
+the commit is a swap under the shard's history lock.
+
+1. `KVShard.MergeFinalized(height)` merges each shard's history
    segments below the watermark into one.  Sealing produces a segment
    per shard per block, so without this the file count grows with the
    chain and nothing bounds it: measured at 512 shards and 5,000
@@ -123,14 +142,14 @@ export keeps working.
 2. `KVShard.PackFinalized(height)` packs every shard's merged segment
    for the set into **one block-set file** under `<db>/sets/`, then
    drops those segments from the shards.  The 1,024 files become 1.
-   Measured on the same set: ~30 ms, one file of 7.6 MB for 40,000
-   keys.
+   Measured on the same set: ~30 ms for the file, one file of 7.6 MB
+   for 40,000 keys.
 
-   The drop writes no manifest.  Each shard records it at its next
-   seal, and only then deletes the files, so the pack costs two
-   barriers in all rather than two per shard.  Until a shard next
-   seals -- or closes -- its packed files linger on disk, harmlessly:
-   a shard that takes no writes for a long time keeps them that long.
+   Each shard's drop is a history-manifest commit of its own -- two
+   barriers -- run sixteen shards at a time, off the protocol path.
+   A merge's inputs that the active manifest still names wait for the
+   shard's next seal before they are deleted (*Two tiers, two locks*
+   in [Segments as storage](design/segment-store.md)).
 
 A lookup that reaches a set costs a bloom probe, one read of the
 shard's index slice, and one read of the value; a key the shard's own
@@ -139,23 +158,47 @@ filter says is absent never reaches the sets.  Measured over the packed
 absent key.  Memory
 per set is 16 KB of directory plus a bloom at ~1.5 bytes a key.
 
-Run stage two after stage one for the same watermark, never
-concurrently with it: the merge retires the files the pack is copying.
+Run stage two after stage one for the same watermark.  Running them
+concurrently is safe -- the pack reads pinned files -- but wasteful.
 
 ### Compaction Ratio
 
-`CompactRatio` (default 0.25) is the share of a mutable layer that must
-be superseded records before `Compress` does anything. `Compress` on a
-cadence used to rewrite the whole layer every call, so reclaiming a
-fixed amount of garbage grew more expensive as the database grew;
-waiting for a fixed *fraction* makes the amortised cost per overwrite
-constant instead. Raise it to compact less often and hold more
-garbage; lower it for the reverse.
+`Compress` compacts the Dyna layer's **history** -- the segments the
+window has rolled past -- and never a record last written inside the
+window.  It rewrites a run of history segments into one holding the
+newest record per key: the newest segment always, and each older one
+while it is no larger than 1/`CompactRatio` of what has gathered
+behind it.  At the default 0.25 a large old segment is rewritten only
+once a quarter of its size has arrived behind it, which keeps the
+bytes rewritten over the store's life a constant multiple of the bytes
+written rather than a whole-layer copy per call.  Raise the ratio to
+rewrite large segments less often and hold more garbage; lower it for
+the reverse.
 
-The estimate behind it is maintained as writes arrive -- a probe of the
-store's own key filter, so deciding costs nothing -- and is carried in
-the manifest, so a reopened store resumes it rather than believing it
-holds no garbage.
+Choosing the run costs no I/O -- it is decided from the record counts
+the segments hold in memory -- so `Compress` on a cadence is cheap when
+there is nothing to do.
+
+### Maintenance Pauses
+
+Every history operation -- merge, compaction, pack -- copies immutable
+segments with no lock, writes its output aside, and takes the history
+lock only to swap the segment list and commit `history.json`.  The
+protocol path (`Put`, `Seal`, `Get` of recent data) takes the store's
+own lock and never the history lock, so it waits for nothing the copy
+does.  Measured with a writer committing every 50 ms and a reader
+every 2 ms while `Compress` and `MergeBelow` ran (N=20; details in
+[Segments as storage](design/segment-store.md)):
+
+| dyna layer | `Compress` | max commit pause before → after | max read pause before → after |
+|---|---|---|---|
+| 0.60 GB | 0.77 s → 0.71 s | 1.06 s → <1 ms | 1.10 s → 20 ms |
+| 1.20 GB | 1.83 s → 1.71 s | 2.13 s → <1 ms | 2.17 s → 24 ms |
+| 2.40 GB | 4.60 s → 4.81 s | 4.88 s → <1 ms | 4.92 s → 48 ms |
+| 4.81 GB | 11.75 s → 11.09 s | 12.09 s → <1 ms | 12.09 s → 55 ms |
+
+Before, the pause was the copy: ~2.4 s per GB of the dynamic layer,
+growing without bound.  After, the compaction takes the same time (it is the same copy, off the lock) and the longest a `Put` waited was under a millisecond in every row; the longest a `Seal` waited was 22, 22, 50 and 56 ms against an idle 15-23 ms, and the longest a `Get` 20, 24, 48 and 55 ms -- the history swap and the disk contention of a multi-GB copy, not the copy itself. Memory is lower too: heap 7/10/16/28 MB before against 6/7/10/14 MB after, and the Dyna layer's resident filters 2.4/4.7/9.4/18.7 MB before against 0.3/0.6/1.1/2.1 MB after, because the filter covers the window rather than the whole layer.
 
 ### Buffer Size
 
@@ -201,10 +244,11 @@ by its own hash -- belongs there.  State that changes belongs in Dyna.
 
 ### 2. Compact Dyna, not Perm
 
-`Compress()` writes a new sealed generation of the Dyna layer and
-commits it with a single manifest rename, reclaiming the space that
-overwritten values still occupy.  It is proportional to live data, so
-run it on a cadence tied to write volume rather than on every block.
+`Compress()` rewrites a run of the Dyna layer's history segments into
+one and commits it with a single history-manifest rename, reclaiming
+the space that overwritten values still occupy.  It never touches the
+segments inside the window, takes no lock a commit takes, and is
+cheap to call when there is nothing to do, so run it on a cadence.
 It is a no-op on the Perm layer, which has nothing to reclaim.
 
 ```go


### PR DESCRIPTION
Issue #57: one mutex covered a whole store, and `MergeBelow` and `Compress` held it for the whole copy. On the 8-node soak that was a 12 s pause of every commit and every read at block 400 and 23–32 s at block 1,040 — ~2.3 s per GB of the dynamic layer, growing without bound.

## The invariant

**The consensus path only ever reads and writes the last 2N blocks; the pause it can suffer from storage maintenance is bounded by the size of those 2N blocks, never by the size of the chain.**

## What changed

**Two tiers, two locks.** The *active* tier is the live tail plus the sealed segments whose oldest block is inside the key filters' window — `tierStart`, a pure function of the block height and N — under `Mutex`, the protocol's lock. *History* is everything older plus the packed sets, under `History`. A segment moves to history when the window rolls past it (`handoffBelowWindow`); tier membership is derived from the segment's block range, never recorded, so a crash at any moment changes nothing about where a segment belongs.

| operation | `Mutex` | `History` | `maint` |
|---|---|---|---|
| `Put`, `PutIfAbsent` | exclusive | — (a filter hit the active tier cannot settle releases `Mutex`, reads history shared, retakes `Mutex`, retries if the window rolled) | — |
| `Get` | shared, released | then shared, released | — |
| `Seal`, `SealNext`, `Sync`, `AdvanceBlock` | exclusive | exclusive inside `Mutex`, for an append — the handoff | — |
| `MergeBelow`, `CompactHistory` | — | shared to read; exclusive for the swap + `history.json` commit | whole op |
| `DropBelow` | — | exclusive for the swap | whole op |
| `PackFinalized` (per shard) | — | shared, pinned | — |
| `ForEach` | shared, released | then shared, released; pinned first | — |
| `Close`, `Open`, `SetFilterBlocks`, import | exclusive | inside `Mutex` | — |

Order is always `Mutex → History → leaf`, `maint → History → leaf`; nothing takes `Mutex` while holding `History` or `maint`, so no cycle. `KV2.MergeBelow` / `KV2.Compress` no longer take the KV2 lock; `Open`, which every shard operation calls first, answers without a lock on an open store.

**History operations are lock-free copies plus a short swap.** The copy reads immutable segments through the pool and writes aside; the swap checks the run is still where it was (a concurrent drop or import abandons the output) and commits `history.json`. Retirement respects readers: history readers hold `History` shared for the walk, iterations and packs pin the files.

**Two manifests.** `segments.json` (settings + active tier) is the seal's; `history.json` is history's. A handoff records nothing: the segment stays in the active manifest until a history commit names it, and only the next active commit drops it — every sealed segment is named by at least one manifest on disk at every moment (`TestHandoffSurvivesACrash`, three crash points). `StoreFormatVersion = 4`. `DropBelow` commits `history.json` itself now (the seal it rode on writes the other manifest); `PackFinalized` drops sixteen shards at a time.

**The dynamic layer ages.** `KV2.Seal` advances the Dyna layer's block, so its segments carry the block they were sealed in and its window rolls with Perm's. A state record last written inside the window is active and compaction never touches it; one not rewritten for 2N blocks is history. `CompactHistory` (what `Compress` calls) rewrites the newest run of history segments — each older one joins while it is no larger than 1/`CompactRatio` of what has gathered behind it — into one holding the newest record per key. `Shadowed`, `Compact`, `CompactNext` are gone. `MergeBelow`/`PackFinalized` work on history only; a watermark inside the window lags by up to N blocks.

## Measured

One `KV2`, N=20, 1,000 blocks × 500 perm keys, dynamic layer of the size shown (~20% live); a writer doing `PutPerm`+`PutDyna`+`Seal` every 50 ms and a reader every 2 ms while `Compress` then `MergeBelow` run once. Longest any call took while the maintenance ran (thelio, NVMe):

| dyna | segs | `Compress` before → after | max Put before → after | max Seal after | max Get before → after |
|---|---|---|---|---|---|
| 0.60 GB | 447 | 0.77 s → 0.71 s | **1.06 s** → <1 ms | 22 ms | **1.10 s** → 20 ms |
| 1.20 GB | 894 | 1.83 s → 1.71 s | **2.13 s** → <1 ms | 22 ms | **2.17 s** → 24 ms |
| 2.40 GB | 1,789 | 4.60 s → 4.81 s | **4.88 s** → <1 ms | 50 ms | **4.92 s** → 48 ms |
| 4.81 GB | 3,579 | 11.75 s → 11.09 s | **12.09 s** → <1 ms | 56 ms | **12.09 s** → 55 ms |

Before: 2.4 s/GB, the issue's curve. After: the maintenance takes the same time — it is the same copy, off the lock — and the protocol path pays the swap (idle Seal maxima were 15–23 ms; the 50–56 ms rows are disk contention with a multi-GB copy). `MergeBelow` 0.34 → 0.33 s. Heap 7/10/16/28 MB → 6/7/10/14 MB; the Dyna layer's resident filters 2.4/4.7/9.4/18.7 MB → 0.3/0.6/1.1/2.1 MB (the filter covers the window, not the layer).

## Verification

- `tiering_test.go`: deterministic — hold `History` exclusively and a Put/Seal/Sync/Get complete; hold `Mutex` exclusively and a merge, a compaction and a pack complete; hold a merge/compaction between copy and swap (`maintenanceHook`) and a Put+Seal and a Get complete within 1 s, at store and KV2 level. Against the old locking (maintenance taking `Mutex` for its length) they fail: "a commit during merge did not complete within 1s", "... during compact ...", "... during Compress ...", "MergeBelow with the store lock held did not complete within 10s".
- `TestCompressNeverTouchesTheWindow`, `TestDynaCompressCrashMidway` (new rule: an uncommitted compaction below the active tier is swept), `TestHistoryManifestIsRequired`, `TestSegmentsHandOffAtTheRoll`.
- **Crash contract: 0 failures in 20 + 80 runs** of `TestCrashRecovery` + `TestCrashRecoverySeal` on thelio (and 150 locally). The first 20-run loop caught one failure — a Dyna layer reopened below a segment a crash had left for `recoverOrphans`, so its next auto-seal refused ("block height 5 is below the newest segment's block 68"); a reopened store's block is now at least its newest segment's (`TestReopenRaisesTheBlockToTheNewestSegment`). The crash child now ages the Dyna layer past the window before each `Compress`, so the history compaction is under the kill.
- File deletion after a commit is a goroutine's (`unlinkLater`), off both locks: deleting a compaction's 7,158 input files under the store lock was a 236 ms `Seal` pause, growing with history.
- `-race`: concurrency, iteration, pool, FD and tiering tests green.
- Full `go test ./database/ -short` green (on thelio).
- `gofmt` clean, `go vet` clean; docs updated (`segment-store.md` *Two tiers, two locks*, `durability.md`, `performance.md`).

## Decisions the owner may want to weigh

- Merging/packing/compaction work on **history only**, so with N=64 the adapter's `MergeBelow(version − 64)` lags by up to 64 blocks (at most 128 blocks of per-block segments live in a shard). #47 asked for the watermark to be free to lag.
- `Shadowed`/`worthCompacting`/`CompactRatio`-as-garbage-ratio (issue #40) are replaced by the run rule; `Compact`/`CompactNext` removed.
- A merge's inputs that the active manifest still names wait for the shard's next active commit before deletion (one seal; the Dyna sync at the block boundary commits one when there is something to finish).
- `DropBelow` costs two barriers per shard per pack (parallel ×16), where #53 had deferred it to the seal.
- `KV2.SetFilterBlocks` now sets both layers.

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKAh7mFDHChAtKQtJYP3a3
