### PR TITLE
Merge each finished window once (#63)

### DIFF
--- a/database/merge_test.go
+++ b/database/merge_test.go
@@ -305,11 +305,12 @@ func TestRepeatedMergesKeepDeepEntriesReachable(t *testing.T) {
 			_, err = store.Seal(block)
 			require.NoError(t, err)
 		}
-		// Finalise every set but the one just written, so each merge
-		// after the first folds in what the previous merge produced.  A
-		// merge works on history -- what the window, N to 2N blocks, has
-		// rolled past -- so the first set has nothing to merge and every
-		// later one merges the set before the one the window still holds.
+		// Finalise every set but the one just written.  A merge works on
+		// history -- what the window, N to 2N blocks, has rolled past --
+		// so the first set has nothing to merge and every later one
+		// merges the set before the one the window still holds.  Each
+		// merge leaves a merged block behind and never touches it again
+		// (issue #63); TestMergeFoldsEachWindowOnce pins that.
 		watermark := block - uint64(setSize) + 1
 		if watermark > 1 {
 			_, merged, err := store.MergeBelow(watermark)
@@ -345,6 +346,79 @@ func TestRepeatedMergesKeepDeepEntriesReachable(t *testing.T) {
 	t.Logf("%d entries over %d blocks, %d merges, %d segments standing",
 		len(all), block, sets-1, len(reopened.sealedSegments()))
 	require.NoError(t, reopened.Close())
+}
+
+// TestMergeFoldsEachWindowOnce
+// A merged block is finished: merged once, then permanent (spec 1.4).
+// MergeBelow folded the whole prefix below the watermark, and the
+// previous merge's output is in that prefix -- so every pass re-copied
+// the entire permanent layer accumulated so far.  Lifetime IO was
+// O(chain^2) and one pass grew without limit: ~10 GB per pass after
+// four hours at 500 tx/s (issue #63).
+//
+// The proof is in what each pass writes.  With one window's worth of
+// blocks arriving between merges, every merge must fold ONE window --
+// its output holding one window's keys, the merged blocks before it
+// untouched -- rather than one output holding everything ever written.
+func TestMergeFoldsEachWindowOnce(t *testing.T) {
+	dir := storeDir(t, "mergeonce")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+	defer store.Close()
+	require.NoError(t, store.SetFilterBlocks(MinFilterBlocks))
+
+	const windows = 5
+	const perBlock = 4
+	kr := NewFastRandom([]byte{177})
+
+	block := uint64(0)
+	var outputs []SegmentMeta
+	for w := 0; w < windows; w++ {
+		for b := 0; b < MinFilterBlocks; b++ {
+			block++
+			for i := 0; i < perBlock; i++ {
+				require.NoError(t, store.Put(kr.NextHash(), []byte{byte(block), byte(i)}))
+			}
+			_, err = store.Seal(block)
+			require.NoError(t, err)
+		}
+		watermark := block - MinFilterBlocks + 1
+		if watermark <= 1 {
+			continue
+		}
+		meta, merged, err := store.MergeBelow(watermark)
+		require.NoErrorf(t, err, "merge %d", w)
+		if !merged {
+			continue
+		}
+		outputs = append(outputs, meta)
+	}
+	require.GreaterOrEqual(t, len(outputs), 3, "several merges must have run")
+
+	// Each pass folds one window, so its output holds about one
+	// window's keys -- never the whole layer.  Before the fix the
+	// counts grew with every pass: 80, 160, 240...
+	windowKeys := uint64(MinFilterBlocks * perBlock)
+	for i, m := range outputs {
+		require.LessOrEqualf(t, m.Count, 2*windowKeys,
+			"merge %d wrote %d keys; one window is ~%d -- it folded the previous output back in",
+			i, m.Count, windowKeys)
+	}
+
+	// And every merged block from an earlier pass is still on disk under
+	// its own name: merged once, then permanent
+	for i, m := range outputs[:len(outputs)-1] {
+		_, err := os.Stat(filepath.Join(dir, m.File))
+		require.NoErrorf(t, err, "merged block %d (%s) was rewritten by a later pass", i, m.File)
+	}
+
+	// History is the merged blocks, oldest first, plus whatever has not
+	// been merged yet -- not one segment holding everything
+	store.History.RLock()
+	n := len(store.history)
+	store.History.RUnlock()
+	require.GreaterOrEqualf(t, n, len(outputs),
+		"each merged window must stand as its own block; history has %d", n)
 }
 
 // TestRejectedImportIsNotAdoptedAfterACrash

--- a/database/segstore.go
+++ b/database/segstore.go
@@ -2897,6 +2897,19 @@ func (s *SegmentStore) concatSegments(segs []*segment, height, seq uint64) (meta
 // to lag behind the window, and so is the merge behind the watermark;
 // nothing about correctness needs either to be current (issue #47).
 //
+// A MERGED BLOCK IS MERGED ONCE.  What this folds is the segments that
+// have arrived since the last merged block -- the newly finished
+// window -- and never the merged blocks themselves, which are
+// permanent: entries are file:offset:length and never move, so the
+// cost of a merge is the size of one window forever, and the lifetime
+// cost is linear in the data (spec 1.4).  Folding the previous output
+// back in made each pass copy the whole permanent layer accumulated so
+// far -- O(chain^2) over a store's life, and a single pass growing
+// without limit: ~10 GB per pass after four hours at 500 tx/s, every
+// 128 commits, competing with the protocol path for the device
+// (issue #63).  A deep read walks the merged blocks newest-first by
+// their filters; that is what they are for.
+//
 // The copy takes no store lock.  Sealed segments are immutable and the
 // pool hands out descriptors for pread, so the run is read and the
 // merged file written aside while commits and reads carry on; History
@@ -2928,18 +2941,30 @@ func (s *SegmentStore) MergeBelow(height uint64) (meta SegmentMeta, merged bool,
 		}
 		n++
 	}
-	run := append([]*segment(nil), s.history[:n]...)
+	// A merged block is FINISHED: it is merged once and never again
+	// (spec 1.4).  Skip the merged blocks at the front of that prefix
+	// and fold only what has arrived since -- the newly finished
+	// window.  Folding them back in is what made a pass copy the whole
+	// permanent layer, once per pass, growing with the chain: lifetime
+	// O(chain^2) IO for a job whose whole purpose is to be O(window).
+	// A merged block is the one thing that reaches over several blocks,
+	// so Span says so; a sealed block has Span 0 (issue #63).
+	first := 0
+	for first < n && s.history[first].meta.Span > 0 {
+		first++
+	}
+	run := append([]*segment(nil), s.history[first:n]...)
 	s.History.RUnlock()
-	if n < 2 {
+	if len(run) < 2 {
 		return meta, false, nil // Nothing to gain from merging one segment
 	}
 
 	// The merged segment takes the sequence after the newest it
 	// replaces.  That is free and correctly ordered: everything merged
 	// is at or below (H, S), and the first segment left standing is in
-	// a block above H, because the run is exactly the segments below
+	// a block above H, because the run ends at the last segment below
 	// `height` and the remainder is exactly those at or above it.
-	last := run[n-1].meta
+	last := run[len(run)-1].meta
 	outHeight, outSeq := last.Height, last.Seq+1
 
 	meta, seg, err := s.concatSegments(run, outHeight, outSeq)
@@ -2963,7 +2988,7 @@ func (s *SegmentStore) MergeBelow(height uint64) (meta SegmentMeta, merged bool,
 		maintenanceHook()
 	}
 
-	merged, err = s.swapHistory(run, seg, 0)
+	merged, err = s.swapHistory(run, seg, first)
 	return meta, merged, err
 }
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -324,9 +324,10 @@ run is still in place and discards its output if not.
   its garbage is never reclaimed.
 - **Perm window merge** — `MergeBelow` → `concatSegments`: byte-
   verbatim body copies, indexes shifted by their body's base, one
-  identity after the run's newest (1.4).  **DEVIATION #63**: the run
-  is currently *everything* below the watermark, so each pass re-folds
-  the previous output — the spec says a finished window merges once.
+  identity after the run's newest (1.4).  The run starts after the
+  merged blocks already standing — a merged block carries `Span > 0`
+  and is merged once, then permanent — so a pass folds the newly
+  finished window and nothing else (#63).
 - **Pack tier** — `KVShard.PackFinalized` + `DropBelow`
   (`kv_shard.go`, `blockset.go`): builds a `.bset` from only the
   segments since the previous set (64 B header, 512-entry directory,
@@ -366,7 +367,6 @@ The current gaps between Section 1 and the code, in one place:
 
 | Issue | Invariant | Gap |
 |---|---|---|
-| #63 | 1.4 merge-once | `MergeBelow` re-folds the previous merge's output |
 | #64 | 1.2 memory / 1.4 cold filters | All blooms resident; open scans every filter |
 | #65 | 1.5 dyna converges | Budget-frozen segments never merge; frozen garbage is permanent |
 | #66 | 1.6 lock rules | `KV2.Put` holds the store-wide lock across cross-layer reads |


### PR DESCRIPTION
## The defect

`MergeBelow(height)` selected `history[:n]` — every history segment below the watermark. The output of the *previous* merge is itself below every later watermark, so each pass re-copied the entire permanent layer accumulated so far:

- lifetime IO **O(chain²)** for a job whose purpose is to be O(window);
- a single pass growing without limit — ~10 GB per pass after four hours at 500 tx/s, every `CompressEvery` (128) commits, competing with the protocol path for the device.

The design (spec §1.4) is the opposite: entries are `file:offset:length` and never move, a finished window is merged **once**, the merged block is permanent, and deep reads walk merged blocks newest-first by their filters. The pack tier (`PackFinalized`) already worked this way; `MergeBelow` did not.

## The fix

The run starts after the merged blocks already standing. A merged block carries `Span > 0` (it reaches over several blocks); a sealed block has `Span 0`. So a pass folds the newly finished window and nothing else, forever.

## The proof

`TestMergeFoldsEachWindowOnce` measures what each pass writes, with one window of blocks arriving between merges:

| | merge 1 | merge 2 | merge 3 |
|---|---|---|---|
| before | 80 keys | **236 keys** | climbing |
| after | ~80 | ~80 | ~80 |

It also asserts every earlier merged block is still on disk under its own name (never rewritten), and that each stands as its own block in history. Against the old selection it fails with `merge 2 wrote 236 keys; one window is ~80 — it folded the previous output back in`.

Full `-short` suite green (87.5 s); spec §2.10 register updated — #63 removed, §2.7 now states the rule.

Closes #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKAh7mFDHChAtKQtJYP3a3