### PR TITLE
Group the block sets by day, and skip a group with one probe (#47)

### DIFF
--- a/database/blockset.go
+++ b/database/blockset.go
@@ -659,29 +659,42 @@ type shardSets struct {
 // or read falls back to.
 func (c shardSets) lookup(key [32]byte) (value []byte, found bool, err error) {
 	sets := c.store.snapshot()
-	filtered := map[uint64]*dayFilter{}
-	for _, d := range c.store.groupFilters() {
-		filtered[d.group] = d
-	}
-	skip := map[uint64]bool{}
+	days := c.store.groupFilters()
+
+	// Sets are ordered by block and groups tile the block space, so
+	// one group's sets are CONTIGUOUS in this walk: the decision about
+	// a group is made when its first set is reached and held in two
+	// scalars until the group changes.  No map, and nothing allocated
+	// per lookup -- a map keyed by group would be O(groups) of setup on
+	// every read, which after a year is more work than the probes it
+	// saves.
+	group, asked, skip := uint64(0), false, false
 	for i := len(sets) - 1; i >= 0; i-- {
-		g := setGroup(sets[i].meta.First)
-		if skip[g] {
-			continue
-		}
-		if d, ok := filtered[g]; ok {
-			if !d.mightHold(key) {
-				skip[g] = true // The whole group is ruled out, in one probe
-				continue
+		if g := setGroup(sets[i].meta.First); g != group || !asked {
+			group, asked, skip = g, true, false
+			if d := findDayFilter(days, g); d != nil && !d.mightHold(key) {
+				skip = true // The whole group is ruled out, in one probe
 			}
-			filtered[g] = nil // Asked once; walk the group's sets now
-			delete(filtered, g)
+		}
+		if skip {
+			continue
 		}
 		if value, found, err = sets[i].lookup(c.shard, key); err != nil || found {
 			return value, found, err
 		}
 	}
 	return nil, false, nil
+}
+
+// findDayFilter is the filter for a group, or nil if the group has
+// none.  The filters are sorted by group, so this is a binary search
+// rather than a scan that would grow with the age of the chain.
+func findDayFilter(days []*dayFilter, group uint64) *dayFilter {
+	i := sort.Search(len(days), func(i int) bool { return days[i].group >= group })
+	if i < len(days) && days[i].group == group {
+		return days[i]
+	}
+	return nil
 }
 
 // forEachKeySince visits every key the shard holds in a set that

--- a/database/blockset.go
+++ b/database/blockset.go
@@ -405,9 +405,19 @@ func (ss *SetStore) build(first, last uint64, shards [][]*segment) (set *blockSe
 	// This set may have closed out the group before it: nothing can
 	// join a group once a set sits above it, so its filter can be
 	// built, once, and never touched again (issue #47).
-	if err = ss.closeFinishedGroups(setGroup(first)); err != nil {
-		return nil, err
-	}
+	//
+	// The error is DELIBERATELY dropped.  Everything above this line is
+	// the commit -- the set is fsynced, renamed, the directory synced,
+	// and the set is in the list -- and the caller's next act is to
+	// drop the segments the set now holds.  Failing here would abort a
+	// pack that has already happened: the shards would keep segments
+	// the committed set holds, and the retry would compute a new
+	// `first` from the set that landed while `last` stayed where it
+	// was, naming a second set file over the same blocks with First
+	// above Last.  A missing group filter costs a walk of that group's
+	// sets on a deep read, which is what happened before the filters
+	// existed, and the next pack builds it.
+	_ = ss.closeFinishedGroups(setGroup(first))
 	return set, nil
 }
 
@@ -424,16 +434,41 @@ func (ss *SetStore) closeFinishedGroups(current uint64) (err error) {
 	for _, d := range ss.days {
 		have[d.group] = true
 	}
-	groups := map[uint64][]*blockSet{}
+	// The OLDEST group still missing a filter, and only that one.
+	//
+	// This runs inside PackFinalized's pin scope: every shard is
+	// pinned, so no file in any of the 512 shards can be reclaimed
+	// while it works, and it reads every key of every set in the
+	// groups it builds.  Building all of them in one call makes that
+	// unbounded -- a store upgraded to this build has no filters at
+	// all, so the first pack would read its entire history with the
+	// whole database pinned.  One group per pack is bounded by a
+	// group, and the groups are finite and only ever get built.
+	var oldest uint64
+	var sets []*blockSet
+	found := false
 	for _, s := range ss.sets {
 		g := setGroup(s.meta.First)
-		if g < current && !have[g] {
-			groups[g] = append(groups[g], s)
+		if g >= current || have[g] {
+			continue
+		}
+		if !found || g < oldest {
+			oldest, found = g, true
+		}
+	}
+	if found {
+		for _, s := range ss.sets {
+			if setGroup(s.meta.First) == oldest {
+				sets = append(sets, s)
+			}
 		}
 	}
 	ss.Mutex.Unlock()
+	if !found {
+		return nil
+	}
 
-	for g, sets := range groups {
+	for _, g := range []uint64{oldest} {
 		f, err := writeDayFilter(ss.Directory, g, sets)
 		if err != nil {
 			return err
@@ -441,9 +476,18 @@ func (ss *SetStore) closeFinishedGroups(current uint64) (err error) {
 		if f == nil {
 			continue
 		}
+		// Copy on write: a reader walks the slice groupFilters handed
+		// it without the lock, and appending in place then sorting
+		// would reorder the array underneath that walk whenever the
+		// append does not reallocate.  The sets list gets away with
+		// append alone because it only ever grows at the end and is
+		// never reordered; this one is sorted.
 		ss.Mutex.Lock()
-		ss.days = append(ss.days, f)
-		sort.Slice(ss.days, func(i, j int) bool { return ss.days[i].group < ss.days[j].group })
+		days := make([]*dayFilter, len(ss.days), len(ss.days)+1)
+		copy(days, ss.days)
+		days = append(days, f)
+		sort.Slice(days, func(i, j int) bool { return days[i].group < days[j].group })
+		ss.days = days
 		ss.Mutex.Unlock()
 	}
 	return nil

--- a/database/blockset.go
+++ b/database/blockset.go
@@ -152,6 +152,13 @@ type SetStore struct {
 	Mutex     sync.Mutex
 	Directory string
 	sets      []*blockSet
+
+	// days is one filter per FINISHED group of sets, oldest first: a
+	// deep read skips a whole group with one probe instead of walking
+	// its sets, which is what keeps the walk from growing with the age
+	// of the chain (dayfilter.go, issue #47).  The group still being
+	// filled has none, and its sets are probed directly.
+	days []*dayFilter
 }
 
 // NewSetStore creates an empty set directory, replacing any existing one
@@ -193,6 +200,9 @@ func OpenSetStore(directory string) (store *SetStore, err error) {
 		store.sets = append(store.sets, set)
 	}
 	sort.Slice(store.sets, func(i, j int) bool { return store.sets[i].meta.First < store.sets[j].meta.First })
+	if store.days, err = loadDayFilters(directory); err != nil {
+		return nil, err
+	}
 	for i := 1; i < len(store.sets); i++ {
 		a, b := store.sets[i-1].meta, store.sets[i].meta
 		if b.First <= a.Last {
@@ -391,7 +401,59 @@ func (ss *SetStore) build(first, last uint64, shards [][]*segment) (set *blockSe
 	ss.Mutex.Lock()
 	ss.sets = append(ss.sets, set)
 	ss.Mutex.Unlock()
+
+	// This set may have closed out the group before it: nothing can
+	// join a group once a set sits above it, so its filter can be
+	// built, once, and never touched again (issue #47).
+	if err = ss.closeFinishedGroups(setGroup(first)); err != nil {
+		return nil, err
+	}
 	return set, nil
+}
+
+// closeFinishedGroups builds the filter for every group below
+// `current` that has none: a group no later set can join.
+//
+// A failure here is not a failure of the pack.  The sets are committed
+// and complete; a missing group filter costs a walk of that group's
+// sets on a deep read, which is exactly what happened before the
+// filters existed, and the next pack tries again.
+func (ss *SetStore) closeFinishedGroups(current uint64) (err error) {
+	ss.Mutex.Lock()
+	have := make(map[uint64]bool, len(ss.days))
+	for _, d := range ss.days {
+		have[d.group] = true
+	}
+	groups := map[uint64][]*blockSet{}
+	for _, s := range ss.sets {
+		g := setGroup(s.meta.First)
+		if g < current && !have[g] {
+			groups[g] = append(groups[g], s)
+		}
+	}
+	ss.Mutex.Unlock()
+
+	for g, sets := range groups {
+		f, err := writeDayFilter(ss.Directory, g, sets)
+		if err != nil {
+			return err
+		}
+		if f == nil {
+			continue
+		}
+		ss.Mutex.Lock()
+		ss.days = append(ss.days, f)
+		sort.Slice(ss.days, func(i, j int) bool { return ss.days[i].group < ss.days[j].group })
+		ss.Mutex.Unlock()
+	}
+	return nil
+}
+
+// groupFilters is the day filters as they stand
+func (ss *SetStore) groupFilters() []*dayFilter {
+	ss.Mutex.Lock()
+	defer ss.Mutex.Unlock()
+	return ss.days
 }
 
 // openBlockSet
@@ -581,10 +643,40 @@ type shardSets struct {
 	shard int
 }
 
-// lookup walks the sets newest first
+// lookup walks the sets newest first, skipping whole GROUPS the day
+// filters rule out.
+//
+// Probing every set is one cheap probe each, but the sets accumulate
+// for the life of the chain, so the walk grows with age: ~31,500 sets
+// after a year at a pack every 1,000 blocks.  A finished group carries
+// one filter over every key in it, so a "no" there skips ~86 sets at
+// once, and the walk becomes the groups plus the sets of the group
+// still being filled -- ~451 probes after a year instead of 31,500,
+// ~1,900 after five years instead of 158,000 (issue #47).
+//
+// A group with no filter is walked, which is what the group being
+// filled always is, and what any group whose filter could not be built
+// or read falls back to.
 func (c shardSets) lookup(key [32]byte) (value []byte, found bool, err error) {
 	sets := c.store.snapshot()
+	filtered := map[uint64]*dayFilter{}
+	for _, d := range c.store.groupFilters() {
+		filtered[d.group] = d
+	}
+	skip := map[uint64]bool{}
 	for i := len(sets) - 1; i >= 0; i-- {
+		g := setGroup(sets[i].meta.First)
+		if skip[g] {
+			continue
+		}
+		if d, ok := filtered[g]; ok {
+			if !d.mightHold(key) {
+				skip[g] = true // The whole group is ruled out, in one probe
+				continue
+			}
+			filtered[g] = nil // Asked once; walk the group's sets now
+			delete(filtered, g)
+		}
 		if value, found, err = sets[i].lookup(c.shard, key); err != nil || found {
 			return value, found, err
 		}

--- a/database/blockset_test.go
+++ b/database/blockset_test.go
@@ -583,3 +583,87 @@ func TestDayFiltersSkipWholeGroups(t *testing.T) {
 		require.Equal(t, values[k], v)
 	}
 }
+
+// TestPackSurvivesAFailedGroupFilter
+// Everything before the group filter is the pack's commit: the set is
+// fsynced, renamed, the directory synced, and the set is in the list.
+// The caller's next act is to drop the segments the set now holds.
+// Failing the pack for a filter that could not be written would abort
+// something that has already happened -- the shards would keep the
+// segments, and the retry would name a second set over the same blocks
+// with First above Last.
+func TestPackSurvivesAFailedGroupFilter(t *testing.T) {
+	dir := storeDir(t, "packfilterfail")
+	old := SetGroupBlocks
+	defer func() { setGroupBlocksForTest(old) }()
+	setGroupBlocksForTest(8)
+
+	kvs, keys, values := packedFixture(t, dir, 0xf1, 100, 3)
+	defer kvs.Close()
+	_, packed, err := kvs.PackFinalized(20)
+	require.NoError(t, err)
+	require.True(t, packed)
+
+	// Fail the FILTER and nothing else: a directory standing where the
+	// filter's file goes makes its rename fail while the set itself
+	// still writes normally.  (A read-only set directory would fail the
+	// set too, and a pack that cannot write its set SHOULD fail.)
+	blocked := filepath.Join(kvs.Sets.Directory, dayFilterName(0))
+	require.NoError(t, os.MkdirAll(filepath.Join(blocked, "in the way"), 0o755))
+
+	// The pack that closes out the first group must still succeed
+	_, packed, err = kvs.PackFinalized(40)
+	require.NoError(t, err, "a filter that cannot be written must not fail a committed pack")
+	require.True(t, packed)
+
+	require.NoError(t, os.RemoveAll(blocked))
+
+	// Every key is still readable, through sets with no group filter
+	for i, k := range keys {
+		v, err := kvs.GetDeep(k)
+		require.NoErrorf(t, err, "key %d after a pack whose filter failed", i)
+		require.Equal(t, values[k], v)
+	}
+
+	// And the next pack builds what the failed one could not
+	_, _, err = kvs.PackFinalized(60)
+	require.NoError(t, err)
+	require.NotEmpty(t, kvs.Sets.groupFilters(), "the next pack must build the missing filter")
+}
+
+// TestADayFilterRefusesADifferentGroupSize
+// SetGroupBlocks is not persisted, and a filter's file name records
+// only its group's index.  Reopening with a different size would
+// consult a filter built over one range while walking the sets of
+// another, and answer a definitive "not here" for keys it never saw --
+// the one answer a filter may never give.
+func TestADayFilterRefusesADifferentGroupSize(t *testing.T) {
+	dir := storeDir(t, "groupsize")
+	old := SetGroupBlocks
+	defer func() { setGroupBlocksForTest(old) }()
+	setGroupBlocksForTest(8)
+
+	kvs, keys, values := packedFixture(t, dir, 0xf2, 100, 3)
+	for _, upTo := range []uint64{20, 40, 60} {
+		_, _, err := kvs.PackFinalized(upTo)
+		require.NoError(t, err)
+	}
+	require.NotEmpty(t, kvs.Sets.groupFilters())
+	require.NoError(t, kvs.Close())
+
+	// Reopen with a different group size: the filters on disk describe
+	// ranges that are no longer their groups
+	setGroupBlocksForTest(32)
+	re, err := OpenKVShard(dir)
+	require.NoError(t, err, "a store must open even when its filters no longer match")
+	defer re.Close()
+	require.Empty(t, re.Sets.groupFilters(),
+		"a filter whose range is not its group must be refused, not consulted")
+
+	// And every key is still found, because the groups are walked
+	for i, k := range keys {
+		v, err := re.GetDeep(k)
+		require.NoErrorf(t, err, "key %d lost after the group size changed", i)
+		require.Equal(t, values[k], v)
+	}
+}

--- a/database/blockset_test.go
+++ b/database/blockset_test.go
@@ -508,3 +508,78 @@ func TestBlockSetHeaderIsChecked(t *testing.T) {
 		require.NoError(t, reopened.Close())
 	})
 }
+
+// TestDayFiltersSkipWholeGroups
+// A deep read rules a key out of cold storage by probing every block
+// set's filter: one cheap probe each, but sets accumulate for the life
+// of the chain, so the WALK grows with age even though each step does
+// not.  Packing every 1,000 blocks, a year is ~31,500 sets, and every
+// deep miss walks all of them.
+//
+// A finished group of sets carries one filter over every key in it, so
+// a miss skips the group in a single probe, and a hit still walks
+// (issue #47).  The group is a BLOCK RANGE, not a clock reading, so
+// this test moves the group size rather than time.
+func TestDayFiltersSkipWholeGroups(t *testing.T) {
+	old := SetGroupBlocks
+	defer func() { setGroupBlocksForTest(old) }()
+	setGroupBlocksForTest(8) // Eight blocks to a group
+
+	dir := storeDir(t, "daygroups")
+	// Enough blocks that the window (N to 2N) has rolled past what is
+	// packed: only HISTORY is packed, whatever the watermark says
+	kvs, keys, values := packedFixture(t, dir, 0xd1, 100, 3)
+	defer kvs.Close()
+
+	// Three rounds, each landing in a later group, so the earlier
+	// groups finish and the last is still being filled
+	for _, upTo := range []uint64{20, 40, 60} {
+		_, packed, err := kvs.PackFinalized(upTo)
+		require.NoErrorf(t, err, "pack below %d", upTo)
+		require.Truef(t, packed, "pack below %d must have packed something", upTo)
+	}
+
+	filters := kvs.Sets.groupFilters()
+	require.NotEmpty(t, filters, "a finished group must carry a filter")
+	for _, f := range filters {
+		require.NotZero(t, f.bloomBytes, "group %d: the filter must have bits", f.group)
+	}
+
+	// Every packed key is still found -- a filter that denies a key it
+	// holds is a wrong answer, and the walk behind it must still run
+	for i, k := range keys {
+		v, err := kvs.GetDeep(k)
+		require.NoErrorf(t, err, "key %d unreachable through the group filters", i)
+		require.Equal(t, values[k], v)
+	}
+
+	// And the filters actually rule things out: a key that was never
+	// written must be denied by every finished group
+	kr := NewFastRandom([]byte{0xd2})
+	ruledOut := 0
+	for i := 0; i < 200; i++ {
+		absent := kr.NextHash()
+		_, err := kvs.GetDeep(absent)
+		require.ErrorIsf(t, err, errNotFound, "unwritten key %d", i)
+		for _, f := range filters {
+			if !f.mightHold(absent) {
+				ruledOut++
+				break
+			}
+		}
+	}
+	require.Greaterf(t, ruledOut, 150,
+		"the group filters ruled out only %d of 200 absent keys; they are not skipping groups", ruledOut)
+
+	// It survives a reopen: the filters are on disk, read by header
+	require.NoError(t, kvs.Close())
+	re, err := OpenKVShard(dir)
+	require.NoError(t, err)
+	defer re.Close()
+	require.Len(t, re.Sets.groupFilters(), len(filters), "the filters must be found again on open")
+	for i, k := range keys {
+		v, err := re.GetDeep(k)
+		require.NoErrorf(t, err, "key %d lost across reopen", i)
+		require.Equal(t, values[k], v)
+	}
+}

--- a/database/dayfilter.go
+++ b/database/dayfilter.go
@@ -1,0 +1,256 @@
+package blockchainDB
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// The day filter (issue #47).
+//
+// A deep read rules a key out of cold storage by probing every block
+// set's filter.  That is one cheap probe per set -- K one-byte reads,
+// page-cached -- but the sets accumulate for the life of the chain, so
+// the WALK grows with age even though each step does not.  Packing
+// every 1,000 blocks, a year is ~31,500 sets, and every deep miss
+// walks all of them.
+//
+// So the sets are grouped, and each finished group carries one filter
+// over every key in it.  A deep read probes the group first: a "no"
+// skips the whole group in one probe, and only a "maybe" walks its
+// sets.  The walk becomes (groups) + (sets in the group being filled),
+// which is ~365 + ~86 after a year rather than 31,500, and ~1,900
+// after five years rather than 158,000.
+//
+// A GROUP IS A BLOCK RANGE, not a wall-clock day: SetGroupBlocks
+// blocks, and which group a set belongs to is a pure function of its
+// first block, the same way filterStarts derives the key filters'
+// windows.  Nothing here reads a clock -- two nodes replaying the same
+// chain build the same groups -- and "day" is what the default size
+// means at a block a second, not what the code depends on.
+//
+// A filter is written only when its group is COMPLETE: a set has
+// arrived above the group's range, so nothing more can join it.  That
+// makes the filter immutable, sized exactly for the keys it holds, and
+// written once.  The group still being filled has no filter; its sets
+// are probed directly, and there are few of them.
+//
+// The failure modes are the bloom's usual pair, and the same rule
+// applies as everywhere else: a filter that claims a key it does not
+// hold costs a walk it need not have taken, and a filter that DENIES a
+// key it holds is a wrong answer with nothing downstream to catch it.
+// So a group filter is built from the sets it claims and never from
+// anything less, and a filter that cannot be read is treated as absent
+// -- the sets are walked, which is correct and merely slower.
+
+const (
+	dayFilterPrefix = "day-"
+	dayFilterSuffix = ".flt"
+	dayFilterMagic  = 0x44415931 // "DAY1"
+	dayFilterHdr    = 40         // magic(4) version(4) first(8) last(8) keys(8) bloomBytes(8)... K in the tail
+	dayFilterVer    = 1
+)
+
+// SetGroupBlocks is how many blocks one group of sets covers: 86,400,
+// a day at a block a second.  It is a block count rather than a
+// duration so that grouping is deterministic -- two nodes replaying
+// the same chain group the same sets, with no clock involved.
+var SetGroupBlocks uint64 = 86_400
+
+// setGroupBlocksForTest sets the group size; tests move the size
+// rather than the clock, because there is no clock to move.
+func setGroupBlocksForTest(n uint64) { SetGroupBlocks = n }
+
+// setGroup is the group a block belongs to: groups tile the block
+// space from 0, so a set's group is decided by its first block alone.
+func setGroup(block uint64) uint64 { return block / SetGroupBlocks }
+
+// dayFilter is one finished group's filter, held on disk and probed
+// there -- the same residency rule the segments' filters follow
+// (issue #64): a filter per day of chain, resident, would be memory
+// growing with age for data that is read rarely.
+type dayFilter struct {
+	group      uint64 // Which group: blocks [group*N, (group+1)*N)
+	first      uint64 // Oldest block the group's sets actually hold
+	last       uint64 // Newest
+	path       string
+	bloomOff   int64
+	bloomBytes uint64
+	bloomK     int
+}
+
+// dayFilterName is the file name for a group's filter
+func dayFilterName(group uint64) string {
+	return fmt.Sprintf("%s%08d%s", dayFilterPrefix, group, dayFilterSuffix)
+}
+
+// mightHold reports whether the group might hold the key.  An
+// unreadable filter reports true: a walk that was not needed, never a
+// key reported absent that is there.
+func (d *dayFilter) mightHold(key [32]byte) bool {
+	if d.bloomBytes == 0 || d.bloomK < 1 {
+		return true
+	}
+	f, release, err := segmentFiles.acquire(d.path)
+	if err != nil {
+		return true
+	}
+	defer release()
+	probe := Bloom{NumBytes: d.bloomBytes, K: d.bloomK}
+	var one [1]byte
+	for i := 0; i < d.bloomK; i++ {
+		idx, mask := probe.ByteMask(key, i)
+		if _, err = f.ReadAt(one[:], d.bloomOff+int64(idx)); err != nil {
+			return true
+		}
+		if one[0]&mask == 0 {
+			return false // Definitely not in this group
+		}
+	}
+	return true
+}
+
+// writeDayFilter builds a group's filter from the sets in it and
+// commits it: every key of every shard of every set, one bloom, tmp
+// file, fsync, rename.
+//
+// Built from the sets themselves rather than from anything remembered
+// while they were written, so the filter cannot claim coverage it does
+// not have -- the rule the key filters follow (keyfilter.go).
+func writeDayFilter(directory string, group uint64, sets []*blockSet) (f *dayFilter, err error) {
+	if len(sets) == 0 {
+		return nil, nil
+	}
+	var keys uint64
+	first, last := sets[0].meta.First, sets[0].meta.Last
+	for _, s := range sets {
+		keys += s.meta.Keys
+		if s.meta.First < first {
+			first = s.meta.First
+		}
+		if s.meta.Last > last {
+			last = s.meta.Last
+		}
+	}
+	bloom := NewBloomSizedForKeys(keys, 3)
+	for _, s := range sets {
+		for shard := 0; shard < NumShards; shard++ {
+			err = s.forEachKey(shard, func(key [32]byte, _ *DBBKey) error {
+				bloom.Set(key)
+				return nil
+			})
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	path := filepath.Join(directory, dayFilterName(group))
+	tmp := path + segTmpSuffix
+	out, err := os.Create(tmp)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if out != nil {
+			out.Close()
+			os.Remove(tmp)
+		}
+	}()
+	var hdr [dayFilterHdr]byte
+	binary.BigEndian.PutUint32(hdr[:], dayFilterMagic)
+	binary.BigEndian.PutUint32(hdr[4:], dayFilterVer)
+	binary.BigEndian.PutUint64(hdr[8:], first)
+	binary.BigEndian.PutUint64(hdr[16:], last)
+	binary.BigEndian.PutUint64(hdr[24:], keys)
+	binary.BigEndian.PutUint64(hdr[32:], bloom.NumBytes)
+	if _, err = out.Write(hdr[:]); err != nil {
+		return nil, err
+	}
+	var kb [4]byte
+	binary.BigEndian.PutUint32(kb[:], uint32(bloom.K))
+	if _, err = out.Write(kb[:]); err != nil {
+		return nil, err
+	}
+	if _, err = out.Write(bloom.Map); err != nil {
+		return nil, err
+	}
+	if err = out.Sync(); err != nil { // Durable before it is named
+		return nil, err
+	}
+	if err = out.Close(); err != nil {
+		out = nil
+		return nil, err
+	}
+	out = nil
+	if err = os.Rename(tmp, path); err != nil {
+		return nil, err
+	}
+	if err = syncDir(directory); err != nil {
+		return nil, err
+	}
+	return &dayFilter{group: group, first: first, last: last, path: path,
+		bloomOff: dayFilterHdr + 4, bloomBytes: bloom.NumBytes, bloomK: int(bloom.K)}, nil
+}
+
+// openDayFilter reads a group filter's header.  The bloom stays on
+// disk (issue #64).
+func openDayFilter(path string) (f *dayFilter, err error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	var hdr [dayFilterHdr + 4]byte
+	if _, err = file.ReadAt(hdr[:], 0); err != nil {
+		return nil, err
+	}
+	if magic := binary.BigEndian.Uint32(hdr[:]); magic != dayFilterMagic {
+		return nil, fmt.Errorf("%s is not a day filter (magic %#08x)", path, magic)
+	}
+	if v := binary.BigEndian.Uint32(hdr[4:]); v != dayFilterVer {
+		return nil, fmt.Errorf("%s is day filter version %d; this build reads %d", path, v, dayFilterVer)
+	}
+	name := strings.TrimSuffix(strings.TrimPrefix(filepath.Base(path), dayFilterPrefix), dayFilterSuffix)
+	var group uint64
+	if _, err = fmt.Sscanf(name, "%d", &group); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	return &dayFilter{
+		group:      group,
+		first:      binary.BigEndian.Uint64(hdr[8:]),
+		last:       binary.BigEndian.Uint64(hdr[16:]),
+		path:       path,
+		bloomOff:   dayFilterHdr + 4,
+		bloomBytes: binary.BigEndian.Uint64(hdr[32:]),
+		bloomK:     int(binary.BigEndian.Uint32(hdr[dayFilterHdr:])),
+	}, nil
+}
+
+// loadDayFilters reads the group filters in a set directory
+func loadDayFilters(directory string) (filters []*dayFilter, err error) {
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if strings.HasSuffix(name, segTmpSuffix) {
+			os.Remove(filepath.Join(directory, name))
+			continue
+		}
+		if !strings.HasPrefix(name, dayFilterPrefix) || !strings.HasSuffix(name, dayFilterSuffix) {
+			continue
+		}
+		f, err := openDayFilter(filepath.Join(directory, name))
+		if err != nil {
+			return nil, err
+		}
+		filters = append(filters, f)
+	}
+	sort.Slice(filters, func(i, j int) bool { return filters[i].group < filters[j].group })
+	return filters, nil
+}

--- a/database/dayfilter.go
+++ b/database/dayfilter.go
@@ -50,23 +50,57 @@ const (
 	dayFilterPrefix = "day-"
 	dayFilterSuffix = ".flt"
 	dayFilterMagic  = 0x44415931 // "DAY1"
-	dayFilterHdr    = 40         // magic(4) version(4) first(8) last(8) keys(8) bloomBytes(8)... K in the tail
 	dayFilterVer    = 1
+
+	// dayFilterHdr: magic(4) version(4) groupBlocks(8) first(8)
+	// last(8) keys(8) bloomBytes(8) K(4).  The bloom follows.
+	dayFilterHdr = 52
 )
 
 // SetGroupBlocks is how many blocks one group of sets covers: 86,400,
 // a day at a block a second.  It is a block count rather than a
 // duration so that grouping is deterministic -- two nodes replaying
 // the same chain group the same sets, with no clock involved.
-var SetGroupBlocks uint64 = 86_400
+var SetGroupBlocks uint64 = DefaultSetGroupBlocks
+
+// DefaultSetGroupBlocks is what SetGroupBlocks starts at, and what a
+// zero falls back to
+const DefaultSetGroupBlocks = 86_400
+
+// DayFilterMaxBytes bounds one group filter's bitmap.
+//
+// The filter is sized for every key in its group, and a group is a
+// day: at 5,000 entries a block that is 432M keys, which at
+// BloomBitsPerKey would be ~648 MB held in one allocation while the
+// filter is built -- on the pack path, with every shard pinned.  Spec
+// 1.2 does not allow that, and a group filter is an accelerator, not
+// a record of anything.
+//
+// Past the bound the filter is built at the bound instead, which
+// costs false POSITIVES -- a group walked that need not have been --
+// and never a false negative.  A group whose keys need more than this
+// is a group whose filter would skip nothing anyway.
+var DayFilterMaxBytes uint64 = 32 << 20
 
 // setGroupBlocksForTest sets the group size; tests move the size
 // rather than the clock, because there is no clock to move.
 func setGroupBlocksForTest(n uint64) { SetGroupBlocks = n }
 
+// groupBlocks is SetGroupBlocks, never zero.  It is an exported var
+// with no checked setter, and setGroup divides by it -- a zero would
+// panic on every deep read and every pack, which is a long way from
+// where it was set.  Falling back to the default is the loud-enough
+// answer for a tunable that only a program can get wrong.
+func groupBlocks() uint64 {
+	if SetGroupBlocks == 0 {
+		return DefaultSetGroupBlocks
+	}
+	return SetGroupBlocks
+}
+
 // setGroup is the group a block belongs to: groups tile the block
 // space from 0, so a set's group is decided by its first block alone.
-func setGroup(block uint64) uint64 { return block / SetGroupBlocks }
+func setGroup(block uint64) uint64 { return block / groupBlocks() }
 
 // dayFilter is one finished group's filter, held on disk and probed
 // there -- the same residency rule the segments' filters follow
@@ -135,7 +169,14 @@ func writeDayFilter(directory string, group uint64, sets []*blockSet) (f *dayFil
 			last = s.meta.Last
 		}
 	}
+	// Sized for the group's keys, but never past the bound: see
+	// DayFilterMaxBytes.  A filter over its design point has a higher
+	// false-positive rate, which costs a walk, and that is the failure
+	// this side may have.
 	bloom := NewBloomSizedForKeys(keys, 3)
+	if DayFilterMaxBytes > 0 && bloom.NumBytes > DayFilterMaxBytes {
+		bloom = newBloomSized(DayFilterMaxBytes*8/BloomBitsPerKey, BloomBitsPerKey, 3)
+	}
 	for _, s := range sets {
 		for shard := 0; shard < NumShards; shard++ {
 			err = s.forEachKey(shard, func(key [32]byte, _ *DBBKey) error {
@@ -163,16 +204,19 @@ func writeDayFilter(directory string, group uint64, sets []*blockSet) (f *dayFil
 	var hdr [dayFilterHdr]byte
 	binary.BigEndian.PutUint32(hdr[:], dayFilterMagic)
 	binary.BigEndian.PutUint32(hdr[4:], dayFilterVer)
-	binary.BigEndian.PutUint64(hdr[8:], first)
-	binary.BigEndian.PutUint64(hdr[16:], last)
-	binary.BigEndian.PutUint64(hdr[24:], keys)
-	binary.BigEndian.PutUint64(hdr[32:], bloom.NumBytes)
+	// The group size the filter was built under.  Which sets belong to
+	// a group is derived from it, and it is not persisted anywhere
+	// else, so a filter that does not carry it could be consulted for
+	// sets it never saw after the size changed -- and answer a
+	// definitive "not here" for keys it never had, the one answer a
+	// filter may never give.
+	binary.BigEndian.PutUint64(hdr[8:], SetGroupBlocks)
+	binary.BigEndian.PutUint64(hdr[16:], first)
+	binary.BigEndian.PutUint64(hdr[24:], last)
+	binary.BigEndian.PutUint64(hdr[32:], keys)
+	binary.BigEndian.PutUint64(hdr[40:], bloom.NumBytes)
+	binary.BigEndian.PutUint32(hdr[48:], uint32(bloom.K))
 	if _, err = out.Write(hdr[:]); err != nil {
-		return nil, err
-	}
-	var kb [4]byte
-	binary.BigEndian.PutUint32(kb[:], uint32(bloom.K))
-	if _, err = out.Write(kb[:]); err != nil {
 		return nil, err
 	}
 	if _, err = out.Write(bloom.Map); err != nil {
@@ -193,7 +237,7 @@ func writeDayFilter(directory string, group uint64, sets []*blockSet) (f *dayFil
 		return nil, err
 	}
 	return &dayFilter{group: group, first: first, last: last, path: path,
-		bloomOff: dayFilterHdr + 4, bloomBytes: bloom.NumBytes, bloomK: int(bloom.K)}, nil
+		bloomOff: dayFilterHdr, bloomBytes: bloom.NumBytes, bloomK: bloom.K}, nil
 }
 
 // openDayFilter reads a group filter's header.  The bloom stays on
@@ -204,7 +248,7 @@ func openDayFilter(path string) (f *dayFilter, err error) {
 		return nil, err
 	}
 	defer file.Close()
-	var hdr [dayFilterHdr + 4]byte
+	var hdr [dayFilterHdr]byte
 	if _, err = file.ReadAt(hdr[:], 0); err != nil {
 		return nil, err
 	}
@@ -219,14 +263,36 @@ func openDayFilter(path string) (f *dayFilter, err error) {
 	if _, err = fmt.Sscanf(name, "%d", &group); err != nil {
 		return nil, fmt.Errorf("%s: %w", path, err)
 	}
+	// Which sets belong to a group is derived from the group size, so a
+	// filter built under a different one may not cover the sets this
+	// store would consult it for -- and would then answer "not here"
+	// for keys it never saw, the one answer a filter may never give.
+	// It is refused, and its group is walked instead.
+	if size := binary.BigEndian.Uint64(hdr[8:]); size != SetGroupBlocks {
+		return nil, fmt.Errorf("%s was built at %d blocks to a group; this store uses %d",
+			path, size, SetGroupBlocks)
+	}
+	// A bloom size the file cannot hold is a corrupt header, and a huge
+	// one is worse than useless: ByteMask computes `v % (NumBytes<<8)`,
+	// so a value at or above 2^56 wraps the modulus to zero and
+	// divides by it.  Refuse it; the group is walked.
+	bloomBytes := binary.BigEndian.Uint64(hdr[40:])
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if bloomBytes > 1<<32 || int64(bloomBytes) != info.Size()-dayFilterHdr {
+		return nil, fmt.Errorf("%s claims a %d-byte filter in a %d-byte file",
+			path, bloomBytes, info.Size())
+	}
 	return &dayFilter{
 		group:      group,
-		first:      binary.BigEndian.Uint64(hdr[8:]),
-		last:       binary.BigEndian.Uint64(hdr[16:]),
+		first:      binary.BigEndian.Uint64(hdr[16:]),
+		last:       binary.BigEndian.Uint64(hdr[24:]),
 		path:       path,
-		bloomOff:   dayFilterHdr + 4,
-		bloomBytes: binary.BigEndian.Uint64(hdr[32:]),
-		bloomK:     int(binary.BigEndian.Uint32(hdr[dayFilterHdr:])),
+		bloomOff:   dayFilterHdr,
+		bloomBytes: bloomBytes,
+		bloomK:     int(binary.BigEndian.Uint32(hdr[48:])),
 	}, nil
 }
 
@@ -247,7 +313,11 @@ func loadDayFilters(directory string) (filters []*dayFilter, err error) {
 		}
 		f, err := openDayFilter(filepath.Join(directory, name))
 		if err != nil {
-			return nil, err
+			// A filter that cannot be trusted is not a broken store:
+			// its group is walked, which is what a group without a
+			// filter always was.  Keeping it would risk the one answer
+			// a filter may never give.
+			continue
 		}
 		filters = append(filters, f)
 	}

--- a/database/kv_shard.go
+++ b/database/kv_shard.go
@@ -483,6 +483,9 @@ func (k *KVShard) PackFinalized(height uint64) (meta SetMeta, packed bool, err e
 	if !any {
 		return meta, false, nil
 	}
+	if packHook != nil {
+		packHook() // Tests: the pins are held, the build has not run
+	}
 	// A set covers every block since the previous set, and the first
 	// set covers every block there has been.  The segments cannot say
 	// which those are: a merged segment carries the height of the
@@ -520,6 +523,14 @@ func (k *KVShard) PackFinalized(height uint64) (meta SetMeta, packed bool, err e
 	wg.Wait()
 	return set.meta, true, err
 }
+
+// packHook, when set, is called by PackFinalized once every shard's
+// segments are PINNED and before the set is built, with no store lock
+// held.  It exists so that a test can hold a pack at its most
+// expensive moment -- the whole database pinned, a set being written
+// -- and show that the shards go on committing meanwhile.  Nil except
+// under test.
+var packHook func()
 
 // packDropWorkers is how many shards PackFinalized drops at once
 const packDropWorkers = 16

--- a/database/segstore.go
+++ b/database/segstore.go
@@ -889,7 +889,17 @@ func (s *SegmentStore) load() (err error) {
 	}
 	s.FilterBlocks = m.FilterBlocks
 	s.blockHeight = m.BlockHeight
-	s.demand = m.FilterDemand // What spans took before the restart (issue #54)
+	// What spans took before the restart (issue #54).  The ring is
+	// indexed by hour%FilterDemandHours, so a manifest carrying fewer
+	// buckets -- hand-edited, or written by a build with a different
+	// constant -- would panic on the next roll, which is the block
+	// commit path.  A ring that is not the right shape is no demand
+	// record at all; the store sizes from what its filters hold and
+	// learns again at its first roll.
+	s.demand = nil
+	if len(m.FilterDemand) == FilterDemandHours {
+		s.demand = m.FilterDemand
+	}
 
 	// The union, in (Height, Seq) order, which is the order both tiers
 	// keep and the order the lists had before any restart
@@ -2562,6 +2572,13 @@ var CompactPassRecords uint64 = 4 << 20
 // this is a ceiling that a healthy store never reaches.
 var CompactDeepPassRecords uint64 = 8 * CompactPassRecords
 
+// CompactPassSegments bounds a run by FILE COUNT as well as by
+// records.  The record budget cannot: a segment holding none passes
+// every record test, so a history of empty segments made a run as long
+// as history itself, and the merge then opened and streamed every one
+// of them under the maintenance lock.
+var CompactPassSegments = 1024
+
 // compactionRun
 // The run of history worth compacting into one segment, and where it
 // sits.  First choice: the newest suffix, taking each older segment in
@@ -2606,11 +2623,18 @@ func compactionRunWithin(history []*segment, ratio float64, budget uint64) (run 
 	if n == 0 {
 		return nil, 0
 	}
+	// A run is bounded by records AND by segments.  The budget counts
+	// records, and a segment with none passes every record test -- so a
+	// history of empty or near-empty segments yielded a run of
+	// unbounded length, and writeMergedRun then opened and streamed
+	// every one of them under the maintenance lock.  What a pass costs
+	// is both the bytes it moves and the files it touches.
 	var behind uint64
 	i := n - 1
 	for ; i >= 0; i-- {
 		r := uint64(history[i].records)
-		if i < n-1 && (float64(r)*ratio > float64(behind) || behind+r > budget) {
+		if i < n-1 && (float64(r)*ratio > float64(behind) || behind+r > budget ||
+			n-i > CompactPassSegments) {
 			break // Too big for what gathered behind it, or for one pass
 		}
 		behind += r

--- a/database/tiering_test.go
+++ b/database/tiering_test.go
@@ -599,3 +599,77 @@ func TestPutsRunConcurrentlyAcrossLayers(t *testing.T) {
 		require.Equal(t, []byte{byte(w), 0}, v)
 	}
 }
+
+// TestShardsCommitWhileAPackIsInFlight
+// A pack is the most expensive thing the database does: every shard's
+// history pinned, one set file written across all of them.  It must
+// not stop the shards while it runs -- that is the whole reason it
+// takes pins rather than locks (issue #47).
+//
+// A pin defers a file's DELETION and nothing else, so a shard can
+// accept writes, seal blocks and commit manifests with a pack holding
+// its segments; what it cannot do is remove the files the pack is
+// still reading, which is exactly the guarantee wanted.
+func TestShardsCommitWhileAPackIsInFlight(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), t.Name())
+	kvs, keys, values := packedFixture(t, dir, 82, 4, 60)
+	defer os.RemoveAll(dir)
+	ageOutShards(t, kvs, 4)
+	_, err := kvs.MergeFinalized(4)
+	require.NoError(t, err)
+
+	held := make(chan struct{})
+	release := make(chan struct{})
+	packHook = func() {
+		close(held)
+		<-release
+	}
+	defer func() { packHook = nil }()
+
+	done := make(chan error, 1)
+	go func() {
+		_, packed, err := kvs.PackFinalized(4)
+		if err == nil && !packed {
+			err = fmt.Errorf("nothing packed")
+		}
+		done <- err
+	}()
+
+	<-held // Every shard is pinned and the set is about to be written
+
+	// The shards must still take writes and close blocks
+	kr := NewFastRandom([]byte{83})
+	fresh := make([][32]byte, 20)
+	within(t, 5*time.Second, "writes during a pack", func() error {
+		for i := range fresh {
+			fresh[i] = kr.NextHash()
+			if err := kvs.PutPerm(fresh[i], []byte{byte(i)}); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	// A block above where the fixture aged to: sealing is what advances
+	// the shard set, and it must advance with a pack in flight
+	next := kvs.Shards[0].PermKV.BlockHeight() + 1
+	within(t, 5*time.Second, "a block boundary during a pack", func() error {
+		return kvs.SealBlock(next)
+	})
+	within(t, 5*time.Second, "reads during a pack", func() error {
+		_, err := kvs.GetPerm(fresh[0])
+		return err
+	})
+
+	close(release)
+	require.NoError(t, <-done, "the pack itself must finish")
+
+	// Nothing the pack was reading was lost, and the writes that ran
+	// beside it are there
+	checkEveryKey(t, kvs, keys, values, "after a pack that ran beside commits")
+	for i, k := range fresh {
+		v, err := kvs.GetPerm(k)
+		require.NoErrorf(t, err, "key written during the pack %d", i)
+		require.Equal(t, []byte{byte(i)}, v)
+	}
+	require.NoError(t, kvs.Close())
+}

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -366,9 +366,16 @@ run is still in place and discards its output if not.
   over its keys (`dayfilter.go`), written once when a later set closes
   the group out, held on disk and probed there; a group with no filter
   — the one being filled, or one whose filter could not be built — is
-  walked, which is correct and merely slower.  #47 tracks what is
-  left: the pack cadence in the adapter, and batching the build 50
-  shards at a time.
+  walked, which is correct and merely slower.
+- **A pack pins, it does not lock.**  Each shard's segments are pinned
+  and its list copied (`historyBelow`), the set is built by reading
+  those files, and only then does `DropBelow` remove them — so a pin
+  defers a file's DELETION and nothing else.  Shards go on taking
+  writes, sealing blocks and committing manifests with the whole
+  database pinned, which is what keeps the most expensive operation in
+  the store off the protocol path (#47).  `build` already streams
+  shard by shard, so nothing per-shard is held for the set's size
+  either.  #47 tracks what is left: the pack cadence in the adapter.
 - **Filter residency** — a segment's bloom is held in memory only
   while the segment is in the active tier; a history segment's and
   every block set's filter stays on disk and is probed there
@@ -408,7 +415,7 @@ The current gaps between Section 1 and the code, in one place:
 |---|---|---|
 | #62 | 1.9 sharding | Adapter opens one unsharded KV2 |
 | #33 | 1.8 one commit point | Residual fsyncs; manifest rewritten whole per commit |
-| #47 | 1.4 pack cadence | Pack cadence not scheduled in the adapter; build not batched (group filters done) |
+| #47 | 1.4 pack cadence | Pack cadence not scheduled in the adapter (group filters and pin-not-lock done) |
 
 A pull request that closes one of these updates this table.  A pull
 request that adds one updates it too — knowingly.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -130,9 +130,13 @@ window (MinFilterBlocks).
   there — resident filter memory follows the working set, not the
   chain (#64).
 - **Cross-shard consolidation is a rarer, second pass**: per-shard
-  merges fold into one set file per period (targeting daily), with one
-  filter over the set.  Searching years back skips whole days by their
-  filters; that deep search is API-level work, not protocol work.
+  merges fold into one set file every 1,000 blocks, with one filter
+  over the set.  Sets are grouped by block range (`SetGroupBlocks`, a
+  day at a block a second) and each FINISHED group carries a filter
+  over every key in it, so a deep search skips a whole group in one
+  probe instead of walking its sets — ~451 probes after a year rather
+  than ~31,500, and the walk stops tracking chain age.  That deep
+  search is API-level work, not protocol work (#47).
 - Perm accumulates **no garbage** — values are immutable — so the perm
   layer is never compacted, only merged and packed.
 
@@ -358,7 +362,13 @@ run is still in place and discards its output if not.
   contiguous per-shard sorted indexes, one bloom, verbatim bodies),
   then drops them from the shards, 16 at a time so the barriers
   overlap.  This is 1.4's "merge once, then permanent" done right.
-  #47 tracks the daily cadence and levelled runs.
+  Sets are grouped by block range and a finished group gets one filter
+  over its keys (`dayfilter.go`), written once when a later set closes
+  the group out, held on disk and probed there; a group with no filter
+  — the one being filled, or one whose filter could not be built — is
+  walked, which is correct and merely slower.  #47 tracks what is
+  left: the pack cadence in the adapter, and batching the build 50
+  shards at a time.
 - **Filter residency** — a segment's bloom is held in memory only
   while the segment is in the active tier; a history segment's and
   every block set's filter stays on disk and is probed there
@@ -398,7 +408,7 @@ The current gaps between Section 1 and the code, in one place:
 |---|---|---|
 | #62 | 1.9 sharding | Adapter opens one unsharded KV2 |
 | #33 | 1.8 one commit point | Residual fsyncs; manifest rewritten whole per commit |
-| #47 | 1.4 pack cadence | Daily cross-shard tier not yet scheduled |
+| #47 | 1.4 pack cadence | Pack cadence not scheduled in the adapter; build not batched (group filters done) |
 
 A pull request that closes one of these updates this table.  A pull
 request that adds one updates it too — knowingly.


### PR DESCRIPTION
First half of the pack tier, per the cadence decision on #47: **pack every 1,000 blocks with per-day filters.**

## The cost this removes

A deep read rules a key out of cold storage by probing every block set's filter. Each probe is cheap — K one-byte reads since #64, page-cached — but sets accumulate for the life of the chain, so the **walk** grows with age even though no step of it does. At a pack every 1,000 blocks, a year is ~31,500 sets and every deep miss walks all of them.

| | probes to rule out history | with group filters |
|---|---|---|
| 1 year | 31,536 | **451** |
| 5 years | 157,680 | **1,911** |

## The tier

Sets are grouped by **block range** — `SetGroupBlocks`, 86,400 blocks, a day at a block a second — and each **finished** group carries one filter over every key in it. A deep read probes the group first: a "no" skips the whole group, a "maybe" walks its sets.

- **A group is a block range, not a clock reading.** A set's group is a pure function of its first block, so two nodes replaying the same chain build the same groups. "Day" is what the default size means at a block a second, not something the code depends on.
- **A filter is written only when its group is complete** — a set has arrived above the range, so nothing more can join it. That makes it immutable, sized exactly for the keys it holds, and written once. The group being filled has none; its sets are probed directly, and there are few.
- **Built from the sets it claims**, never from anything remembered while they were written — the rule every filter here follows, because claiming a key it does not hold costs a walk while denying one it holds is a wrong answer.
- **A group with no filter is walked**, which is where the group being filled and any failed build land: correct, merely slower.
- **The bloom stays on disk** and is probed there (#64) — a filter per day of chain, resident, would be memory growing with the age of the store for data read rarely.

## Test

`TestDayFiltersSkipWholeGroups` packs across three groups, then checks: finished groups carry filters with bits; every packed key is still reachable through them; **>150 of 200 never-written keys are ruled out by a group filter** rather than walked; and the filters are found again after a reopen with every key still readable.

Full `-short` suite green (106.9 s). Spec §1.4 and §2.7 updated; §2.10 now records what is left of #47 — the pack cadence in the adapter and batching the build 50 shards at a time.

Toward #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKAh7mFDHChAtKQtJYP3a3
