### PR TITLE
Hold a filter in memory only while its segment is in the window (#64)

### DIFF
--- a/database/blockset.go
+++ b/database/blockset.go
@@ -101,10 +101,48 @@ type setEntry struct {
 // whether, and where, to read.  The file itself is borrowed from the
 // shared pool for the length of a read, like a segment's.
 type blockSet struct {
-	meta  SetMeta
-	path  string
-	dir   []setEntry // One per shard
-	bloom *Bloom     // Over every key in the set
+	meta SetMeta
+	path string
+	dir  []setEntry // One per shard
+
+	// The set's filter stays ON DISK.  A set covers a whole finished
+	// period -- every key of every shard -- so its filter is the
+	// largest single thing a set would keep resident, and sets
+	// accumulate for the life of the chain: holding them all is memory
+	// growing with the age of the store, and reading them all is an
+	// open that gets slower forever (issue #64).  A set is consulted
+	// only by a deep read, which is rare by design (spec 1.4), and the
+	// probe costs K one-byte reads from a file the pool already holds
+	// open.
+	bloomOff   int64
+	bloomBytes uint64
+	bloomK     int
+}
+
+// bloomTest asks the set's on-disk filter whether the key might be
+// here.  An unreadable filter reads as "might": a pointless read, not
+// a wrong answer.
+func (b *blockSet) bloomTest(key [32]byte) (mightBe bool, err error) {
+	if b.bloomBytes == 0 || b.bloomK < 1 {
+		return true, nil
+	}
+	f, release, err := segmentFiles.acquire(b.path)
+	if err != nil {
+		return true, err
+	}
+	defer release()
+	probe := Bloom{NumBytes: b.bloomBytes, K: b.bloomK}
+	var one [1]byte
+	for i := 0; i < b.bloomK; i++ {
+		idx, mask := probe.ByteMask(key, i)
+		if _, err = f.ReadAt(one[:], b.bloomOff+int64(idx)); err != nil {
+			return true, err
+		}
+		if one[0]&mask == 0 {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 // SetStore
@@ -341,10 +379,14 @@ func (ss *SetStore) build(first, last uint64, shards [][]*segment) (set *blockSe
 	}
 
 	set = &blockSet{
-		meta:  SetMeta{First: first, Last: last, File: name, Keys: keys},
-		path:  path,
-		dir:   dir,
-		bloom: bloom,
+		meta: SetMeta{First: first, Last: last, File: name, Keys: keys},
+		path: path,
+		dir:  dir,
+		// The filter this build just wrote is left on disk with the
+		// rest of the set, and probed there (issue #64)
+		bloomOff:   int64(setHdrSize) + NumShards*setDirEntSize + int64(keys)*DBKeyFullSize,
+		bloomBytes: bloom.NumBytes,
+		bloomK:     bloom.K,
 	}
 	ss.Mutex.Lock()
 	ss.sets = append(ss.sets, set)
@@ -401,19 +443,10 @@ func openBlockSet(path string) (set *blockSet, err error) {
 		}
 	}
 
-	bitmap := make([]byte, bloomBytes)
-	bloomOff := int64(setHdrSize) + NumShards*setDirEntSize + int64(set.meta.Keys)*DBKeyFullSize
-	if _, err = f.ReadAt(bitmap, bloomOff); err != nil {
-		return nil, err
-	}
-	set.bloom = &Bloom{
-		SizeOfMap: float64(bloomBytes) / (1024 * 1024),
-		NumBytes:  bloomBytes,
-		Map:       bitmap,
-		K:         bloomK,
-		Capacity:  bloomBytes * 8 / BloomBitsPerKey,
-		Count:     set.meta.Keys,
-	}
+	// The filter is left where it is; see blockSet (issue #64)
+	set.bloomOff = int64(setHdrSize) + NumShards*setDirEntSize + int64(set.meta.Keys)*DBKeyFullSize
+	set.bloomBytes = bloomBytes
+	set.bloomK = bloomK
 	return set, nil
 }
 
@@ -421,8 +454,11 @@ func openBlockSet(path string) (set *blockSet, err error) {
 // Find a key in this set: bloom, then the shard's directory entry, then
 // a binary search of that shard's index slice, then the value.
 func (b *blockSet) lookup(shard int, key [32]byte) (value []byte, found bool, err error) {
-	if !b.bloom.Test(key) {
-		return nil, false, nil // Definitely not here: no file needed
+	switch mightBe, err := b.bloomTest(key); {
+	case err != nil:
+		return nil, false, err
+	case !mightBe:
+		return nil, false, nil // Definitely not here
 	}
 	e := b.dir[shard]
 	if e.count == 0 {

--- a/database/keyfilter.go
+++ b/database/keyfilter.go
@@ -203,6 +203,9 @@ func (s *SegmentStore) SetFilterBlocks(n uint64) (err error) {
 	}
 	if back < len(s.history) {
 		pulled := s.history[back:]
+		for _, seg := range pulled { // Back inside the window (issue #64)
+			_ = seg.loadBloom()
+		}
 		s.active = append(append([]*segment(nil), pulled...), s.active...)
 		s.history = append([]*segment(nil), s.history[:back]...)
 		if back > 0 {

--- a/database/keyfilter_test.go
+++ b/database/keyfilter_test.go
@@ -622,3 +622,93 @@ func TestFilterBlocksIsValidatedAndPersisted(t *testing.T) {
 	require.Equal(t, uint64(MinFilterBlocks+5), reopened.PermKV.FilterBlocks, "the period must survive a reopen")
 	require.NoError(t, reopened.Close())
 }
+
+// TestResidentFiltersFollowTheWindow
+// A segment's bloom is worth memory only while the segment is in the
+// window a protocol read walks.  Holding every filter resident cost
+// 1.5 bytes per key for every key the store had ever held: memory
+// growing with the age of the chain, scanned by every GC, and read in
+// full at open, so opening got slower forever (issue #64).  History is
+// probed on disk instead -- the same bits, K one-byte reads -- so what
+// the store holds follows the working set, not the chain (spec 1.2).
+func TestResidentFiltersFollowTheWindow(t *testing.T) {
+	dir := storeDir(t, "residency")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+	defer store.Close()
+	require.NoError(t, store.SetFilterBlocks(MinFilterBlocks))
+
+	kr := NewFastRandom([]byte{179})
+	var keys [][32]byte
+	const blocks = 6 * MinFilterBlocks
+	for b := uint64(1); b <= blocks; b++ {
+		for i := 0; i < 5; i++ {
+			k := kr.NextHash()
+			keys = append(keys, k)
+			require.NoError(t, store.Put(k, []byte{byte(b), byte(i)}))
+		}
+		_, err = store.Seal(b)
+		require.NoError(t, err)
+	}
+
+	resident := func(segs []*segment) (n int) {
+		for _, seg := range segs {
+			if seg.bloom != nil {
+				n++
+			}
+		}
+		return n
+	}
+	store.History.RLock()
+	history := append([]*segment(nil), store.history...)
+	store.History.RUnlock()
+	store.Mutex.RLock()
+	active := append([]*segment(nil), store.active...)
+	store.Mutex.RUnlock()
+
+	require.NotEmpty(t, history, "the window must have rolled past something")
+	require.Equal(t, 0, resident(history),
+		"history holds %d resident filters; they belong on disk", resident(history))
+	require.Equal(t, len(active), resident(active),
+		"the window's filters are the ones worth memory")
+
+	// Cold filters still answer, and answer correctly: every key is
+	// found through the history walk, and unwritten keys are not
+	for i, k := range keys {
+		v, err := store.GetDeep(k)
+		require.NoErrorf(t, err, "key %d unreachable with cold filters", i)
+		require.Equal(t, []byte{byte(i/5 + 1), byte(i % 5)}, v)
+	}
+	for i := 0; i < 200; i++ {
+		_, err := store.GetDeep(kr.NextHash())
+		require.ErrorIsf(t, err, errNotFound, "unwritten key %d", i)
+	}
+
+	// A cold probe agrees with the resident one, bit for bit: load a
+	// history segment's filter and compare the two answers
+	seg := history[0]
+	require.Nil(t, seg.bloom)
+	var cold []bool
+	for _, k := range keys {
+		mightBe, err := seg.bloomTest(k)
+		require.NoError(t, err)
+		cold = append(cold, mightBe)
+	}
+	require.NoError(t, seg.loadBloom())
+	require.NotNil(t, seg.bloom, "the filter must be loadable when it is wanted")
+	for i, k := range keys {
+		require.Equalf(t, cold[i], seg.bloom.Test(k), "key %d: cold and resident disagree", i)
+	}
+	seg.freeBloom()
+
+	// And an open reads no filter it does not need
+	require.NoError(t, store.Close())
+	reopened, err := OpenSegmentStore(dir)
+	require.NoError(t, err)
+	defer reopened.Close()
+	reopened.History.RLock()
+	rh := resident(reopened.history)
+	nh := len(reopened.history)
+	reopened.History.RUnlock()
+	require.Equalf(t, 0, rh, "reopen materialised %d of %d history filters", rh, nh)
+}

--- a/database/segstore.go
+++ b/database/segstore.go
@@ -223,9 +223,87 @@ type segment struct {
 	meta      SegmentMeta
 	dataPath  string
 	indexPath string
-	count     int64  // Indexed keys
-	records   int64  // Physical records in the data file; > count if any key repeats
-	bloom     *Bloom // Membership filter over this segment's keys
+	count     int64 // Indexed keys
+	records   int64 // Physical records in the data file; > count if any key repeats
+
+	// bloom is the segment's membership filter, held in memory only
+	// while the segment is worth the memory -- the active tier, the
+	// window a commit writes and a protocol read walks.  A history
+	// segment's filter is COLD: it stays on disk and is probed there
+	// (bloomTest).  Holding every filter resident cost 1.5 bytes per
+	// key for every key the store had ever held -- growing without
+	// limit, scanned by every GC, and read in full at open, so opening
+	// took longer the older the store was (issue #64).  What the bloom
+	// bits cost cold is what Test reads: K bytes, at K offsets, from a
+	// file the pool already holds open and the page cache keeps hot.
+	bloom *Bloom
+
+	// Where the bloom lives in the index file, so a cold filter can be
+	// probed without materialising it.  Set for every segment.
+	bloomOff   int64
+	bloomBytes uint64
+	bloomK     int
+}
+
+// loadBloom brings the segment's filter into memory, if it has one and
+// it is not there already
+func (s *segment) loadBloom() (err error) {
+	if s.bloom != nil || s.bloomBytes == 0 {
+		return nil
+	}
+	index, release, err := s.index()
+	if err != nil {
+		return err
+	}
+	defer release()
+	bitmap := make([]byte, s.bloomBytes)
+	if _, err = index.ReadAt(bitmap, s.bloomOff); err != nil {
+		return err
+	}
+	s.bloom = &Bloom{
+		SizeOfMap: float64(s.bloomBytes) / (1024 * 1024),
+		NumBytes:  s.bloomBytes,
+		Map:       bitmap,
+		K:         s.bloomK,
+		Capacity:  s.bloomBytes * 8 / BloomBitsPerKey,
+		Count:     uint64(s.count),
+	}
+	return nil
+}
+
+// freeBloom drops the resident filter; the segment goes on answering
+// from the one on disk
+func (s *segment) freeBloom() { s.bloom = nil }
+
+// bloomTest asks the segment's filter whether the key might be here.
+// Resident: a memory probe.  Cold: one byte read per hash function,
+// from the index file -- the same bits, at the same offsets, without
+// holding the map.  An unreadable filter reads as "might", which costs
+// a lookup and never a wrong answer.
+func (s *segment) bloomTest(key [32]byte) (mightBe bool, err error) {
+	if s.bloom != nil {
+		return s.bloom.Test(key), nil
+	}
+	if s.bloomBytes == 0 || s.bloomK < 1 {
+		return true, nil // No filter: everything might be here
+	}
+	index, release, err := s.index()
+	if err != nil {
+		return true, err
+	}
+	defer release()
+	probe := Bloom{NumBytes: s.bloomBytes, K: s.bloomK}
+	var b [1]byte
+	for i := 0; i < s.bloomK; i++ {
+		idx, mask := probe.ByteMask(key, i)
+		if _, err = index.ReadAt(b[:], s.bloomOff+int64(idx)); err != nil {
+			return true, err
+		}
+		if b[0]&mask == 0 {
+			return false, nil // Definitely not in this segment
+		}
+	}
+	return true, nil
 }
 
 // close
@@ -254,8 +332,11 @@ func (s *segment) index() (f *os.File, release func(), err error) {
 // Find a key in this segment.  Returns where its value lives in the
 // segment's data file.
 func (s *segment) lookup(key [32]byte) (dbb *DBBKey, found bool, err error) {
-	if s.bloom != nil && !s.bloom.Test(key) {
-		return nil, false, nil // Definitely not in this segment: no file needed
+	switch mightBe, err := s.bloomTest(key); {
+	case err != nil:
+		return nil, false, err
+	case !mightBe:
+		return nil, false, nil // Definitely not in this segment
 	}
 	// One borrow for the whole binary search rather than one per probe
 	index, release, err := s.index()
@@ -840,9 +921,14 @@ func (s *SegmentStore) load() (err error) {
 	for _, seg := range all {
 		if seg.meta.first() < start {
 			s.history = append(s.history, seg)
-		} else {
-			s.active = append(s.active, seg)
+			continue
 		}
+		s.active = append(s.active, seg)
+		// The window's filters are worth memory; history's are read
+		// from disk (issue #64).  A filter that will not load is left
+		// cold rather than failing the open: cold is correct, just
+		// slower, and it is one pread per probe.
+		_ = seg.loadBloom()
 	}
 	if n := len(s.history); n > 0 {
 		s.historyNewest, s.historyAny = s.history[n-1].meta, true
@@ -945,6 +1031,11 @@ func (s *SegmentStore) handoffBelowWindow() {
 	s.handoffMu.Lock()
 	for _, seg := range moved {
 		s.handoffs = append(s.handoffs, handoff{seg: seg})
+		// Out of the window, out of memory: history is probed on disk,
+		// so the filters the store holds cover the window and no more
+		// (issue #64).  This is the one place a segment leaves the
+		// active tier while the store runs.
+		seg.freeBloom()
 	}
 	s.handoffMu.Unlock()
 	s.History.Unlock()
@@ -1094,23 +1185,14 @@ func (s *SegmentStore) openSegmentAt(meta SegmentMeta, dataPath, indexPath strin
 		return nil, err
 	}
 	seg.count = int64(binary.BigEndian.Uint64(header[8:]))
-	bloomBytes := binary.BigEndian.Uint64(header[16:])
-	bloomK := int(binary.BigEndian.Uint32(header[24:]))
-	if bloomBytes > 0 {
-		bitmap := make([]byte, bloomBytes)
-		if _, err = index.ReadAt(bitmap, segIndexHdrSize+seg.count*DBKeyFullSize); err != nil {
-			seg.close()
-			return nil, err
-		}
-		seg.bloom = &Bloom{
-			SizeOfMap: float64(bloomBytes) / (1024 * 1024),
-			NumBytes:  bloomBytes,
-			Map:       bitmap,
-			K:         bloomK,
-			Capacity:  bloomBytes * 8 / BloomBitsPerKey,
-			Count:     uint64(seg.count),
-		}
-	}
+	seg.bloomBytes = binary.BigEndian.Uint64(header[16:])
+	seg.bloomK = int(binary.BigEndian.Uint32(header[24:]))
+	seg.bloomOff = segIndexHdrSize + seg.count*DBKeyFullSize
+	// The filter is left on disk.  Whoever places the segment in a tier
+	// loads it if the segment is worth the memory -- the active tier --
+	// and a history segment is probed cold (issue #64).  Opening a
+	// store therefore reads one header per segment rather than every
+	// filter it ever wrote.
 	return seg, nil
 }
 
@@ -2206,6 +2288,7 @@ func (s *SegmentStore) seal(height uint64, blockBoundary bool) (meta SegmentMeta
 		return meta, err
 	}
 	s.active = append(s.active, seg)
+	_ = seg.loadBloom() // Active: worth the memory (issue #64)
 	// The tail's keys are in every live filter already, and the segment
 	// they now sit in is inside the window by construction, so the
 	// filters cover it; advancing the block is what may roll them, and
@@ -3217,6 +3300,7 @@ func (s *SegmentStore) ImportSegmentFile(path string, meta SegmentMeta) (err err
 		return s.writeManifest() // Commit
 	}
 	s.active = append(s.active, seg)
+	_ = seg.loadBloom() // Active: worth the memory (issue #64)
 	// Into every live filter, whether or not the segment's block is in
 	// its range: a filter holding a key it need not is slower, never
 	// wrong, and the segment is the newest thing in the store

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -335,9 +335,14 @@ run is still in place and discards its output if not.
   then drops them from the shards, 16 at a time so the barriers
   overlap.  This is 1.4's "merge once, then permanent" done right.
   #47 tracks the daily cadence and levelled runs.
-- **DEVIATION #64**: every segment's and set's bloom is loaded
-  resident at open, so filter memory and open time grow with age; the
-  spec keeps cold filters on disk.
+- **Filter residency** — a segment's bloom is held in memory only
+  while the segment is in the active tier; a history segment's and
+  every block set's filter stays on disk and is probed there
+  (`segment.bloomTest`, `blockSet.bloomTest`): K one-byte reads from a
+  file the pool already holds open, which the page cache keeps hot.
+  Resident filter memory therefore follows the window, not the chain,
+  and an open reads one index header per segment rather than every
+  filter the store ever wrote (#64).
 
 ### 2.8 Crash recovery (1.8)
 
@@ -367,7 +372,6 @@ The current gaps between Section 1 and the code, in one place:
 
 | Issue | Invariant | Gap |
 |---|---|---|
-| #64 | 1.2 memory / 1.4 cold filters | All blooms resident; open scans every filter |
 | #65 | 1.5 dyna converges | Budget-frozen segments never merge; frozen garbage is permanent |
 | #66 | 1.6 lock rules | `KV2.Put` holds the store-wide lock across cross-layer reads |
 | #62 | 1.9 sharding | Adapter opens one unsharded KV2 |


### PR DESCRIPTION
## The cost

Every sealed segment's bloom was read into memory at open and kept for the segment's life (`openSegmentAt`), and every block set's with it (`openBlockSet`). At `BloomBitsPerKey = 12` that is **1.5 bytes resident per key the store has ever held** — memory growing with the age of the chain, scanned by every GC — and an `Open()` that reads every filter ever written, so starting a node got slower forever. It showed up as the ~18 MB/h of segment-metadata growth in the 4 h load run.

Measured here on 779 history segments holding 160,000 keys:

| | heap | bitmaps held |
|---|---|---|
| before (all resident) | 4.1 MB | 3.0 MB |
| after (cold) | **1.2 MB** | 0 |

The bitmap total scales linearly with keys forever: ~1.5 GB at a billion keys.

## The fix

Consulting a filter does not need the map — `Test` reads K bytes at K offsets. A cold filter is probed where it lies: K one-byte `ReadAt`s into the index (or set) file the descriptor pool already holds open, which the page cache keeps hot for anything actually being read.

Residency follows the tiers, which is what the spec's memory rule asks for (§1.2):
- a segment **loads** its filter entering the active tier — seal, import, open, a window that grew (`SetFilterBlocks`);
- it **frees** it at `handoffBelowWindow`, the one place a segment leaves the window while the store runs;
- **block sets are always cold**: a set covers a whole finished period, its filter is the largest single thing it would hold, sets accumulate for the life of the chain, and only a deep read consults one (§1.4).

An unreadable filter reads as "might" — a pointless lookup, never a wrong answer, matching the existing never-under-report rule.

## The test

`TestResidentFiltersFollowTheWindow`: no history filter resident after the roll, every window filter resident, **cold and resident probes agreeing key for key** on 30 blocks' worth of keys, every key still reachable through `GetDeep`, unwritten keys still absent, and a reopen that materialises none of them.

Full `-short` suite green (107.7 s). Spec §2.7 rewritten, §2.10 register updated.

Closes #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKAh7mFDHChAtKQtJYP3a3