### PR TITLE
KVShard.Stats, and settle the un-shard-perm ToDo (toward #62)

### DIFF
--- a/database/kv_2.go
+++ b/database/kv_2.go
@@ -37,10 +37,16 @@ const DynaDirName = "dyna"
 // peer syncs them by copying files.  The Dyna layer lets the newer write shadow the older,
 // so its sealed segments overlap and Compress reclaims what the shadowing left behind.
 //
-// ToDo: Because KV2 can be used as a shard in a sharded database, and because the PermKV values don't
-// change and that database does not benefit from sharding, then KV2 might ought to accept a
-// *SegmentStore for the PermKV. That way, only the DynaKV is really sharded, while all the permanent
-// key/values are kept in one store.
+// BOTH layers are sharded when a KV2 is used as a shard (KVShard).  It
+// was once proposed to un-shard the Perm layer, on the grounds that
+// immutable values accumulate no garbage and so gain nothing from
+// sharding.  That reasoning covers compaction only.  Sharding buys the
+// Perm layer what it buys any layer on the write path: parallel
+// ingest -- one lock, one live tail and one seal per shard instead of
+// one for the whole node -- and permanent keys are content-addressed,
+// so they balance across shards essentially perfectly.  Permanent data
+// is also the larger and faster-growing half, which makes it the half
+// that most needs the parallelism (spec 1.9).
 
 type KV2 struct {
 	// Mutex is the protocol's lock at this level: Put, PutPerm, PutDyna

--- a/database/kv_shard.go
+++ b/database/kv_shard.go
@@ -524,6 +524,40 @@ func (k *KVShard) PackFinalized(height uint64) (meta SetMeta, packed bool, err e
 // packDropWorkers is how many shards PackFinalized drops at once
 const packDropWorkers = 16
 
+// Stats
+// The two layers' counters, summed over every shard: what a sharded
+// database did, in the shape one store reports it (StoreStats).  A
+// caller watching a node has one database, not 512, and the per-shard
+// split is an implementation detail of routing -- so the sum is the
+// number that answers "is the immutability check earning its keep",
+// "what are the filters buying".  Taken without any lock, like the
+// per-store snapshot it is built from.
+func (k *KVShard) Stats() (perm, dyna StoreStats) {
+	add := func(dst *StoreStats, s StoreStats) {
+		dst.PutTotal += s.PutTotal
+		dst.PutNew += s.PutNew
+		dst.PutDuplicate += s.PutDuplicate
+		dst.PutConflict += s.PutConflict
+		dst.LookupTotal += s.LookupTotal
+		dst.FilterAbsent += s.FilterAbsent
+		dst.FilterWalked += s.FilterWalked
+		dst.FilterMisled += s.FilterMisled
+		dst.LiveHit += s.LiveHit
+	}
+	for _, shard := range k.Shards {
+		if shard == nil {
+			continue
+		}
+		if shard.PermKV != nil {
+			add(&perm, shard.PermKV.Stats())
+		}
+		if shard.DynaKV != nil {
+			add(&dyna, shard.DynaKV.Stats())
+		}
+	}
+	return perm, dyna
+}
+
 // Compress
 // Compress all the shards
 func (k *KVShard) Compress() (err error) {

--- a/database/kv_shard_test.go
+++ b/database/kv_shard_test.go
@@ -10,6 +10,7 @@ import (
 
 	humanize "github.com/dustin/go-humanize"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestKVShard(t *testing.T) {
@@ -295,4 +296,42 @@ func TestBuildBig2(t *testing.T) {
 	fmt.Printf("wps %8.3f %s\n", wps, tpw)
 	cntWrites++
 
+}
+
+// TestShardStatsSumTheShards
+// A caller watching a node has one database, not 512: KVShard.Stats
+// reports what the two layers did across every shard, in the shape one
+// store reports it.  Wired for the Accumulate adapter's move to the
+// sharded store (issue #62).
+func TestShardStatsSumTheShards(t *testing.T) {
+	dir := storeDir(t, "shardstats")
+	kvs, err := NewKVShard(dir, 1000)
+	require.NoError(t, err)
+	defer kvs.Close()
+
+	kr := NewFastRandom([]byte{178})
+	keys := make([][32]byte, 200)
+	for i := range keys {
+		keys[i] = kr.NextHash()
+		require.NoError(t, kvs.PutPerm(keys[i], []byte{byte(i)}))
+	}
+	for i := range keys { // Every one a duplicate: same key, same value
+		require.NoError(t, kvs.PutPerm(keys[i], []byte{byte(i)}))
+	}
+	for i := 0; i < 50; i++ {
+		require.NoError(t, kvs.PutDyna(kr.NextHash(), []byte{9}))
+	}
+
+	perm, dyna := kvs.Stats()
+	require.Equal(t, uint64(len(keys)*2), perm.PutTotal, "every permanent write is counted once")
+	require.Equal(t, uint64(len(keys)), perm.PutNew)
+	require.Equal(t, uint64(len(keys)), perm.PutDuplicate, "the second pass was all duplicates")
+	require.Equal(t, uint64(50), dyna.PutTotal, "the dynamic layer is counted apart")
+
+	// The sum is the shards' sum, not one shard's
+	var byShard uint64
+	for _, shard := range kvs.Shards {
+		byShard += shard.PermKV.Stats().PutTotal
+	}
+	require.Equal(t, byShard, perm.PutTotal)
 }


### PR DESCRIPTION
Groundwork for #62 — the Accumulate adapter opening the sharded store instead of a single `KV2`.

**`KVShard.Stats()`** sums both layers' `StoreStats` across all 512 shards. The adapter reports `d.kv.PermKV.Stats(), d.kv.DynaKV.Stats()` into `stats.json`; a sharded database has no single pair of stores to ask, and a caller watching a node has one database, not 512. Test: `TestShardStatsSumTheShards`.

**The `kv_2.go` ToDo** proposing an un-sharded Perm layer is settled the other way, in place. Its reasoning — immutable values accumulate no garbage, so sharding buys nothing — covers compaction only. Sharding buys Perm what it buys any layer on the write path: parallel ingest, one lock/tail/seal per shard instead of one for the whole node, with content-addressed keys balancing essentially perfectly. Permanent data is the larger and faster-growing half, so it needs it most (spec §1.9).

The adapter change itself is not in this PR: a soak is running in that tree right now, and swapping its store mid-run would corrupt the measurement. The patch is ready to apply when that finishes.

Full `-short` suite green (96.7 s).

Toward #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKAh7mFDHChAtKQtJYP3a3