### PR TITLE
Size each key filter from what spans recently took (#54)

### DIFF
--- a/database/bloomset.go
+++ b/database/bloomset.go
@@ -51,6 +51,17 @@ func (b *BloomSet) Count() (n uint64) {
 	return n
 }
 
+// Capacity
+// How many keys the set is sized for: every layer's design capacity.
+// A set at or over it is past its design point and layering, which
+// costs a probe per layer on every lookup.
+func (b *BloomSet) Capacity() (n uint64) {
+	for _, l := range b.Layers {
+		n += l.Capacity
+	}
+	return n
+}
+
 // Set
 // Add a key.  Grows a new layer when the active one is full.
 func (b *BloomSet) Set(key [32]byte) {

--- a/database/keyfilter.go
+++ b/database/keyfilter.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // The rolling key filter (issue #44).
@@ -102,6 +103,110 @@ const (
 	filtersMagic       = 0x4B465731        // "KFW1"
 )
 
+// Filter sizing from demand (issue #54).
+//
+// A bloom filter's false-positive rate is set by bits per key at its
+// design capacity, so the size a filter is built at decides what it
+// costs and what it is worth.  Too small and it fills past its design
+// point: the rate climbs, and every false positive is a segment walk
+// that finds nothing -- silent, nothing fails, everything slows.  Too
+// large and the bits are memory spent on nothing, doubled, because two
+// filters are live at once.
+//
+// The right size is not a constant.  Keys per span follow the
+// transaction rate, which moves with the time of day and grows over
+// the life of a chain.  So each roll sizes the filter it starts from
+// what spans actually took recently: the largest completed span in the
+// last FilterDemandHours, plus FilterHeadroomPercent.
+//
+// Demand is remembered as one bucket per hour -- the largest span that
+// completed in that hour -- and 24 of them.  A ring that small is
+// exact enough for a maximum, and it is written into the manifest,
+// which a seal rewrites: a per-span record would be hundreds of
+// entries a day in a file on the protocol path, and this is 24.
+const (
+	// FilterDemandHours is how far back the sizing looks.  A day
+	// smooths over a burst that lasted one roll while still tracking
+	// real growth.
+	FilterDemandHours = 24
+
+	// FilterHeadroomPercent is how much room over the recent peak a new
+	// filter is given, so a rise from one roll to the next does not
+	// push it past its design point.
+	FilterHeadroomPercent = 150
+)
+
+// FilterCapacityMax caps what demand can ask for, so a wrong estimate
+// -- or a burst that will not repeat -- cannot allocate without limit.
+// 16Mi keys is ~24 MB of bits per filter at BloomBitsPerKey; a store
+// whose spans really need more is one whose filter window is set too
+// wide (SetFilterBlocks), and the BloomSet layers rather than fails.
+var FilterCapacityMax uint64 = 16 << 20
+
+// spanDemand is the largest span that completed in one hour: `hour` is
+// the hour number since the epoch, so a bucket says which hour it
+// speaks for and is stale rather than wrong after a gap.
+type spanDemand struct {
+	Hour int64  `json:"hour"`
+	Keys uint64 `json:"keys"`
+}
+
+// recordSpanDemand notes what a completed span took.  The caller must
+// hold the Mutex.
+func (s *SegmentStore) recordSpanDemand(keys uint64, now time.Time) {
+	if keys == 0 {
+		return
+	}
+	if s.demand == nil {
+		s.demand = make([]spanDemand, FilterDemandHours)
+	}
+	hour := now.Unix() / 3600
+	b := &s.demand[hour%FilterDemandHours]
+	if b.Hour != hour { // A new hour reuses the bucket a day older
+		b.Hour, b.Keys = hour, keys
+		return
+	}
+	if keys > b.Keys {
+		b.Keys = keys
+	}
+}
+
+// spanDemandPeak is the largest span completed within the demand
+// window, and whether anything was recorded there at all.  The caller
+// must hold the Mutex.
+func (s *SegmentStore) spanDemandPeak(now time.Time) (keys uint64, ok bool) {
+	oldest := now.Unix()/3600 - FilterDemandHours + 1
+	for _, b := range s.demand {
+		if b.Hour >= oldest && b.Keys > keys {
+			keys, ok = b.Keys, true
+		}
+	}
+	return keys, ok
+}
+
+// filterCapacity is what a filter starting now should be sized for:
+// the recent peak plus headroom, bounded above by FilterCapacityMax
+// and below by whatever the live filters already hold -- a filter
+// cannot be sized under what its own window has taken.  With no
+// history at all (a fresh store) the estimate is zero and
+// newKeyFilter's floor, the seal limit, decides.  The caller must hold
+// the Mutex.
+func (s *SegmentStore) filterCapacity(live []*keyFilter, now time.Time) uint64 {
+	var want uint64
+	if peak, ok := s.spanDemandPeak(now); ok {
+		want = peak * FilterHeadroomPercent / 100
+	}
+	if want > FilterCapacityMax {
+		want = FilterCapacityMax
+	}
+	for _, f := range live { // Never below what a live span already holds
+		if n := f.keys.Count(); n > want {
+			want = n
+		}
+	}
+	return want
+}
+
 // keyFilter is one live filter: a membership set over every key the
 // store holds from block `start` on.
 type keyFilter struct {
@@ -168,6 +273,26 @@ func (s *SegmentStore) windowStart() (start uint64, ok bool) {
 		return 0, false
 	}
 	return s.filters[0].start, true
+}
+
+// FilterSizing
+// What the live filters were sized for and what they hold: the numbers
+// that say whether demand sizing is working (issue #54).  Capacity is
+// what a filter starting now would be built for, Peak is the largest
+// span the demand window remembers, and Fill is what the live filters
+// actually hold, largest first.  A Fill well under Capacity is memory
+// spent on nothing; a Fill at or over it means the filter is past its
+// design point and the false-positive rate is climbing.
+func (s *SegmentStore) FilterSizing() (capacity, peak uint64, fill []uint64) {
+	s.Mutex.RLock()
+	defer s.Mutex.RUnlock()
+	now := time.Now()
+	peak, _ = s.spanDemandPeak(now)
+	capacity = s.newKeyFilter(s.filterCapacity(s.filters, now)).Capacity()
+	for _, f := range s.filters {
+		fill = append(fill, f.keys.Count())
+	}
+	return capacity, peak, fill
 }
 
 // SetFilterBlocks
@@ -297,21 +422,13 @@ func (s *SegmentStore) rollKeyFilters() {
 		}
 		if live {
 			kept = append(kept, f)
-		} else if n := f.keys.Count(); n > s.spanKeys {
-			s.spanKeys = n // Its span is complete: this is what a span takes
+		} else {
+			// Its span is complete: this is what a span took, and it is
+			// what the filters starting from here are sized from
+			s.recordSpanDemand(f.keys.Count(), time.Now())
 		}
 	}
-	// Size a filter that is starting for what a full span held, which
-	// is the best estimate of what this one will take.  The estimate is
-	// the largest span seen so far; issue #54 would make it the largest
-	// over a recent period, which is why the completed count is recorded
-	// above rather than read from the filter being dropped.
-	expected := s.spanKeys
-	for _, f := range kept {
-		if n := f.keys.Count(); n > expected {
-			expected = n
-		}
-	}
+	expected := s.filterCapacity(kept, time.Now())
 	for _, start := range wanted {
 		have := false
 		for _, f := range kept {

--- a/database/keyfilter_test.go
+++ b/database/keyfilter_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -711,4 +712,91 @@ func TestResidentFiltersFollowTheWindow(t *testing.T) {
 	nh := len(reopened.history)
 	reopened.History.RUnlock()
 	require.Equalf(t, 0, rh, "reopen materialised %d of %d history filters", rh, nh)
+}
+
+// TestFilterSizingFollowsRecentDemand
+// A filter's size decides both what it costs and what it is worth: too
+// small and it fills past its design point, so every false positive
+// becomes a segment walk that finds nothing; too large and the bits
+// are memory spent on nothing, doubled, because two filters are live
+// at once.  Keys per span are not a constant -- they follow the
+// transaction rate -- so each roll sizes the filter it starts from
+// what spans actually took recently (issue #54).
+func TestFilterSizingFollowsRecentDemand(t *testing.T) {
+	dir := storeDir(t, "demand")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+	defer store.Close()
+	require.NoError(t, store.SetFilterBlocks(MinFilterBlocks))
+
+	now := time.Now()
+	store.Mutex.Lock()
+	// Yesterday's peak, outside the window, must not size anything
+	store.recordSpanDemand(9_000_000, now.Add(-(FilterDemandHours+2)*time.Hour))
+	// and this hour's demand must
+	store.recordSpanDemand(1000, now.Add(-2*time.Hour))
+	store.recordSpanDemand(4000, now.Add(-time.Hour))
+	store.recordSpanDemand(2000, now)
+	peak, ok := store.spanDemandPeak(now)
+	want := store.filterCapacity(nil, now)
+	store.Mutex.Unlock()
+
+	require.True(t, ok)
+	require.Equal(t, uint64(4000), peak, "the peak is the largest span inside the window")
+	require.Equal(t, uint64(4000*FilterHeadroomPercent/100), want,
+		"a filter is sized for the recent peak plus headroom")
+
+	// The ceiling holds: a wild span cannot ask for unbounded memory
+	store.Mutex.Lock()
+	store.recordSpanDemand(FilterCapacityMax*100, now)
+	capped := store.filterCapacity(nil, now)
+	store.Mutex.Unlock()
+	require.Equal(t, FilterCapacityMax, capped, "demand is bounded above")
+
+	// And a filter is never sized under what a live span already holds
+	store.Mutex.Lock()
+	store.demand = nil
+	live := []*keyFilter{{start: 0, keys: NewBloomSet(10, 3)}}
+	for i := 0; i < 500; i++ {
+		live[0].keys.Set(NewFastRandom([]byte{byte(i)}).NextHash())
+	}
+	floor := store.filterCapacity(live, now)
+	store.Mutex.Unlock()
+	require.GreaterOrEqual(t, floor, uint64(500),
+		"a filter cannot be sized under what its own window has taken")
+}
+
+// TestFilterDemandSurvivesAReopen
+// The measurement is only useful if a restart keeps it: a store that
+// forgot yesterday's demand would size its first filters from a guess,
+// which is what dynamic sizing exists to stop (issue #54).
+func TestFilterDemandSurvivesAReopen(t *testing.T) {
+	dir := storeDir(t, "demandreopen")
+	store, err := NewSegmentStore(dir, false)
+	require.NoError(t, err)
+	require.NoError(t, store.SetFilterBlocks(MinFilterBlocks))
+
+	now := time.Now()
+	store.Mutex.Lock()
+	store.recordSpanDemand(7500, now)
+	store.Mutex.Unlock()
+	require.NoError(t, store.Put(NewFastRandom([]byte{190}).NextHash(), []byte("x")))
+	_, err = store.Seal(1) // A seal writes the manifest, demand and all
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+
+	reopened, err := OpenSegmentStore(dir)
+	require.NoError(t, err)
+	defer reopened.Close()
+	reopened.Mutex.RLock()
+	peak, ok := reopened.spanDemandPeak(now)
+	reopened.Mutex.RUnlock()
+	require.True(t, ok, "the demand record must survive a restart")
+	require.Equal(t, uint64(7500), peak)
+
+	capacity, reportedPeak, fill := reopened.FilterSizing()
+	require.Equal(t, uint64(7500), reportedPeak)
+	require.GreaterOrEqual(t, capacity, uint64(7500*FilterHeadroomPercent/100),
+		"the reported capacity is what a filter starting now would take")
+	require.NotEmpty(t, fill, "the live filters report what they hold")
 }

--- a/database/segstore.go
+++ b/database/segstore.go
@@ -197,6 +197,12 @@ type StoreManifest struct {
 	FilterHeight   uint64 `json:"filterHeight,omitempty"`
 	FilterSeq      uint64 `json:"filterSeq,omitempty"`
 	FilterSegments uint64 `json:"filterSegments,omitempty"`
+
+	// FilterDemand is what completed filter spans took recently, one
+	// bucket per hour: what the next filter is sized from (issue #54).
+	// Small by construction -- 24 entries -- because a seal rewrites
+	// this file.
+	FilterDemand []spanDemand `json:"filterDemand,omitempty"`
 }
 
 // HistoryManifest
@@ -622,11 +628,11 @@ type SegmentStore struct {
 	// added (attachCold).  Filters loaded from disk were saved complete.
 	filtersLackCold bool
 
-	// spanKeys is the most keys a completed filter span has taken, which
-	// is what a filter that is starting is sized for (rollKeyFilters).
-	// Not persisted: a reopened store sizes its first filters from what
-	// they hold and learns the rest at its first roll.
-	spanKeys uint64
+	// demand is what completed filter spans took, one bucket per hour,
+	// and it is what a filter that is starting is sized from
+	// (keyfilter.go, issue #54).  Persisted in the manifest, so a
+	// restart sizes from yesterday's demand rather than from a guess.
+	demand []spanDemand
 
 	stats storeCounters // Atomic: the read path holds only a shared lock
 }
@@ -883,6 +889,7 @@ func (s *SegmentStore) load() (err error) {
 	}
 	s.FilterBlocks = m.FilterBlocks
 	s.blockHeight = m.BlockHeight
+	s.demand = m.FilterDemand // What spans took before the restart (issue #54)
 
 	// The union, in (Height, Seq) order, which is the order both tiers
 	// keep and the order the lists had before any restart
@@ -1515,7 +1522,7 @@ func (s *SegmentStore) writeManifest() (err error) {
 
 	m := StoreManifest{Version: StoreFormatVersion,
 		Mutable: s.Mutable, SealLimit: s.SealLimit, FilterBlocks: s.FilterBlocks,
-		BlockHeight: s.blockHeight}
+		BlockHeight: s.blockHeight, FilterDemand: s.demand}
 	if s.filterValid {
 		m.FilterValid = true
 		m.FilterStart, m.FilterHeight = s.filterSaved.Start, s.filterSaved.Height

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -288,8 +288,13 @@ directory fsync.  `StoreFormatVersion` (4) is checked strictly (1.10).
 
 `keyfilter.go`: a pair of `BloomSet`s spanning 2N each, rolled every N
 (`rollKeyFilters` — an allocation at a normal roll, a bounded rebuild
-after a block jump).  Sizing feeds from the largest completed span
-(`spanKeys`; #54 will bound it to recent demand).  Coverage claims are
+after a block jump).  Sizing feeds from recent demand: each completed span records what it
+took in an hourly bucket (24 of them, carried in the manifest so a
+restart does not size from a guess), and a filter starting now is
+built for the largest span of the last day plus 50% headroom, floored
+by what a live span already holds and by the seal limit, capped by
+`FilterCapacityMax`.  `FilterSizing` reports capacity, peak and fill
+so the sizing can be checked against reality (#54).  Coverage claims are
 verified before a persisted filter is trusted; any doubt rebuilds from
 the window, and a store that cannot build filters *walks* — a filter
 may cost a pointless walk, never a false "absent" (#35).
@@ -388,7 +393,6 @@ The current gaps between Section 1 and the code, in one place:
 | #62 | 1.9 sharding | Adapter opens one unsharded KV2 |
 | #33 | 1.8 one commit point | Residual fsyncs; manifest rewritten whole per commit |
 | #47 | 1.4 pack cadence | Daily cross-shard tier not yet scheduled |
-| #54 | 1.3 filter sizing | Filters sized from all-time max, not recent demand |
 
 A pull request that closes one of these updates this table.  A pull
 request that adds one updates it too — knowingly.


### PR DESCRIPTION
Your design from #54, implemented.

## Why a fixed size is wrong

A bloom filter's false-positive rate is set by bits per key **at its design capacity**. Too small and it fills past that point: the rate climbs, and every false positive is a segment walk that finds nothing — silent, nothing fails, everything slows. Too large and the bits are memory spent on nothing, doubled, because two filters are live at once.

Keys per span are not a constant — they follow the transaction rate, which moves with the time of day and grows over the life of a chain. The old estimate was the largest span *ever* seen, so it was wrong in one direction or the other most of the time, and could only ratchet up.

## The sizing

Each roll sizes the filter it starts to **the largest span completed in the last 24 hours, plus 50% headroom** (`FilterDemandHours`, `FilterHeadroomPercent`), with:
- a **floor**: never under what a live span already holds, nor under the seal limit;
- a **ceiling**: `FilterCapacityMax` (16Mi keys, ~24 MB of bits), so a wrong estimate or a one-off burst cannot allocate without limit.

## Where demand lives

One bucket per hour, 24 of them — exact enough for a maximum, and small enough to carry **in the manifest**. That matters: a seal rewrites the manifest, so a per-span record would be hundreds of entries a day in a file on the protocol path. Carrying it there is what lets a restart size from yesterday's demand rather than from a guess.

## Checking it against reality

`SegmentStore.FilterSizing()` reports the capacity a filter would take now, the peak the window remembers, and what each live filter holds — the metric the issue asked for, so sizing can be verified rather than trusted. A fill well under capacity is memory spent on nothing; a fill at or over it means the filter is past its design point and layering (a probe per layer per lookup).

## Tests

- `TestFilterSizingFollowsRecentDemand` — a peak outside the window sizes nothing, the peak inside it sizes with headroom, the ceiling caps a wild span, and a filter is never sized under what a live span already holds.
- `TestFilterDemandSurvivesAReopen` — demand crosses a restart through the manifest, and `FilterSizing` reports it.

Full `-short` suite green (106.9 s). Spec §2.5 and the §2.10 register updated.

Closes #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKAh7mFDHChAtKQtJYP3a3