### PR TITLE
N = 20, and fold merged blocks by the same ratio as compaction

### DIFF
--- a/database/keyfilter.go
+++ b/database/keyfilter.go
@@ -68,9 +68,8 @@ import (
 
 const (
 	// DefaultFilterBlocks is the roll period N for a store that is not
-	// told otherwise: a fresh filter every 128 blocks, so the live pair
-	// covers 128 to 256 blocks -- two to four minutes of chain at a
-	// block a second.
+	// told otherwise: a fresh filter every 20 blocks, so the live pair
+	// covers 20 to 40 blocks.
 	//
 	// The window is the reach of the immutability check (lookup), so N
 	// trades that reach against two bounded costs: what the two filters
@@ -80,17 +79,23 @@ const (
 	// ~1.9 MB a filter and a rescan of ~61 MB; at 100 entries a block,
 	// the 4 KB floor per filter and ~1.2 MB.
 	//
-	// What the window has to reach is short.  Healing writes reach back
-	// several blocks (MinFilterBlocks is the floor for that), and replay
-	// after a crash re-applies the last committed block or two.  It
-	// does NOT need to reach the packed block sets: those carry a
-	// filter of their own, and a hit is followed into them.  128 is
-	// twice the merge lag Accumulate's adapter runs with, so every write
-	// still sitting in a per-block segment is inside the window, and
-	// anything beyond a few hundred blocks would buy nothing but a
-	// larger rescan.  It was 1,000 at first, chosen as a cautious
-	// bound; the repository owner set it to 128.
-	DefaultFilterBlocks = 128
+	// What the window has to reach is SHORT, and deliberately so.  It
+	// is the reach of the immutability check and the horizon of a
+	// protocol read -- not the reach of the database.  Everything older
+	// is still there and still readable; reaching it is an explicit
+	// deep read (GetDeep), which is what the API, healing, and anything
+	// else that knowingly looks back use.  Sizing the window for those
+	// callers would make every node pay their memory and their rescan
+	// on every block.
+	//
+	// So N is set at the floor of what the protocol itself needs:
+	// healing writes reach back several blocks, and replay after a
+	// crash re-applies the last committed block or two.  20 is the
+	// repository owner's floor for that (MinFilterBlocks), and the
+	// default now sits on it.  It was 1,000 at first, then 128; each
+	// reduction was a smaller resident filter, a shorter rescan, and a
+	// smaller active tier for maintenance to work around.
+	DefaultFilterBlocks = MinFilterBlocks
 
 	// MinFilterBlocks is the smallest roll period a store accepts.
 	// Healing writes reach back over several blocks, and a window that

--- a/database/merge_test.go
+++ b/database/merge_test.go
@@ -367,17 +367,19 @@ func TestMergeFoldsEachWindowOnce(t *testing.T) {
 	defer store.Close()
 	require.NoError(t, store.SetFilterBlocks(MinFilterBlocks))
 
-	const windows = 5
+	const windows = 20
 	const perBlock = 4
 	kr := NewFastRandom([]byte{177})
 
 	block := uint64(0)
 	var outputs []SegmentMeta
+	var keys uint64
 	for w := 0; w < windows; w++ {
 		for b := 0; b < MinFilterBlocks; b++ {
 			block++
 			for i := 0; i < perBlock; i++ {
 				require.NoError(t, store.Put(kr.NextHash(), []byte{byte(block), byte(i)}))
+				keys++
 			}
 			_, err = store.Seal(block)
 			require.NoError(t, err)
@@ -388,37 +390,34 @@ func TestMergeFoldsEachWindowOnce(t *testing.T) {
 		}
 		meta, merged, err := store.MergeBelow(watermark)
 		require.NoErrorf(t, err, "merge %d", w)
-		if !merged {
-			continue
+		if merged {
+			outputs = append(outputs, meta)
 		}
-		outputs = append(outputs, meta)
 	}
-	require.GreaterOrEqual(t, len(outputs), 3, "several merges must have run")
+	require.GreaterOrEqual(t, len(outputs), 5, "several merges must have run")
 
-	// Each pass folds one window, so its output holds about one
-	// window's keys -- never the whole layer.  Before the fix the
-	// counts grew with every pass: 80, 160, 240...
-	windowKeys := uint64(MinFilterBlocks * perBlock)
-	for i, m := range outputs {
-		require.LessOrEqualf(t, m.Count, 2*windowKeys,
-			"merge %d wrote %d keys; one window is ~%d -- it folded the previous output back in",
-			i, m.Count, windowKeys)
+	// The number that separates amortised from quadratic: what every
+	// pass wrote, added up, against what the store holds.  Folding the
+	// previous output back in makes pass k rewrite everything so far,
+	// so the total grows with the SQUARE of the chain -- for 20 windows
+	// here, about ten times the data.  The ratio rule rewrites a block
+	// only once enough has gathered behind it to justify its size, so a
+	// byte is copied a few times over the life of the store.
+	var written uint64
+	for _, m := range outputs {
+		written += m.Count
 	}
+	require.LessOrEqualf(t, written, 5*keys,
+		"merging wrote %d keys to hold %d: a pass is copying the layer, not what arrived", written, keys)
 
-	// And every merged block from an earlier pass is still on disk under
-	// its own name: merged once, then permanent
-	for i, m := range outputs[:len(outputs)-1] {
-		_, err := os.Stat(filepath.Join(dir, m.File))
-		require.NoErrorf(t, err, "merged block %d (%s) was rewritten by a later pass", i, m.File)
-	}
-
-	// History is the merged blocks, oldest first, plus whatever has not
-	// been merged yet -- not one segment holding everything
+	// And the merged blocks stay few.  One per pass, never folded into
+	// each other, is the inode problem merging exists to solve (#30).
 	store.History.RLock()
 	n := len(store.history)
 	store.History.RUnlock()
-	require.GreaterOrEqualf(t, n, len(outputs),
-		"each merged window must stand as its own block; history has %d", n)
+	require.Lessf(t, n, len(outputs),
+		"history holds %d segments after %d merges; merged blocks must consolidate, not accumulate one per pass",
+		n, len(outputs))
 }
 
 // TestRejectedImportIsNotAdoptedAfterACrash

--- a/database/segstore.go
+++ b/database/segstore.go
@@ -3139,23 +3139,29 @@ func (s *SegmentStore) MergeBelow(height uint64) (meta SegmentMeta, merged bool,
 		}
 		n++
 	}
-	// A merged block is FINISHED: it is merged once and never again
-	// (spec 1.4).  Skip the merged blocks at the front of that prefix
-	// and fold only what has arrived since -- the newly finished
-	// window.  Folding them back in is what made a pass copy the whole
-	// permanent layer, once per pass, growing with the chain: lifetime
-	// O(chain^2) IO for a job whose whole purpose is to be O(window).
-	// A merged block is the one thing that reaches over several blocks,
-	// so Span says so; a sealed block has Span 0 (issue #63).
-	first := 0
-	for first < n && s.history[first].meta.Span > 0 {
-		first++
+	// Which of them to fold is the same question compaction answers,
+	// and the same rule answers it: take the newest suffix, and reach
+	// one segment further back only when what has gathered behind it is
+	// worth its size (CompactRatio), inside one pass's budget.
+	//
+	// Folding the WHOLE prefix every time -- which is what this did --
+	// re-copied the previous merge's output on every pass, so a pass
+	// copied the entire permanent layer accumulated so far: O(chain^2)
+	// over a store's life (issue #63).  Never folding a merged block
+	// again is the other extreme, and it trades that for file count:
+	// one merged block per pass, forever, which is the inode problem
+	// merging exists to solve (issue #30).  The ratio is the middle and
+	// the standard answer -- a block is rewritten only once enough has
+	// arrived to justify its size, so a byte is copied a few times over
+	// the store's life rather than once per pass, and the merged blocks
+	// stay few.  It is the rule the dynamic layer already uses (#31).
+	run, first := compactionRunWithin(s.history[:n], CompactRatio, CompactPassRecords)
+	if run == nil { // Nothing worth folding yet
+		s.History.RUnlock()
+		return meta, false, nil
 	}
-	run := append([]*segment(nil), s.history[first:n]...)
+	run = append([]*segment(nil), run...)
 	s.History.RUnlock()
-	if len(run) < 2 {
-		return meta, false, nil // Nothing to gain from merging one segment
-	}
 
 	// The merged segment takes the sequence after the newest it
 	// replaces.  That is free and correctly ordered: everything merged

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -112,11 +112,16 @@ window (MinFilterBlocks).
   offsets so an index survives its body being placed in a different
   file behind a different base; nothing in an index or a body is ever
   rewritten (#37, #47).
-- **A finished window of perm data merges exactly once**, into one
-  merged block (per shard).  Merged blocks are permanent: they are
-  never re-merged, never rewritten, never moved.  Merge cost is
-  therefore O(window) per window, and lifetime merge cost is linear in
-  the data — never quadratic (#63).
+- **A finished window of perm data is merged into a merged block**,
+  per shard, and a merged block is folded again only when enough new
+  data has gathered behind it to justify its size — the same
+  amortisation the dynamic layer compacts by (1.5).  That is the
+  middle of two failures: folding every pass re-copies the whole layer
+  each time, which is quadratic in the life of the chain (#63); never
+  folding a merged block again leaves one per pass forever, which is
+  the file-count problem merging exists to solve (#30).  Under the
+  ratio a byte is copied a few times over the store's life, and the
+  merged blocks stay few.
 - **Deep reads are explicit** (`GetDeep`): they walk merged blocks
   newest-first, one filter probe per block, binary-searching only a
   block whose filter claims the key.  The protocol path never takes
@@ -342,10 +347,11 @@ run is still in place and discards its output if not.
   set instead of holding frozen garbage forever (#65).
 - **Perm window merge** — `MergeBelow` → `concatSegments`: byte-
   verbatim body copies, indexes shifted by their body's base, one
-  identity after the run's newest (1.4).  The run starts after the
-  merged blocks already standing — a merged block carries `Span > 0`
-  and is merged once, then permanent — so a pass folds the newly
-  finished window and nothing else (#63).
+  identity after the run's newest (1.4).  The run is chosen by the
+  same rule compaction uses (`compactionRunWithin`): the newest suffix
+  below the watermark, reaching one block further back only when what
+  has gathered behind it is worth its size, inside one pass's budget
+  (#63).
 - **Pack tier** — `KVShard.PackFinalized` + `DropBelow`
   (`kv_shard.go`, `blockset.go`): builds a `.bset` from only the
   segments since the previous set (64 B header, 512-entry directory,


### PR DESCRIPTION
Two changes that belong together: the window gets smaller, so what sits outside it matters more.

## N = 20

N is the reach of the immutability check and the horizon of a protocol read — **not the reach of the database**. Everything older is still there and still readable; reaching it is an explicit deep read, which is what the API, healing, and anything else that knowingly looks back now use (Accumulate side: `BeginDeep`). Sizing the window for those callers makes every node pay their memory and their crash-rescan on every block.

So the default sits on the floor of what the protocol itself needs — 20, the owner's minimum for healing's reach (`MinFilterBlocks`). Smaller resident filters, shorter rescan, smaller active tier for maintenance to work around.

## Repairing the first #63 fix

Folding the whole prefix below the watermark re-copied the previous merge's output every pass — quadratic over the life of the chain. My fix skipped merged blocks entirely, which traded that for **unbounded file growth**: one merged block per pass, never folded into another — the inode problem merging exists to solve (#30).

Measured on the Accumulate adapter at a 4-commit cadence: **23 merged blocks after 120 blocks**, climbing with every pass.

The middle is the rule the dynamic layer already compacts by (#31): a block is folded again only once enough has gathered behind it to justify its size, inside one pass's budget. `MergeBelow` now chooses its run with `compactionRunWithin` — the same function compaction uses. A byte is copied a few times over the life of the store rather than once per pass, and the merged blocks stay few.

## The test

`TestMergeFoldsEachWindowOnce` now measures both halves over 20 windows: total keys written across every pass against what the store holds, and whether history consolidates. Without amortisation it fails with .

Adapter file count over 120 blocks: **119 → 104** files, and no longer growing per pass.

Full `-short` suite green (108.0 s). Spec §1.4 and §2.7 rewritten — the invariant is now amortised folding, stated with both failure modes it sits between.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKAh7mFDHChAtKQtJYP3a3