### PR TITLE
Never adopt a segment that duplicates what the manifest names (#52)

### DIFF
--- a/database/merge_test.go
+++ b/database/merge_test.go
@@ -537,3 +537,114 @@ func TestImportRefusesToReplaceAFileAtItsIdentity(t *testing.T) {
 	require.NoError(t, os.Remove(squatter))
 	require.NoError(t, dst.ImportSegmentFile(exported, meta))
 }
+
+// TestRecoveryNeverAdoptsAMergeOutput
+// recoverOrphans classifies an unnamed data file by height: above the
+// manifest's newest is an interrupted seal, complete by construction,
+// and is adopted.  That is right for a seal, whose records exist
+// nowhere else -- and wrong for a merge output, whose every key is
+// still in the inputs the manifest names.  A shard whose segments are
+// ALL below the watermark (a shard that took no writes for a whole
+// set, ordinary at low entry rates) merges its entire list, so the
+// output takes an identity above everything and the height rule adopts
+// it: every key of that shard, stored twice, until a later merge folds
+// the duplicate away (issue #52).
+//
+// The output says what it is in its header now, and recovery believes
+// the file over the arithmetic.
+func TestRecoveryNeverAdoptsAMergeOutput(t *testing.T) {
+	dir := storeDir(t, "orphanmerge")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+	require.NoError(t, store.SetFilterBlocks(MinFilterBlocks))
+
+	kr := NewFastRandom([]byte{183})
+	var keys [][32]byte
+	for b := uint64(1); b <= 3; b++ {
+		for i := 0; i < 10; i++ {
+			k := kr.NextHash()
+			keys = append(keys, k)
+			require.NoError(t, store.Put(k, []byte{byte(b), byte(i)}))
+		}
+		_, err = store.Seal(b)
+		require.NoError(t, err)
+	}
+	// Roll the window so all three are history, and merge them the way
+	// MergeBelow would -- but stop before the commit, which is the crash
+	for b := uint64(4); b <= 3*MinFilterBlocks; b++ {
+		_, err = store.Seal(b)
+		require.NoError(t, err)
+	}
+	store.History.RLock()
+	run := append([]*segment(nil), store.history...)
+	store.History.RUnlock()
+	require.GreaterOrEqual(t, len(run), 3, "the run must be history for this to test anything")
+
+	last := run[len(run)-1].meta
+	meta, seg, err := store.concatSegments(run, last.Height, last.Seq+1)
+	require.NoError(t, err)
+	seg.close()
+	orphan := filepath.Join(dir, meta.File)
+	_, err = os.Stat(orphan)
+	require.NoError(t, err, "the merge output must be on disk for the crash to matter")
+
+	// The crash: reopen without closing, so recovery runs against a
+	// store whose manifest never learned about that file
+	reopened, err := OpenSegmentStore(dir)
+	require.NoError(t, err)
+	defer reopened.Close()
+
+	_, err = os.Stat(orphan)
+	require.Truef(t, os.IsNotExist(err),
+		"recovery adopted the merge output %s; its keys are already in the segments the manifest names", meta.File)
+
+	// Every key is still there, exactly once
+	for i, k := range keys {
+		v, err := reopened.GetDeep(k)
+		require.NoErrorf(t, err, "key %d lost", i)
+		require.Equal(t, []byte{byte(i/10 + 1), byte(i % 10)}, v)
+	}
+	seen := map[string]bool{}
+	for _, s := range reopened.sealedSegments() {
+		require.Falsef(t, seen[s.meta.File], "%s counted twice", s.meta.File)
+		seen[s.meta.File] = true
+	}
+}
+
+// TestRecoveryStillAdoptsAnInterruptedSeal
+// The other half of the rule: a SEAL that reached disk before its
+// commit is the only copy of its records, and must still be adopted
+// (issue #45).  Marking maintenance output must not cost that.
+func TestRecoveryStillAdoptsAnInterruptedSeal(t *testing.T) {
+	dir := storeDir(t, "orphanseal")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+
+	kr := NewFastRandom([]byte{184})
+	first := kr.NextHash()
+	require.NoError(t, store.Put(first, []byte("committed")))
+	_, err = store.Seal(1)
+	require.NoError(t, err)
+
+	// A seal whose manifest commit never happened: write the tail,
+	// promote it, and reopen without committing
+	late := kr.NextHash()
+	require.NoError(t, store.Put(late, []byte("late")))
+	store.Mutex.Lock()
+	sl, seq, err := store.promoteLiveFile(2, 0)
+	require.NoError(t, err)
+	require.NoError(t, writeIndexFile(
+		filepath.Join(dir, strings.TrimSuffix(segmentFileName(2, seq), segDataSuffix)+segIndexSuffix),
+		sl.order, sl.entries))
+	store.Mutex.Unlock()
+
+	reopened, err := OpenSegmentStore(dir)
+	require.NoError(t, err)
+	defer reopened.Close()
+	v, err := reopened.GetDeep(late)
+	require.NoError(t, err, "an interrupted seal is the only copy of its records; it must be adopted")
+	require.Equal(t, []byte("late"), v)
+	v, err = reopened.GetDeep(first)
+	require.NoError(t, err)
+	require.Equal(t, []byte("committed"), v)
+}

--- a/database/segstore.go
+++ b/database/segstore.go
@@ -122,7 +122,7 @@ const (
 	// every segment history.json names.
 	StoreFormatVersion = 4
 	segIndexHdrSize    = 32 // magic(4) version(4) count(8) bloomBytes(8) bloomK(4) reserved(4)
-	segDataHdrSize     = 24 // magic(4) version(4) sinceOffset(8) count(8) -- segment.go's stream header
+	segDataHdrSize     = 24 // magic(4) version(4) kind(1) unused(7) count(8) -- segment.go's stream header
 	segRecHdrSize      = 40 // key(32) valueLen(8) precede each value in a .dat
 )
 
@@ -1104,6 +1104,54 @@ func (s *SegmentStore) addSegmentKeys(keys *BloomSet, seg *segment) (err error) 
 // count on trust, so a file that was not a segment at all -- or was one
 // written by a format this build does not understand -- was parsed as
 // though it were.
+// A segment's KIND, written in the header byte that segment.go's
+// stream format documented as the start of "sinceOffset" and that
+// nothing has ever written or read.  Zero -- what every file written
+// before this says -- is segKindSealed, which is what those files are.
+//
+// It answers one question, and recovery is the only thing that asks
+// it: is a file the manifests do not name a SEAL that reached disk
+// before its commit, or the OUTPUT of maintenance that did the same?
+// A seal is data that exists nowhere else and must be adopted.  A
+// merge, compaction or pack output holds keys that its inputs still
+// hold -- the inputs the manifest still names -- so adopting one
+// stores every one of those keys twice, until a later merge folds the
+// duplicate away.  It is space, not wrong answers, but it is space a
+// crash can leave behind at any size (issue #52).
+const (
+	segKindSealed  byte = 0 // A sealed live tail: adopt it if it is not named
+	segKindDerived byte = 1 // Maintenance output: named by a manifest, or garbage
+)
+
+// segKindOffset is where the kind byte sits in a segment data header
+const segKindOffset = 8
+
+// writeSegmentDataHeader fills in a segment file's header: what it is,
+// and how many physical records follow.
+func writeSegmentDataHeader(hdr []byte, kind byte, records uint64) {
+	binary.BigEndian.PutUint32(hdr[:], segmentMagic)
+	binary.BigEndian.PutUint32(hdr[4:], segmentVersion)
+	hdr[segKindOffset] = kind
+	binary.BigEndian.PutUint64(hdr[16:], records)
+}
+
+// segmentKind reads a segment data file's kind byte.  An unreadable
+// file reads as sealed, which is the conservative answer: recovery
+// adopts it and a later merge sorts out any duplication, rather than
+// deleting something that might be the only copy.
+func segmentKind(path string) byte {
+	f, err := os.Open(path)
+	if err != nil {
+		return segKindSealed
+	}
+	defer f.Close()
+	var hdr [segDataHdrSize]byte
+	if _, err = f.ReadAt(hdr[:], 0); err != nil {
+		return segKindSealed
+	}
+	return hdr[segKindOffset]
+}
+
 func checkSegmentHeader(path string, hdr []byte) error {
 	if magic := binary.BigEndian.Uint32(hdr[:]); magic != segmentMagic {
 		return fmt.Errorf("%s is not a segment file (magic %#08x)", path, magic)
@@ -1303,11 +1351,37 @@ func (s *SegmentStore) recoverOrphans(all []*segment) (segs []*segment, adopted 
 		}
 		orphan := SegmentMeta{Height: height, Seq: seq}
 		path := filepath.Join(s.Directory, name)
-		if haveSegments && !orphan.after(newest) { // Superseded by a committed compaction
-			auditUnlink(s.Directory, fmt.Sprintf("recoverOrphans-superseded(newest=%d-%d)", newest.Height, newest.Seq), path)
+		drop := func(why string) {
+			auditUnlink(s.Directory, why, path)
 			os.Remove(path)
 			os.Remove(strings.TrimSuffix(path, segDataSuffix) + segIndexSuffix)
+		}
+		if haveSegments && !orphan.after(newest) { // Superseded by a committed compaction
+			drop(fmt.Sprintf("recoverOrphans-superseded(newest=%d-%d)", newest.Height, newest.Seq))
 			continue
+		}
+		// Above the newest, so the height rule calls it an interrupted
+		// seal -- but only a SEAL holds data that exists nowhere else.
+		// A merge, compaction or pack output is named by a manifest or
+		// it is garbage: its keys are all in the inputs the manifest
+		// still names, and a run whose every segment is below the
+		// watermark produces an output above them all, so the height
+		// rule alone would adopt it and store those keys twice
+		// (issue #52).
+		if segmentKind(path) == segKindDerived {
+			drop("recoverOrphans-derived-output")
+			continue
+		}
+		// A shard whose segments were packed into a block set commits a
+		// manifest naming none of them; a crash before the unlinks
+		// leaves files above nothing at all.  The set holds those keys
+		// now, so the cold watermark settles them as the manifest would
+		// have (issue #52).
+		if s.cold != nil {
+			if last, ok := s.cold.watermark(); ok && height <= last {
+				drop(fmt.Sprintf("recoverOrphans-packed(watermark=%d)", last))
+				continue
+			}
 		}
 		hash, count, err := s.identify(path)
 		if err != nil {
@@ -2374,9 +2448,7 @@ func (s *SegmentStore) promoteLiveFile(height, seq uint64) (sl sealed, seqOut ui
 		return sl, seq, err
 	}
 	var header [segDataHdrSize]byte
-	binary.BigEndian.PutUint32(header[:], segmentMagic)
-	binary.BigEndian.PutUint32(header[4:], segmentVersion)
-	binary.BigEndian.PutUint64(header[16:], count)
+	writeSegmentDataHeader(header[:], segKindSealed, count)
 	if err = s.liveFile.WriteAt(0, header[:]); err != nil {
 		return sl, seq, err
 	}
@@ -2743,9 +2815,7 @@ func (s *SegmentStore) writeMergedRun(run []*segment, height, seq uint64) (meta 
 		out = io.MultiWriter(bw, h)
 	}
 	var header [segDataHdrSize]byte
-	binary.BigEndian.PutUint32(header[:], segmentMagic)
-	binary.BigEndian.PutUint32(header[4:], segmentVersion)
-	binary.BigEndian.PutUint64(header[16:], count)
+	writeSegmentDataHeader(header[:], segKindDerived, count) // Maintenance output (issue #52)
 	if _, err = out.Write(header[:]); err != nil {
 		return meta, nil, err
 	}
@@ -2932,13 +3002,11 @@ func (s *SegmentStore) concatSegments(segs []*segment, height, seq uint64) (meta
 	}
 
 	var header [segDataHdrSize]byte
-	binary.BigEndian.PutUint32(header[:], segmentMagic)
-	binary.BigEndian.PutUint32(header[4:], segmentVersion)
 	var physical uint64
 	for _, seg := range segs {
 		physical += uint64(seg.records)
 	}
-	binary.BigEndian.PutUint64(header[16:], physical)
+	writeSegmentDataHeader(header[:], segKindDerived, physical) // Maintenance output (issue #52)
 	if _, err = out.Write(header[:]); err != nil {
 		return meta, nil, err
 	}

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -304,9 +304,13 @@ Deletion is deferred through `retireAfterActiveCommit` and an unlink
 queue; `retireWhy` **refuses to unlink any file an on-disk manifest
 still names** and audits the refusal (`unlink.log`) — invariant 1.8
 made executable (#61).  `recoverOrphans` deletes only files named by
-*no* manifest, and only at or below the newest named identity; above
-it, an orphan is an interrupted seal and is adopted (#45, #52 tracks a
-duplicate-adoption gap).
+*no* manifest.  At or below the newest named identity an orphan was
+superseded; above it, an orphan is an interrupted seal and is adopted
+(#45) -- unless the file says it is maintenance output, which is named
+by a manifest or is garbage, or the cold watermark already covers its
+block, both of which would otherwise store the same keys twice (#52).
+A segment's header records which it is; files written before that
+field read as sealed, which is what they are.
 
 ### 2.7 Maintenance (1.2, 1.4, 1.5, 1.7)
 
@@ -384,7 +388,6 @@ The current gaps between Section 1 and the code, in one place:
 | #62 | 1.9 sharding | Adapter opens one unsharded KV2 |
 | #33 | 1.8 one commit point | Residual fsyncs; manifest rewritten whole per commit |
 | #47 | 1.4 pack cadence | Daily cross-shard tier not yet scheduled |
-| #52 | 1.8 recovery | recoverOrphans can adopt a duplicate of named data |
 | #54 | 1.3 filter sizing | Filters sized from all-time max, not recent demand |
 
 A pull request that closes one of these updates this table.  A pull


### PR DESCRIPTION
## The gap

`recoverOrphans` classifies an unnamed data file by height against the manifests' newest:

- **above** → an interrupted seal, complete by construction → adopted
- **at or below** → superseded by a committed compaction → deleted

Right for a seal, whose records exist nowhere else. Wrong for maintenance output, whose every key is still in the inputs the manifest names. Two shapes hit it:

1. **A merge of a shard whose segments are all below the watermark** — ordinary at low entry rates, where a block touches a fraction of the 512 shards. The run is the whole list, so the output takes an identity above everything, and a crash between its rename and the commit leaves a file the height rule adopts. Every key of that shard is then stored twice.
2. **A shard that packed its last segments into a block set** commits a manifest naming nothing; a crash before the unlinks leaves files above nothing at all.

Neither loses data — but both cost duplicated bytes at any size a crash happens to catch.

## The fix

A segment records **what it is** in its header — in the byte `segment.go`'s stream format documented as the start of `sinceOffset` and that nothing has ever written or read:

- `segKindSealed` (0) — a sealed live tail: adopt it if no manifest names it.
- `segKindDerived` (1) — merge, compaction or pack output: **named by a manifest, or garbage.**

Zero is what every file written before this says, and sealed is what those files are, so nothing migrates. Recovery also drops an orphan the **cold watermark** already covers, which settles case 2 as the manifest would have.

An unreadable header reads as *sealed*: adopting a file that might be the only copy is the conservative mistake, and a later merge folds a duplicate away.

## Tests

- `TestRecoveryNeverAdoptsAMergeOutput` — crashes a store between a merge's rename and its commit. Without the fix: `recovery adopted the merge output seg-00000003-0001.dat; its keys are already in the segments the manifest names`.
- `TestRecoveryStillAdoptsAnInterruptedSeal` — the other half of the rule (#45) still holds: an interrupted seal is the only copy of its records and is adopted.

Full `-short` suite green (109.0 s). Spec §2.6 and the §2.10 register updated.

Closes #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKAh7mFDHChAtKQtJYP3a3