### PR TITLE
Give the segments the pass budget froze a tier of their own (#65)

### DIFF
--- a/database/indexmerge_test.go
+++ b/database/indexmerge_test.go
@@ -217,9 +217,79 @@ func TestCompactionPassIsBounded(t *testing.T) {
 	require.Equal(t, 0, at)
 	require.Equal(t, int64(400), run[0].records)
 
-	// Nothing fits: two giants and nothing else
-	run, _ = compactionRun(mk(2000, 3000), DefaultCompactRatio)
-	require.Nil(t, run)
+	// Nothing fits the ordinary budget: two giants and nothing else.
+	// The deeper tier is what folds these, and only when the cheap pass
+	// is idle -- TestFrozenSegmentsStillConverge covers it (issue #65).
+	run, _ = compactionRunWithin(mk(2000, 3000), DefaultCompactRatio, CompactPassRecords)
+	require.Nil(t, run, "one ordinary pass must stay inside its budget")
+}
+
+// TestFrozenSegmentsStillConverge
+// CompactPassRecords bounds one pass, which is what keeps a
+// compaction from stalling the maintenance behind it -- but a segment
+// that grows past the budget was frozen for good: the suffix rule
+// stops at it and no pair containing it fits, so its garbage was
+// permanent and the dynamic layer grew without limit under exactly
+// the workload it is built for, a bounded key set rewritten forever
+// (issue #65).  When the ordinary pass has nothing to do, one deeper
+// fold is allowed, and the frozen segments halve with each one.
+func TestFrozenSegmentsStillConverge(t *testing.T) {
+	mk := func(records ...int64) (h []*segment) {
+		for i, r := range records {
+			h = append(h, &segment{records: r, meta: SegmentMeta{Height: uint64(i+1) * 10}})
+		}
+		return h
+	}
+	oldPass, oldDeep := CompactPassRecords, CompactDeepPassRecords
+	defer func() { CompactPassRecords, CompactDeepPassRecords = oldPass, oldDeep }()
+	CompactPassRecords = 1000
+	CompactDeepPassRecords = 8000
+
+	// Two frozen segments: each is over the ordinary budget, so nothing
+	// the cheap pass can do -- and before the deep pass they stood
+	// forever, holding whatever the other superseded
+	frozen := mk(900, 800)
+	run, _ := compactionRunWithin(frozen, DefaultCompactRatio, CompactPassRecords)
+	require.Nil(t, run, "the ordinary budget cannot touch them")
+	run, at := compactionRun(frozen, DefaultCompactRatio)
+	require.Len(t, run, 2, "the deep pass folds them")
+	require.Equal(t, 0, at)
+
+	// It still has to be worth it: a big segment with little behind it
+	// is not rewritten just because the deep budget could afford it
+	run, _ = compactionRun(mk(5000, 10), DefaultCompactRatio)
+	require.Nil(t, run, "the ratio gate holds at every budget")
+
+	// And the deep pass never pre-empts the cheap one: with ordinary
+	// work available, that is what runs
+	run, _ = compactionRun(mk(4000, 300, 200, 100), DefaultCompactRatio)
+	require.Len(t, run, 3, "the affordable suffix, not the giant")
+	var total int64
+	for _, s := range run {
+		total += s.records
+	}
+	require.LessOrEqual(t, uint64(total), CompactPassRecords)
+
+	// Convergence: repeatedly folding a frozen ladder ends at one
+	// segment, rather than stalling forever
+	ladder := mk(900, 800, 700, 600)
+	for pass := 0; pass < 10 && len(ladder) > 1; pass++ {
+		run, at := compactionRun(ladder, DefaultCompactRatio)
+		if run == nil {
+			break
+		}
+		var folded int64
+		for _, s := range run {
+			folded += s.records
+		}
+		require.LessOrEqualf(t, uint64(folded), CompactDeepPassRecords,
+			"pass %d folded %d records; every pass must stay inside a budget", pass, folded)
+		next := append([]*segment(nil), ladder[:at]...)
+		next = append(next, &segment{records: folded, meta: ladder[at+len(run)-1].meta})
+		next = append(next, ladder[at+len(run):]...)
+		ladder = next
+	}
+	require.Lenf(t, ladder, 1, "the ladder must consolidate, not freeze: %d segments left", len(ladder))
 }
 
 // TestCompactHistoryFoldsANonSuffixRun
@@ -269,6 +339,9 @@ func TestCompactionRefusesATakenIdentity(t *testing.T) {
 	old := CompactPassRecords
 	defer func() { CompactPassRecords = old }()
 	CompactPassRecords = 700 // Only (0,0)+(0,1) fits the budget
+	oldDeep := CompactDeepPassRecords
+	defer func() { CompactDeepPassRecords = oldDeep }()
+	CompactDeepPassRecords = CompactPassRecords // The subject here is the chooser, not the tier (#65)
 
 	// The chooser must decline: the one pair under budget would mint
 	// (0,2), and (0,2) is a committed segment
@@ -440,11 +513,23 @@ func TestCompactHistoryFoldsANonSuffixRun(t *testing.T) {
 	require.Len(t, store.history, 2)
 	require.Equal(t, int64(900), store.history[0].records, "the over-budget segment stands untouched")
 
-	// A second pass has nothing it may touch: the survivors' pair is
-	// over the budget
+	// A second pass has nothing the ORDINARY budget may touch: the
+	// survivors' pair is over it
+	deep := CompactDeepPassRecords
+	CompactDeepPassRecords = CompactPassRecords // No deeper tier for now
 	compacted, err = store.CompactHistory()
 	require.NoError(t, err)
 	require.False(t, compacted)
+
+	// With the deeper tier back, the frozen pair does fold -- one pass,
+	// inside its own budget, and only because the cheap pass was idle.
+	// Without it the 900 would hold whatever the 600 superseded for the
+	// life of the store (issue #65).
+	CompactDeepPassRecords = deep
+	compacted, err = store.CompactHistory()
+	require.NoError(t, err)
+	require.True(t, compacted, "the deeper tier folds what the budget froze")
+	require.Len(t, store.history, 1)
 
 	for i, k := range keys {
 		v, err := store.GetDeep(k)

--- a/database/segstore.go
+++ b/database/segstore.go
@@ -2470,6 +2470,19 @@ var CompactRatio = DefaultCompactRatio
 // moment it froze.
 var CompactPassRecords uint64 = 4 << 20
 
+// CompactDeepPassRecords bounds the rarer pass that folds two
+// segments the ordinary budget has frozen (compactionRun).  It runs
+// only when the ordinary pass has nothing to do, folds one pair, and
+// halves the frozen count each time, so the dynamic layer converges to
+// the size of its live key set instead of growing forever with the
+// garbage inside frozen segments (issue #65).
+//
+// 32Mi records is eight ordinary passes: a few seconds of streaming
+// merge, off the protocol path, at a moment when nothing cheaper is
+// worth doing.  The dynamic layer is meant to be small (spec 1.5), so
+// this is a ceiling that a healthy store never reaches.
+var CompactDeepPassRecords uint64 = 8 * CompactPassRecords
+
 // compactionRun
 // The run of history worth compacting into one segment, and where it
 // sits.  First choice: the newest suffix, taking each older segment in
@@ -2482,11 +2495,38 @@ var CompactPassRecords uint64 = 4 << 20
 // shorter than two is nothing to do.  Sized by physical record count,
 // which every segment holds in memory, so choosing costs no I/O.
 func compactionRun(history []*segment, ratio float64) (run []*segment, at int) {
+	// The ordinary pass, bounded so a compaction never stalls the
+	// maintenance behind it
+	if run, at = compactionRunWithin(history, ratio, CompactPassRecords); run != nil {
+		return run, at
+	}
+	// Nothing fits that budget.  A segment that grows past it is
+	// otherwise frozen for good: the suffix rule stops at it, and no
+	// pair containing it can fit, so every key in it that is later
+	// overwritten becomes garbage no pass will ever reclaim -- the
+	// dynamic layer's disk grows without limit under exactly the
+	// workload it is designed for, a bounded key set rewritten forever
+	// (issue #65).  So when the cheap pass has nothing to do, one
+	// deeper fold is allowed, on a budget of its own.
+	//
+	// This cannot run away.  It fires only when the ordinary pass is
+	// idle; it folds one pair; the pair must still be worth folding by
+	// the same ratio; and each fold leaves one segment where there
+	// were two, so the frozen segments halve with each one until a
+	// single segment stands and there is nothing left to pair.  The
+	// price is that a rare pass costs up to CompactDeepPassRecords
+	// instead of CompactPassRecords -- bounded latency, still, just a
+	// larger bound, and paid only when the alternative is unbounded
+	// disk.
+	return compactionRunWithin(history, ratio, CompactDeepPassRecords)
+}
+
+// compactionRunWithin is compactionRun under one record budget
+func compactionRunWithin(history []*segment, ratio float64, budget uint64) (run []*segment, at int) {
 	n := len(history)
 	if n == 0 {
 		return nil, 0
 	}
-	budget := CompactPassRecords
 	var behind uint64
 	i := n - 1
 	for ; i >= 0; i-- {

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -320,8 +320,12 @@ run is still in place and discards its output if not.
   last.Seq+1)`; the chooser refuses a pair whose successor already
   holds that identity, and `claimSegmentName` (hard link) refuses to
   replace any existing file — a taken name skips the pass, audibly
-  (#61).  **DEVIATION #65**: a segment at the budget freezes forever;
-  its garbage is never reclaimed.
+  (#61).  A segment that grows past the budget would otherwise freeze
+  for good, so when the ordinary pass has nothing to do one deeper
+  fold is allowed, bounded by `CompactDeepPassRecords`: it folds one
+  pair, still only if the ratio says it is worth it, and the frozen
+  segments halve with each one, so the layer converges to its live key
+  set instead of holding frozen garbage forever (#65).
 - **Perm window merge** — `MergeBelow` → `concatSegments`: byte-
   verbatim body copies, indexes shifted by their body's base, one
   identity after the run's newest (1.4).  The run starts after the
@@ -372,7 +376,6 @@ The current gaps between Section 1 and the code, in one place:
 
 | Issue | Invariant | Gap |
 |---|---|---|
-| #65 | 1.5 dyna converges | Budget-frozen segments never merge; frozen garbage is permanent |
 | #66 | 1.6 lock rules | `KV2.Put` holds the store-wide lock across cross-layer reads |
 | #62 | 1.9 sharding | Adapter opens one unsharded KV2 |
 | #33 | 1.8 one commit point | Residual fsyncs; manifest rewritten whole per commit |


### PR DESCRIPTION
## The trap in the budget

`CompactPassRecords` (4 Mi) bounds one compaction pass — the right call for latency (#59). But a segment that grew past it could never be folded again: the suffix rule stops at it, and no pair containing it fits the budget, so two frozen segments could never pair with each other either.

Every key in a frozen segment that a later write superseded therefore became garbage **no pass would ever reclaim**. Under exactly the workload the dynamic layer is built for — a bounded key set (the BPT) rewritten forever — the disk grows without limit, and each frozen segment adds one more filter to probe.

## The tier

When the ordinary pass has nothing to do, one deeper fold is allowed, on a budget of its own (`CompactDeepPassRecords`, eight ordinary passes).

It cannot run away:
- it fires **only when the cheap pass is idle** — affordable work always wins;
- it folds **one pair** per call;
- the **ratio gate still applies**, so a big segment with little behind it is not rewritten just because the budget could afford it;
- each fold leaves one segment where there were two, so **frozen segments halve** with each one until a single segment stands and there is nothing left to pair.

A rare pass costs the larger bound. The alternative was unbounded disk — and the dynamic layer is meant to be small (spec §1.5), so a healthy store never reaches this ceiling.

## Tests

- `TestFrozenSegmentsStillConverge` drives a frozen ladder (900, 800, 700, 600 with a 1,000 budget) down to **one segment**, asserting every pass stays inside a budget, the ratio gate holds at every budget, and the deep tier never pre-empts affordable work.
- `TestCompactHistoryFoldsANonSuffixRun` now shows it end to end: with the tier disabled the survivors stand (the old behaviour, preserved as its own assertion); with it enabled they fold.

Full `-short` suite green (108.5 s). Spec §2.7 and the §2.10 register updated.

Closes #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKAh7mFDHChAtKQtJYP3a3